### PR TITLE
Allow dropdowns to open only downwards

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -212,7 +212,8 @@ export class SelectComponent extends BaseComponent {
         containerOuter: 'choices form-group formio-choices',
         containerInner: 'form-control'
       },
-      shouldSort: false
+      shouldSort: false,
+      position: 'bottom'
     });
 
     // If a search field is provided, then add an event listener to update items on search.


### PR DESCRIPTION
Some of our forms appear high on the page and if it is a small form with
select boxes, were opening upwards and off the page. In all cases, we
think opening downwards provides a much better experience.

I added the [documented option](https://github.com/jshjohnson/Choices#position) `position:bottom` to force always opening downwards.