### PR TITLE
Add Gmap Component

### DIFF
--- a/src/components/gmap/Gmap.js
+++ b/src/components/gmap/Gmap.js
@@ -1,0 +1,172 @@
+import Promise from "native-promise-only";
+import { BaseComponent } from '../base/Base';
+export class GmapComponent extends BaseComponent {
+
+  build() {
+    this.element = this.ce('element', 'div', {
+      class: 'map-container'
+    });
+    this.initGoogleMap();
+    this.input = this.createInput(this.element);
+    this.addInput(this.input, this.element);
+    let gmapElement = this.ce('gmapElement', 'div', {
+      id: this.component.map.gmapId,
+      style: "min-height: 300px; height: calc(100vh - 600px);"
+    });
+    this.element.appendChild(gmapElement);
+  }
+
+  constructor(component, options, data) {
+    console.log('component', component, options, data);
+    super(component, options, data);
+
+    // If google maps api is not ready, then load it.
+    if (!GmapComponent.apiAdded && !(
+        window.google &&
+        window.google.maps &&
+        window.google.maps.places &&
+        window.google.maps.places.Autocomplete
+      )) {
+      // Add the API.
+      GmapComponent.apiAdded = true;
+
+      // Get the source for Google Maps API
+      let src = 'https://maps.googleapis.com/maps/api/js?v=3&libraries=places&callback=formioGoogleMapsCallback';
+      if (component.map && component.map.key) {
+        src += '&key=' + component.map.key;
+      }
+      if (component.map && component.map.region) {
+        src += '&region=' + component.map.region;
+      }
+      let script = document.createElement('script');
+      script.setAttribute('src', src);
+      script.setAttribute('type', 'text/javascript');
+      script.setAttribute('defer', true);
+      script.setAttribute('async', true);
+      document.getElementsByTagName('head')[0].appendChild(script);
+    }
+  }
+
+  setValue(value) {
+    console.log('value', value);
+    super.setValue(value, true);
+  }
+
+  addInput(input, container) {
+    super.addInput(input, container);
+    let that = this;
+    GmapComponent.apiReady.then((result) => {
+      let autocompleteOptions = {};
+      if (this.component.map) {
+        autocompleteOptions = this.component.map.autocompleteOptions || {};
+      }
+      let autocomplete = new google.maps.places.Autocomplete(input, autocompleteOptions);
+      autocomplete.addListener('place_changed', function() {
+        that.marker.setVisible(false);
+        let place = autocomplete.getPlace();
+        if (!place.geometry) {
+          console.log("Autocomplete's returned place contains no geometry");
+          return;
+        }
+
+        // If the place has a geometry, then present it on a map.
+        if (place.geometry.viewport) {
+          that.map.fitBounds(place.geometry.viewport);
+        } else {
+          that.map.setCenter(place.geometry.location);
+          that.map.setZoom(17);  // Why 17? Because it looks good.
+        }
+        that.marker.setIcon(/** @type {google.maps.Icon} */({
+          url: place.icon,
+          size: new google.maps.Size(71, 71),
+          origin: new google.maps.Point(0, 0),
+          anchor: new google.maps.Point(17, 34),
+          scaledSize: new google.maps.Size(35, 35)
+        }));
+        that.marker.setPosition(place.geometry.location);
+        that.marker.setVisible(true);
+        let address = '';
+        if (place.address_components) {
+          address = [
+            (place.address_components[0] && place.address_components[0].short_name || ''),
+            (place.address_components[1] && place.address_components[1].short_name || ''),
+            (place.address_components[2] && place.address_components[2].short_name || '')
+          ].join(' ');
+        }
+        console.log('place.name', place.name, place);
+        that.setValue(place.name);
+      });
+    });
+  }
+
+  elementInfo() {
+    let info = super.elementInfo();
+    info.attr.class += ' Gmap-search';
+    return info;
+  }
+
+  initGoogleMap() {
+    GmapComponent.apiReady.then((result) => {
+      let defaultLatlng = new google.maps.LatLng(45.5041482, -73.5574125);
+      let options = {
+        zoom: 19,
+        center: defaultLatlng,
+        mapTypeId: google.maps.MapTypeId.ROADMAP,
+        styles: [
+          {
+            "featureType": "poi",
+            "stylers": [
+              {
+                "visibility": "off"
+              }
+            ]
+          },
+          {
+            "featureType": "transit",
+            "stylers": [
+              {
+                "visibility": "off"
+              }
+            ]
+          }
+        ]
+      };
+      this.map = new google.maps.Map(document.getElementById(this.component.map.gmapId), options);
+      this.addMarker(defaultLatlng, 'Default Marker', this.map);
+    });
+  }
+
+  addMarker(latlng, title, map) {
+    let that = this;
+    this.marker = new google.maps.Marker({
+      position: latlng,
+      map: map,
+      title: title,
+      draggable:true
+    });
+    this.marker.addListener('dragend', function(event) {
+      let geocoder = new google.maps.Geocoder;
+      let latlng = {lat: parseFloat(event.latLng.lat()), lng: parseFloat(event.latLng.lng())};
+      geocoder.geocode({'location': latlng}, function(results, status) {
+        if (status === google.maps.GeocoderStatus.OK) {
+          if (results[1]) {
+            that.setValue(results[0].formatted_address);
+          } else {
+            console.log('No results found');
+          }
+        } else {
+          console.log('Geocoder failed due to: ' + status);
+        }
+      });
+    });
+  }
+}
+
+GmapComponent.apiReady = new Promise((resolve, reject) => {
+  GmapComponent.apiResolve = resolve;
+  GmapComponent.apiReject = reject;
+});
+
+window.formioGoogleMapsCallback = function() {
+  GmapComponent.apiResolve();
+};

