### PR TITLE
Share jsonLogic with ng-formio factory

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,8 @@
 const _get = require('lodash/get');
 import jsonLogic from 'json-logic-js';
 module.exports = {
+  jsonLogic, // Share
+
   /**
    * Determine if a component is a layout component or not.
    *


### PR DESCRIPTION
ng-formio FormioUtils factory refers to jsonLogic in formio.js version but it's not set.
Can cause problems when needed to evaluate things like JSON Next Page.
