### PR TITLE
Use handler.type instead of undefined handler.event property

### DIFF
--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -763,7 +763,7 @@ export class BaseComponent {
       }
     });
     _each(this.eventHandlers, (handler) => {
-      window.removeEventListener(handler.event, handler.func);
+      window.removeEventListener(handler.type, handler.func);
     });
   }
 


### PR DESCRIPTION
In `destroy` we were accessing an undefined property `handler.event`. Correct property to access is `handler.type`.