### PR TITLE
Add nextPage in panel components to allow conditional next page

### DIFF
--- a/src/components/panel/fixtures/comp1.js
+++ b/src/components/panel/fixtures/comp1.js
@@ -76,6 +76,7 @@ export const component = {
       "input": true
     }
   ],
+  "nextPage": null,
   "theme": "default",
   "title": "User Information",
   "input": false,

--- a/test/wizards/index.js
+++ b/test/wizards/index.js
@@ -1,3 +1,4 @@
 export const WizardTests = [
-  require('./simple')
+  require('./simple'),
+  require('./condional.next.page')
 ];


### PR DESCRIPTION
Manage previous page button to keep the form flow, manage submit in intermediate page with null value in nextPage function and dynamicly update the next button into a submit button.

The server `form.io` will certainly need an update without the `Form Component` that you describe in the issue https://github.com/formio/formio/issues/296 to avoid to check a bypassed page which contains required fields.