### PR TITLE
Pass validity data with onChange event

### DIFF
--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -934,7 +934,8 @@ export class BaseComponent {
       this.emit('componentChange', {
         component: this.component,
         value: this.value,
-        validate: !noValidate
+        validate: !noValidate,
+        isValid: this.checkValidity()
       });
     }
   }


### PR DESCRIPTION
We have a React UI to which we have embedded several formio forms. We would like the validity state of an embedded form to affect the rest of the UI. In specific we would like to enable / disable a button on the UI depending on whether the form is in valid state or not.

After some investigation we could not find an elegant way to gain the validity information of an embedded form.

Associated pull request tackles this problem for us by delivering the current validity state within the `onChange` event. This should just work as a discussion opener. If there are other ways of finding out the validity of the form we would be interested in knowing.