### PR TITLE
Add base64 file upload type

### DIFF
--- a/src/providers/storage/base64.js
+++ b/src/providers/storage/base64.js
@@ -1,0 +1,37 @@
+const Promise = require('native-promise-only');
+const base64 = function () {
+  return {
+    title: 'Base64',
+    name: 'base64',
+    uploadFile: function (file, fileName) {
+      const reader = new FileReader();
+
+      return new Promise((resolve, reject) => {
+        reader.onload = (event) => {
+          const url = event.target.result;
+          resolve({
+            storage: 'base64',
+            name: fileName,
+            url: url,
+            size: file.size,
+            type: file.type,
+            data: url.replace(`data:${file.type};base64,`, '')
+          });
+        };
+
+        reader.onerror = () => {
+          return reject(this);
+        };
+
+        reader.readAsDataURL(file);
+      });
+    },
+    downloadFile: function (file) {
+      // Return the original as there is nothing to do.
+      return Promise.resolve(file);
+    }
+  };
+};
+
+base64.title = 'Base64';
+module.exports = base64;

--- a/src/providers/storage/index.js
+++ b/src/providers/storage/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  base64: require('./base64'),
   dropbox: require('./dropbox.js'),
   s3: require('./s3.js'),
   url: require('./url.js'),


### PR DESCRIPTION
File contents will be base64 encoded in submission object. This is useful for cases where multipart/form-data is not an option for form submission.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL), IE 10 is required for `readAsDataURL` to work. I'm not sure what browsers Form.io targets, but that would be a constraint of using this upload type.

I need this for a project our company is working on because the enterprise system that we're interfacing with has a convoluted way of dealing with `multipart/form-data` forms, to the point that I have not been able to successfully get a single form to process. I recognize that it likely won't be a common upload type, but hopefully it will be useful for someone else at some point.

Please let me know if there's anything I can change/fix about this PR.