### PR TITLE
Add stripe component: card input field/Pay button

### DIFF
--- a/app/examples/stripe.md
+++ b/app/examples/stripe.md
@@ -1,0 +1,203 @@
+---
+title: Stripe
+layout: vtabs
+section: examples
+weight: 150
+contrib: true
+---
+
+### Stripe
+Stripe securely collect card information from your customers and create a card payment.
+This component provides a card input field created by [Stripe](https://stripe.com/docs/stripe-js) library.
+The component also provides a "pay button" using Android Pay, Apple Pay or Payment Request API.
+
+The authorization will be automaticly called when users use the pay button. Instead, for the card input field, the call will be done before submission
+or you can call manually add an button which call the method `authorize()`.
+
+These parameters are directly injected to Stripe functions:
+
+- `cardData` for [Stripe.createToken()](https://stripe.com/docs/stripe-js/reference#stripe-create-token)
+- `stripeElementsOptions` for [stripe.elements()](https://stripe.com/docs/stripe-js/reference#stripe-payment-request).
+- `stripeElementOptions` for [elements.create()](https://stripe.com/docs/stripe-js/reference#the-elements-object).
+- `payButton.paymentRequest` for [stripe.paymentRequest()](https://stripe.com/docs/stripe-js/reference#stripe-payment-request).
+- `payButton.stripeOptions` for [elements.create()](https://stripe.com/docs/stripe-js/reference#the-elements-object).
+
+
+Stripe can be configured with this following parameters:
+```js
+  "stripe": {
+    "apiKey": "pk_test_Aprek1cboUExxK6dHoBaOphh",
+    "payButton": {
+      "enable": true,
+      "separatorLabel": "Or",
+      "paymentRequest": {
+        "country": 'CA',
+        "currency": 'cad',
+        "total": {
+          "label": 'Test payment',
+          "amount": 1000,
+        }
+      },
+      "stripeOptions": {}
+    },
+    "cardData": {
+      "name": "{{ data.firstName }} {{ data.lastName }}",
+      "address_line1": "{{ data.address }}",
+      "address_city": "{{ data.city }}",
+      "address_country": "{{ data.country }}",
+    },
+    "successLabel": "Payment successful",
+    "stripeElementsOptions": {},
+    "stripeElementOptions": {}
+  }
+```
+
+#### Install
+To use this plugin, you must first include the contributed modules for the Form.io renderer using.
+
+```html
+<script src="https://unpkg.com/formiojs@latest/dist/formio.contrib.min.js"></script>
+```
+
+After you have included this library within your page, you will then need to register it with the Form renderer using the following.
+
+```js
+Formio.registerComponent('stripe', Formio.contrib.stripe.stripe);
+```
+
+If you are including this within your own library, you can also include it with the following.
+
+```js
+import { StripeComponent } from 'formiojs/build/contrib/stripe/stripe/stripe';
+Formio.registerComponent('stripe', StripeComponent);
+```
+
+#### Example
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.full.min.css">
+<script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
+<script src="https://unpkg.com/formiojs@latest/dist/formio.contrib.min.js"></script>
+<div id="formio"></formio>
+```
+
+```js
+// Register the contrib component.
+Formio.registerComponent('stripe', Formio.contrib.stripe.stripe);
+
+Formio.createForm(document.getElementById('formio'), {
+  components: [
+    {
+      type: 'textfield',
+      label: 'First name',
+      placeholder: 'Enter the first name.',
+      key: 'firstName',
+      input: true,
+      inputType: 'text'
+    },
+    {
+      type: 'textfield',
+      label: 'Last name',
+      placeholder: 'Enter the last name.',
+      key: 'lastName',
+      input: true,
+      inputType: 'text'
+    },
+    {
+      type: 'stripe',
+      key: 'card',
+      label: 'Credit card',
+      validate: {
+        required: true
+      },
+      stripe: {
+        apiKey: 'pk_test_Aprek1cboUExxK6dHoBaOphh',
+        cardData: {
+          name: '{{ data.firstName }} {{ data.lastName }}'
+        },
+        payButton: {
+          enable: true,
+          paymentRequest: {
+            currency: 'cad',
+            country: 'CA',
+            total: {
+              label: 'Tee-shirt',
+              amount: 3000,
+            }
+          }
+        }
+      },
+    },
+    {
+      type: 'button',
+      action: 'submit',
+      label: 'Submit',
+      theme: 'primary',
+      key: 'submit'
+    }
+  ]
+});
+```
+
+
+#### Result
+
+<div class="well">
+<div id="formio"></div>
+<script type="text/javascript">
+Formio.registerComponent('stripe', Formio.contrib.stripe.stripe);
+
+Formio.createForm(document.getElementById('formio'), {
+  components: [
+    {
+      type: 'textfield',
+      label: 'First name',
+      placeholder: 'Enter the first name.',
+      key: 'firstName',
+      input: true,
+      inputType: 'text'
+    },
+    {
+      type: 'textfield',
+      label: 'Last name',
+      placeholder: 'Enter the last name.',
+      key: 'lastName',
+      input: true,
+      inputType: 'text'
+    },
+    {
+      type: 'stripe',
+      key: 'card',
+      label: 'Credit card',
+      validate: {
+        required: true
+      },
+      stripe: {
+        apiKey: 'pk_test_Aprek1cboUExxK6dHoBaOphh',
+        cardData: {
+          name: '{{ data.firstName }} {{ data.lastName }}'
+        },
+        payButton: {
+          enable: true,
+          paymentRequest: {
+            currency: 'cad',
+            country: 'CA',
+            total: {
+              label: 'T-Shirt',
+              amount: 3000,
+            }
+          }
+        }
+      },
+    },
+    {
+      type: 'button',
+      action: 'submit',
+      label: 'Submit',
+      theme: 'primary',
+      key: 'submit'
+    }
+  ]
+});
+</script>
+</div>

--- a/src/contrib/index.js
+++ b/src/contrib/index.js
@@ -1,6 +1,8 @@
+import { StripeComponent } from './stripe/stripe/Stripe';
 import { StripeCheckoutComponent } from './stripe/checkout/StripeCheckout';
 module.exports = {
   stripe: {
+    stripe: StripeComponent,
     checkout: StripeCheckoutComponent
   }
 };

--- a/src/contrib/stripe/stripe/Stripe.js
+++ b/src/contrib/stripe/stripe/Stripe.js
@@ -1,0 +1,266 @@
+import _isObject from 'lodash/isObject';
+import _isArray from 'lodash/isArray';
+import _cloneDeep from 'lodash/cloneDeep';
+import _each from 'lodash/each';
+import { Validator } from '../../../components/Validator';
+import { BaseComponent } from '../../../components/base/Base';
+
+
+// Register a custom validor to use card validition from Stripe
+if (typeof Validator.validators.stripe === "undefined") {
+  Validator.validators.stripe =  {
+    key: 'validate.stripe',
+    message(component, setting) {
+      let stripeMessage = "";
+      if (component.lastResult && component.lastResult.error) {
+        stripeMessage = component.lastResult.error.message;
+      }
+      return component.t(component.errorMessage('stripe'), {
+        field: component.errorLabel,
+        stripe: stripeMessage,
+        stripeError: component.lastResult.error,
+        data: component.data
+      });
+    },
+    check(component, setting, value) {
+      if (!component.paymentDone && component.lastResult) {
+        return !component.lastResult.error && !component.isEmpty(value);
+      }
+      return true;
+    }
+  };
+}
+
+
+/**
+ * This is the StripeComponent class.
+ */
+export class StripeComponent extends BaseComponent {
+  constructor(component, options, data) {
+    super(component, options, data);
+
+    // Get the source for Stripe API
+    let src = 'https://js.stripe.com/v3/';
+
+    /**
+     * Promise when Stripe is ready.
+     * @type {Promise}
+     */
+    this.stripeReady = BaseComponent.requireLibrary('stripe', 'Stripe', src, true);
+
+    /**
+     * The last result returned by Stripe.
+     * @type {Object}
+     */
+    this.lastResult = null;
+
+    /**
+     * The state of the payment.
+     * @type {Boolean}
+     */
+    this.paymentDone = false;
+
+    // Use stripe validator
+    this.validators.push('stripe');
+  }
+
+  elementInfo() {
+    let info = super.elementInfo();
+    info.type = 'input';
+    info.attr.type = 'hidden';
+    info.changeEvent = 'change';
+    return info;
+  }
+
+  /**
+   * Set CSS classes for pending authorization
+   */
+  authorizePending() {
+    this.addClass(this.element, 'stripe-submitting');
+    this.removeClass(this.element, 'stripe-error');
+    this.removeClass(this.element, 'stripe-submitted');
+  }
+
+  /**
+   * Set CSS classes and display error when error occurs during authorization
+   * @param {Object} resultError - The result error returned by Stripe API.
+   */
+  authorizeError(resultError) {
+    this.removeClass(this.element, 'stripe-submitting');
+    this.addClass(this.element, 'stripe-submit-error');
+    this.removeClass(this.element, 'stripe-submitted');
+
+    if (!this.lastResult) {
+      this.lastResult = {};
+    }
+    this.lastResult.error = resultError;
+    this.setValue(this.getValue(), {
+      changed: true
+    });
+  }
+
+  /**
+   * Set CSS classes and save token when authorization successed
+   * @param {Object} result - The result returned by Stripe API.
+   */
+  authorizeDone(result) {
+    this.removeClass(this.element, 'stripe-submit-error');
+    this.removeClass(this.element, 'stripe-submitting');
+    this.addClass(this.element, 'stripe-submitted');
+
+    this.stripeSuccess.style.display = "block";
+    if (this.component.stripe.payButton && this.component.stripe.payButton.enable) {
+      this.stripeElementPayButton.style.display = "none";
+      this.stripeSeparator.style.display = "none";
+    }
+    this.stripeElementCard.style.display = "none";
+
+    // Store token in hidden input
+    this.setValue(result.token.id);
+
+    this.paymentDone = true;
+  }
+
+
+  /**
+   * Call Stripe API to get token
+   */
+  authorize() {
+    if (this.paymentDone) {
+      return;
+    }
+
+    let that = this;
+    return new Promise(function(resolve, reject) {
+      that.authorizePending();
+
+      // Get all additionnal data to send to Stripe
+      let cardData = _cloneDeep(that.component.stripe.cardData) || {};
+      _each(cardData, (value, key) => {
+        cardData[key] = that.t(value);
+      });
+
+      return that.stripe.createToken(that.stripeCard, cardData).then((result) => {
+        if (result.error) {
+          that.authorizeError(result.error);
+          reject(result.error);
+        } else {
+          that.authorizeDone(result);
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
+   * Handle event dispatched by Stripe library
+   * @param {Object} result - The result returned by Stripe.
+   */
+  onElementCardChange(result) {
+    // If the field is not required and the field is empty, do not throw an error
+    if (result.empty && (!this.component.validate || !this.component.validate.required)) {
+      delete result.error;
+    }
+
+    // Force change when complete or when an error is thrown or fixed
+    let changed = result.complete || this.lastResult && (!!this.lastResult.error != !!result.error)
+                  || this.lastResult && this.lastResult.error && result.error && this.lastResult.error.code != result.error.code || false;
+    this.lastResult = result;
+
+    // When the field is not empty, use "." as value to not trigger "required" validator
+    let value = result.empty ? "" : ".";
+    this.setValue(value, {
+      changed: changed
+    });
+  }
+
+  beforeSubmit() {
+    // Get the token before submitting when the field is not empty or required
+    if (this.lastResult && !this.lastResult.empty || (this.component.validate && this.component.validate.required)) {
+      return this.authorize();
+    }
+  }
+
+  build() {
+    super.build();
+
+    let successLabel = this.component.stripe.payButton.successLabel || "Payment successful";
+    this.stripeSuccess = this.ce('div', {
+      class: "Stripe-success",
+      style: "display: none"
+    }, this.t(successLabel));
+    this.element.appendChild(this.stripeSuccess);
+
+    // Add container for pay button
+    if (this.component.stripe.payButton && this.component.stripe.payButton.enable) {
+      this.stripeElementPayButton = this.ce('div', {
+        class: "Stripe-paybutton"
+      });
+      this.element.appendChild(this.stripeElementPayButton);
+
+      let separatorLabel = this.component.stripe.payButton.separatorLabel || "Or";
+      this.stripeSeparator = this.ce('div', {
+        class: "Stripe-separator",
+        style: "display: none"
+      }, this.t(separatorLabel));
+      this.element.appendChild(this.stripeSeparator);
+    }
+
+    // Create container for stripe cart input
+    this.stripeElementCard = this.ce('div');
+    this.element.appendChild(this.stripeElementCard);
+
+    this.stripeReady.then(() => {
+      this.stripe = new Stripe(this.component.stripe.apiKey);
+
+      // Create an instance of Elements
+      let stripeElementsOptions = {};
+      if (this.component.stripe) {
+        stripeElementsOptions = _cloneDeep(this.component.stripe.stripeElementsOptions) || {};
+      }
+      if (typeof stripeElementsOptions.locale === "undefined") {
+        stripeElementsOptions.locale = this.options.language;
+      }
+      let elements = this.stripe.elements(stripeElementsOptions);
+
+      // Create an instance of the card Element
+      let stripeElementOptions = {};
+      if (this.component.stripe) {
+        stripeElementOptions = this.component.stripe.stripeElementOptions || {};
+      }
+      this.stripeCard = elements.create('card', stripeElementOptions);
+
+      // Add an instance of the card Element into the `card-element` <div>
+      this.stripeCard.mount(this.stripeElementCard);
+
+      // Handle real-time validation errors from the card Element.
+      this.addEventListener(this.stripeCard, 'change', this.onElementCardChange.bind(this));
+
+      // If there is a pay button, then create it and add listener
+      if (this.component.stripe.payButton && this.component.stripe.payButton.enable) {
+        let paymentRequest = this.stripe.paymentRequest(this.component.stripe.payButton.paymentRequest);
+
+        this.addEventListener(paymentRequest, 'token', (result) => {
+          this.authorizeDone(result, true);
+          result.complete("success");
+        });
+
+        let stripeOptionsPayButton = {};
+        if (this.component.stripe.payButton) {
+          stripeOptionsPayButton = this.component.stripe.payButton.stripeOptions || {};
+        }
+        stripeOptionsPayButton.paymentRequest = paymentRequest;
+
+        let paymentRequestElement = elements.create("paymentRequestButton", stripeOptionsPayButton);
+
+        paymentRequest.canMakePayment().then((result) => {
+          if (result) {
+            // Display label separator
+            this.stripeSeparator.style.display = "block";
+            paymentRequestElement.mount(this.stripeElementPayButton);
+          }
+        });
+      }
+    });
+  }
+}

--- a/src/contrib/stripe/stripe/Stripe.spec.js
+++ b/src/contrib/stripe/stripe/Stripe.spec.js
@@ -1,0 +1,11 @@
+'use strict';
+import { StripeComponent } from './Stripe';
+import { components as comps } from './fixtures/index';
+import { Harness } from '../../../test/harness';
+describe('Stripe Component', function() {
+  it('Should build an stripe component', function(done) {
+    Harness.testCreate(StripeComponent, comps.comp1).then((component) => {
+      done();
+  });
+  });
+});

--- a/src/contrib/stripe/stripe/fixtures/comp1.js
+++ b/src/contrib/stripe/stripe/fixtures/comp1.js
@@ -1,0 +1,38 @@
+export const component = {
+  "input": true,
+  "tableView": true,
+  "label": "stripe",
+  "key": "stripe",
+  "placeholder": "",
+  "multiple": false,
+  "protected": false,
+  "clearOnHide": true,
+  "unique": false,
+  "persistent": true,
+  "action": "button",
+  "stripe": {
+    "apiKey": "",
+    "payButton": {
+      "enable": false,
+      "separatorLabel": "Or",
+      "paymentRequest": {},
+      "stripeOptions": {}
+    },
+    "cardData": {},
+    "successLabel": "Payment successful",
+    "stripeElementsOptions": {},
+    "stripeElementOptions": {}
+  },
+  "validate": {
+    "required": true
+  },
+  "type": "stripe",
+  "tags": [
+
+  ],
+  "conditional": {
+    "show": "",
+    "when": null,
+    "eq": ""
+  }
+};

--- a/src/contrib/stripe/stripe/fixtures/index.js
+++ b/src/contrib/stripe/stripe/fixtures/index.js
@@ -1,0 +1,4 @@
+import { component as comp1 } from './comp1';
+export const components = {
+  comp1: comp1
+};

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -14,6 +14,7 @@ module.exports = {
         invalid_email: '{{field}} must be a valid email.',
         invalid_regex: '{{field}} does not match the pattern {{regex}}.',
         invalid_date: '{{field}} is not a valid date.',
+        stripe: '{{stripe}}',
         month: 'Month',
         day: 'Day',
         year: 'Year',


### PR DESCRIPTION
Hi,

This is a another stripe component. This component provides a card input field and optionally a pay button (Apple Pay, Android Pay, Payment request API). Like the other component, Stripe will return a token.

There are 3 cases:
- With a card input field, the validation to stripe will be done before submission with `beforeSubmit()` method
- With a card input field and a button to Authorize the payment, the call to Stripe will be done when the user clicks on the button
- With the pay button, the authorization will be done when the user validates the popup for payment


@travist I created a parameter `componentsMapping` to allow injection of the value from other fields into the request to Stripe for card validation. But I saw your nice example on http://formio.github.io/formio.js/app/examples/stripeCheckout.html where you inject values from other component.
So, should I change `componentsMapping` to take a value as input instead of the key of another component ?

I made an example here with different cases:
https://htmlpreview.github.io/?https://raw.githubusercontent.com/GuillaumeSmaha/formio.js/feature/add_stripe_component_build/app/examples/stripe.html


cc: @stephenott