### PR TITLE
Add SPAN around label text for better styling hooks

### DIFF
--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -48,15 +48,15 @@ export class CheckBoxComponent extends BaseComponent {
     });
 
     // Create the SPAN around the textNode for better style hooks
-    this.labelText = this.ce('span', 'span');
+    this.labelSpan = this.ce('labelSpan', 'span');
 
     if (this.info.attr.id) {
       this.label.setAttribute('for', this.info.attr.id);
     }
     this.addInput(input, this.label);
     if (!this.options.inputsOnly) {
-      this.labelText.appendChild(this.text(this.component.label));
-      this.label.appendChild(this.labelText);
+      this.labelSpan.appendChild(this.text(this.component.label));
+      this.label.appendChild(this.labelSpan);
     }
     container.appendChild(this.label);
   }

--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -46,12 +46,17 @@ export class CheckBoxComponent extends BaseComponent {
     this.label = this.ce('label', 'label', {
       class: 'control-label'
     });
+
+    // Create the SPAN around the textNode for better style hooks
+    this.labelText = this.ce('span', 'span');
+
     if (this.info.attr.id) {
       this.label.setAttribute('for', this.info.attr.id);
     }
     this.addInput(input, this.label);
     if (!this.options.inputsOnly) {
-      this.label.appendChild(document.createTextNode(this.component.label));
+      this.labelText.appendChild(this.text(this.component.label));
+      this.label.appendChild(this.labelText);
     }
     container.appendChild(this.label);
   }

--- a/src/components/checkbox/Checkbox.spec.js
+++ b/src/components/checkbox/Checkbox.spec.js
@@ -10,9 +10,19 @@ describe('Checkbox Component', function() {
       for (let i=0; i < inputs.length; i++) {
         assert.equal(inputs[i].name, 'data[' + comps.comp1.key + ']');
       }
+      Harness.testElements(component, 'span', 1);
       done();
+      
     });
   });
+
+  it('Span should have correct text label', function(done) {
+    Harness.testCreate(CheckBoxComponent, comps.comp1).then((component) => {
+      let spans = component.element.querySelectorAll('span');
+      assert.equal(spans[0].innerHTML, 'Check me');
+      done();
+    });
+  }); 
 
   it('Should be able to set and get data', function(done) {
     Harness.testCreate(CheckBoxComponent, comps.comp1).then((component) => {

--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -24,7 +24,7 @@ export class RadioComponent extends BaseComponent {
       });
 
       // Create the SPAN around the textNode for better style hooks
-      let labelText = this.ce('span', 'span');
+      let labelSpan = this.ce('labelSpan', 'span');
 
       // Determine the attributes for this input.
       let inputId = this.component.key + this.row + '-' + value.value;
@@ -39,10 +39,10 @@ export class RadioComponent extends BaseComponent {
       });
       this.addInput(input, label);
       
-      labelText.appendChild(this.text(value.label));
+      labelSpan.appendChild(this.text(value.label));
       
       labelWrapper.appendChild(label);
-      labelWrapper.appendChild(labelText)
+      labelWrapper.appendChild(labelSpan)
       
       inputGroup.appendChild(labelWrapper);
     });

--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -23,6 +23,9 @@ export class RadioComponent extends BaseComponent {
         class: 'control-label'
       });
 
+      // Create the SPAN around the textNode for better style hooks
+      let labelText = this.ce('span', 'span');
+
       // Determine the attributes for this input.
       let inputId = this.component.key + this.row + '-' + value.value;
       this.info.attr.id = inputId;
@@ -35,8 +38,12 @@ export class RadioComponent extends BaseComponent {
         input.setAttribute(key, value);
       });
       this.addInput(input, label);
-      label.appendChild(document.createTextNode(value.label));
+      
+      labelText.appendChild(this.text(value.label));
+      
       labelWrapper.appendChild(label);
+      labelWrapper.appendChild(labelText)
+      
       inputGroup.appendChild(labelWrapper);
     });
     container.appendChild(inputGroup);

--- a/src/components/radio/Radio.spec.js
+++ b/src/components/radio/Radio.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+import assert from 'power-assert';
 import { RadioComponent } from './Radio';
 import { components as comps } from './fixtures/index';
 import { Harness } from '../../../test/harness';
@@ -6,7 +7,19 @@ describe('Radio Component', function() {
   it('Should build a radio component', function(done) {
     Harness.testCreate(RadioComponent, comps.comp1).then((component) => {
       Harness.testElements(component, 'input[type="radio"]', 4);
+      Harness.testElements(component, 'span', 4);
       done();
     });
   });
+
+  it('Span should have correct text label', function(done) {
+    Harness.testCreate(RadioComponent, comps.comp1).then((component) => {
+      let spans = component.element.querySelectorAll('span');
+      assert.equal(spans[0].innerHTML, 'Red');
+      assert.equal(spans[1].innerHTML, 'Green');
+      assert.equal(spans[2].innerHTML, 'Blue');
+      assert.equal(spans[3].innerHTML, 'Yellow');
+      done();
+    });
+  });  
 });


### PR DESCRIPTION
After looking to better enable styling radio and checkboxes for A11y and touch screens, I made a simple change to the rendering to wrap the label textNode with a SPAN tag. I submit for your consideration.

Closes #101