### PR TITLE
Wait for form to load before loading submission

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -188,6 +188,12 @@ export class SelectComponent extends BaseComponent {
         // Search for the choice.
         const choices = this.choices.store.getChoices();
         const foundChoice = choices.find((choice) => {
+          // For resources we may have two different instances of the same resource
+          // Unify them so we don't have two copies of the same thing in the dropdown
+          // and so the correct resource gets selected in the first place
+          if (choice.value._id && value._id && choice.value._id === value._id) {
+            value = choice.value;
+          }
           return choice.value === value;
         });
 

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -101,7 +101,10 @@ export class SelectComponent extends BaseComponent {
     // Make the request.
     Formio.request(url, null, null, headers, options)
       .then((response) => this.setItems(response))
-      .catch(() => console.warn('Unable to load resources for ' + this.component.key))
+      .catch((err) => {
+        this.events.emit('formio.error', err);
+        console.warn('Unable to load resources for ' + this.component.key);
+      })
   }
 
   updateItems() {

--- a/src/formio.form.js
+++ b/src/formio.form.js
@@ -260,12 +260,15 @@ export class FormioForm extends FormioComponents {
     this.url = value;
     this.nosubmit = false;
     this.formio.loadForm().then(
-      (form) => this.setForm(form),
+      (form) => {
+        var setForm = this.setForm(form);
+        this.loadSubmission();
+        return setForm;
+      },
       (err) => this.formReadyReject(err)
     ).catch(
       (err) => this.formReadyReject(err)
     );
-    this.loadSubmission();
   }
 
   /**


### PR DESCRIPTION
I'm using the Chrome browser on Windows 10.
My form contains a resource component followed by some text components.
Using code like this to render form with existing submission...

Formio.setBaseUrl('http://localhost:3001');
var form = new FormioForm(document.getElementById('formio'));
form.src = 'http://localhost:3001/form/59259f9614746b2a8819866c/submission/59774528acdba937887da5e7';

Code which populates resource component and code which sets submissions resource value are both trying to access instance of 'choices' at the same time and things go haywire.  Following component values do not get set with submission data.
Fix is to load submission after loading of form as in Formio.createForm.
Also fix select dropdown duplication caused by different instances of the same resource.
Also emit formio.error event when resource item loading fails for something like unauthorized.