### PR TITLE
Add class name in formio.form and formio.wizard

### DIFF
--- a/src/formio.form.js
+++ b/src/formio.form.js
@@ -17,6 +17,7 @@ export class FormioForm extends FormioComponents {
   constructor(element, options) {
     super(null, getOptions(options));
     this.type = 'form';
+    this._class = 'form';
     this._src = '';
     this._loading = true;
     this.formio = null;
@@ -250,6 +251,10 @@ export class FormioForm extends FormioComponents {
   reset() {
     // Reset the submission data.
     this.submission = {data: {}};
+  }
+
+  getClassName() {
+    return this._class;
   }
 
   submit() {

--- a/src/formio.wizard.js
+++ b/src/formio.wizard.js
@@ -5,6 +5,7 @@ import each from 'lodash/each';
 export class FormioWizard extends FormioForm {
   constructor(element, options) {
     super(element, options);
+    this._class = 'wizard';
     this.pages = [];
     this.page = 0;
   }


### PR DESCRIPTION
To add wizard support on ng2-formio, I need to know the current class name on the object `this.formio`