### PR TITLE
force the select to open downwards

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -212,7 +212,8 @@ export class SelectComponent extends BaseComponent {
         containerOuter: 'choices form-group formio-choices',
         containerInner: 'form-control'
       },
-      shouldSort: false
+      shouldSort: false,
+      position: 'bottom'
     });
 
     // If a search field is provided, then add an event listener to update items on search.

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -205,6 +205,7 @@ export class SelectComponent extends BaseComponent {
     if (this.component.multiple) {
       input.setAttribute('multiple', true);
     }
+    var tabIndex = input.tabIndex;
     this.choices = new Choices(input, {
       removeItemButton: true,
       itemSelectText: '',
@@ -215,6 +216,7 @@ export class SelectComponent extends BaseComponent {
       shouldSort: false,
       position: 'bottom'
     });
+    this.choices.itemList.tabIndex = tabIndex;
 
     // If a search field is provided, then add an event listener to update items on search.
     if (this.component.searchField) {

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -213,8 +213,7 @@ export class SelectComponent extends BaseComponent {
         containerOuter: 'choices form-group formio-choices',
         containerInner: 'form-control'
       },
-      shouldSort: false,
-      position: 'bottom'
+      shouldSort: false
     });
     this.choices.itemList.tabIndex = tabIndex;
 

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -9,4 +9,20 @@ describe('Select Component', function() {
       done();
     });
   });
+
+  it('Should preserve the tabindex', function(done) {
+    Harness.testCreate(SelectComponent, comps.comp2).then((component) => {
+      let element = component.element.getElementsByClassName("choices__list choices__list--single")[0];
+      Harness.testElementAttribute(element, 'tabindex', '10');
+      done();
+    });
+  });
+
+  it('Should default to 0 when tabindex is not specified', function(done) {
+    Harness.testCreate(SelectComponent, comps.comp1).then((component) => {
+      let element = component.element.getElementsByClassName("choices__list choices__list--single")[0];
+      Harness.testElementAttribute(element, 'tabindex', '0');
+      done();
+    });
+  });
 });

--- a/src/components/select/fixtures/comp2.js
+++ b/src/components/select/fixtures/comp2.js
@@ -1,0 +1,65 @@
+export const component = {
+  "conditional": {
+    "eq": "",
+    "when": null,
+    "show": ""
+  },
+  "tags": [],
+  "type": "select",
+  "validate": {
+    "required": false
+  },
+  "tabindex": "10",
+  "persistent": true,
+  "unique": false,
+  "protected": false,
+  "multiple": false,
+  "template": "<span>{{ item.label }}</span>",
+  "authenticate": false,
+  "filter": "",
+  "refreshOn": "",
+  "defaultValue": "",
+  "valueProperty": "",
+  "dataSrc": "values",
+  "data": {
+    "custom": "",
+    "resource": "",
+    "url": "",
+    "json": "",
+    "values": [
+      {
+        "label": "Red",
+        "value": "red"
+      },
+      {
+        "label": "Blue",
+        "value": "blue"
+      },
+      {
+        "label": "Green",
+        "value": "green"
+      },
+      {
+        "label": "Yellow",
+        "value": "yellow"
+      },
+      {
+        "label": "Purple",
+        "value": "purple"
+      },
+      {
+        "label": "Orange",
+        "value": "orange"
+      },
+      {
+        "label": "Black",
+        "value": "black"
+      }
+    ]
+  },
+  "placeholder": "Enter your favorite color",
+  "key": "favoriteColor",
+  "label": "Favorite Color",
+  "tableView": true,
+  "input": true
+};

--- a/src/components/select/fixtures/index.js
+++ b/src/components/select/fixtures/index.js
@@ -1,4 +1,6 @@
 import { component as comp1 } from './comp1';
+import { component as comp2 } from './comp2';
 export const components = {
-  comp1: comp1
+  comp1: comp1,
+  comp2: comp2
 };

--- a/test/harness.js
+++ b/test/harness.js
@@ -50,6 +50,12 @@ export const Harness = {
     }
     return elements;
   },
+  testElementAttribute: function(element, attribute, expected) {
+    if (element !== undefined && element.getAttribute(attribute)) {
+      assert.equal(expected, element.getAttribute(attribute));
+    }
+    return element;
+  },
   testSetGet: function(component, value) {
     component.setValue(value);
     assert.deepEqual(component.getValue(), value);


### PR DESCRIPTION
Some of our forms appear high on the page and if it is a small form with
select boxes, were opening upwards and off the page. In all cases, we
think opening downwards provides a much better experience.

I added the [documented option](https://github.com/jshjohnson/Choices#position) `position:bottom` to force always opening downwards.