--- a/src/components/gmap/Gmap.spec.js
+++ b/src/components/gmap/Gmap.spec.js
@@ -1,0 +1,11 @@
+'use strict';
+import { GmapComponent } from './Gmap';
+import { components as comps } from './fixtures/index';
+import { Harness } from '../../../test/harness';
+describe('Gmap Component', function() {
+  it('Should build an address component', function(done) {
+    Harness.testCreate(GmapComponent, comps.comp1).then((component) => {
+      done();
+  });
+  });
+});

--- a/src/components/gmap/fixtures/comp1.js
+++ b/src/components/gmap/fixtures/comp1.js
@@ -1,0 +1,36 @@
+export const component = {
+  "input": true,
+  "tableView": true,
+  "label": "gmap",
+  "key": "gmap",
+  "placeholder": "",
+  "multiple": false,
+  "protected": false,
+  "clearOnHide": true,
+  "unique": false,
+  "persistent": true,
+  "map": {
+    "gmapId": "",
+    "region": "",
+    "key": "",
+    "autocompleteOptions" : {
+      "componentRestrictions" : {
+        "country" : [
+          ""
+        ]
+      }
+    }
+  },
+  "validate": {
+    "required": false
+  },
+  "type": "gmap",
+  "tags": [
+
+  ],
+  "conditional": {
+    "show": "",
+    "when": null,
+    "eq": ""
+  }
+};

--- a/src/components/gmap/fixtures/index.js
+++ b/src/components/gmap/fixtures/index.js
@@ -1,0 +1,4 @@
+import { component as comp1 } from './comp1';
+export const components = {
+  comp1: comp1
+};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,4 @@
-import { AddressComponent } from './address/address';
+import { AddressComponent } from './address/Address';
 import { BaseComponent } from './base/Base';
 import { ContentComponent } from './content/Content';
 import { ContainerComponent } from './container/Container';
@@ -29,6 +29,7 @@ import { RadioComponent } from './radio/Radio';
 import { SelectBoxesComponent } from './selectboxes/SelectBoxes';
 import { SurveyComponent } from './survey/Survey';
 import { WellComponent } from './well/Well';
+import { GmapComponent } from './gmap/Gmap';
 module.exports = {
   address: AddressComponent,
   base: BaseComponent,
@@ -61,6 +62,7 @@ module.exports = {
   selectboxes: SelectBoxesComponent,
   survey: SurveyComponent,
   well: WellComponent,
+  gmap: GmapComponent,
   create: function(component, options, data) {
     let comp = null;
     if (!component.type) {


### PR DESCRIPTION
Adding new component to display googleMap:

Behaviors:
- User enter an address (google.maps.places.Autocomplete) and select it from autocomplete
- A Marker is display on the Map
- User can move (drag) the marker and the address is set in the input field.

This component was done to answer our requirement,
Please let me know if there is anything else need to be done in this component in order to push it.
Thanks

**Screenshot**

![gmap](https://cloud.githubusercontent.com/assets/1858504/24062231/229b81be-0b31-11e7-8d91-4039f8dccc08.jpg)


**Sample Use:**

```
{
  "input": true,
  "tableView": true,
  "label": "gmap",
  "key": "gmap",
  "placeholder": "",
  "multiple": false,
  "protected": false,
  "clearOnHide": true,
  "unique": false,
  "persistent": true,
  "map": {
    "gmapId": "googleMap",
    "region": ".ca",
    "key": "YOUR_GOOGLE_KEY_HERE",
    "autocompleteOptions" : {
      "componentRestrictions" : {
        "country" : [
          "ca"
        ]
      }
    }
  },
  "validate": {
    "required": false
  },
  "type": "gmap",
  "tags": [

  ],
  "conditional": {
    "show": "",
    "when": null,
    "eq": ""
  }
}

```
 