### PR TITLE
Feature/spell check

### DIFF
--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -1923,7 +1923,7 @@ export class BaseComponent {
       type: this.component.inputType || 'text',
       class: 'form-control',
       lang: this.options.language
-  };
+    };
 
     if (this.component.placeholder) {
       attributes.placeholder = this.t(this.component.placeholder);

--- a/src/components/textfield/TextField.js
+++ b/src/components/textfield/TextField.js
@@ -4,6 +4,10 @@ export class TextFieldComponent extends BaseComponent {
     let info = super.elementInfo();
     info.type = 'input';
 
+    if (this.component.hasOwnProperty('spellCheck')) {
+      info.attr.spellcheck = this.component.spellCheck;
+    }
+
     if (this.component.mask) {
       info.attr.type = 'password';
     }

--- a/src/components/textfield/TextField.js
+++ b/src/components/textfield/TextField.js
@@ -4,8 +4,8 @@ export class TextFieldComponent extends BaseComponent {
     let info = super.elementInfo();
     info.type = 'input';
 
-    if (this.component.hasOwnProperty('spellCheck')) {
-      info.attr.spellcheck = this.component.spellCheck;
+    if (this.component.hasOwnProperty('spellcheck')) {
+      info.attr.spellcheck = this.component.spellcheck;
     }
 
     if (this.component.mask) {


### PR DESCRIPTION
Allow for text-field and text-area to use builders spell-check option. Text-area is extended by text-field, no need for changes on src/components/textarea/textarea.js

https://github.com/formio/ngFormBuilder/pull/374 