### PR TITLE
WYSIWYG Update - placeholder, backspace, etc.

### DIFF
--- a/src/components/Validator.js
+++ b/src/components/Validator.js
@@ -71,7 +71,6 @@ export const Validator = {
         if (!FormioUtils.boolValue(setting)) {
           return true;
         }
-
         return !component.isEmpty(value);
       }
     },

--- a/src/components/Validator.js
+++ b/src/components/Validator.js
@@ -72,14 +72,6 @@ export const Validator = {
           return true;
         }
 
-        // WYSIWYG validation
-        if (component.quill) {
-          if (value === "<p><br></p>") {
-            return false
-          }
-          return true
-        }
-
         return !component.isEmpty(value);
       }
     },

--- a/src/components/Validator.js
+++ b/src/components/Validator.js
@@ -71,6 +71,15 @@ export const Validator = {
         if (!FormioUtils.boolValue(setting)) {
           return true;
         }
+
+        // WYSIWYG validation
+        if (component.quill) {
+          if (value === "<p><br></p>") {
+            return false
+          }
+          return true
+        }
+
         return !component.isEmpty(value);
       }
     },

--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -1,5 +1,6 @@
 import { TextFieldComponent } from '../textfield/TextField';
 import { BaseComponent } from '../base/Base';
+
 export class TextAreaComponent extends TextFieldComponent {
   constructor(component, options, data) {
     super(component, options, data);
@@ -91,6 +92,23 @@ export class TextAreaComponent extends TextFieldComponent {
     return this.input;
   }
 
+  isEmpty(value) {
+    if (this.quill) {
+      return (value === '<p><br></p>');
+    }
+    else {
+      return super.isEmpty(value);
+    }
+  }
+
+  get defaultValue() {
+    let defaultValue = super.defaultValue;
+    if (this.quill && !defaultValue) {
+      defaultValue = '<p></p>';
+    }
+    return defaultValue;
+  }
+
   setValue(value, flags) {
     if (!this.component.wysiwyg) {
       return super.setValue(value, flags);
@@ -103,24 +121,7 @@ export class TextAreaComponent extends TextFieldComponent {
   }
 
   getValue() {
-    if (!this.component.wysiwyg) {
-      return super.getValue();
-    }
-
-    // FOR-998 Assigns default value
-    if (!this.data[this.component.key]) {
-      this.data[this.component.key] = "<p></p>";
-      return this.data[this.component.key]
-    }
-    if (this.quill && this.data[this.component.key]) {
-      var innerHTML = this.quill.root.innerHTML;
-
-      // Required for pristine validation
-      if (this.data[this.component.key] === "<p></p>" && innerHTML === "<p><br></p>") {
-        return this.data[this.component.key]
-      }
-      return innerHTML;
-    }
+    return this.quill ? this.quill.root.innerHTML : super.getValue();
   }
 
   elementInfo() {

--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -108,7 +108,7 @@ export class TextAreaComponent extends TextFieldComponent {
     }
 
     // FOR-998 Assigns default value
-    if(!this.data[this.component.key]){
+    if (!this.data[this.component.key]) {
       this.data[this.component.key] = "<p></p>";
       return this.data[this.component.key]
     }

--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -71,7 +71,7 @@ export class TextAreaComponent extends TextFieldComponent {
 
         this.quill.on('text-change', () => {
           txtArea.value = this.quill.root.innerHTML;
-          this.updateValue(true, txtArea.value);
+          this.updateValue(txtArea.value, true);
         });
 
         if (this.options.readOnly || this.component.disabled) {
@@ -91,11 +91,11 @@ export class TextAreaComponent extends TextFieldComponent {
 
     this.quillReady.then((quill) => {
       quill.clipboard.dangerouslyPasteHTML(value);
-      this.updateValue(flags);
+      this.updateValue(value, flags);
     });
   }
 
-  updateValue(flags, value) {
+  updateValue(value, flags) {
     if (!this.component.wysiwyg) {
       return super.updateValue();
     }

--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -61,6 +61,13 @@ export class TextAreaComponent extends TextFieldComponent {
         var txtArea = document.createElement('textarea');
         txtArea.setAttribute('class', 'quill-source-code');
         this.quill.addContainer('ql-custom').appendChild(txtArea);
+
+        // Allows users to skip toolbar items when tabbing though form
+        var elm = document.querySelectorAll('.ql-formats > button');
+        for (var i=0; i < elm.length; i++) {
+          elm[i].setAttribute("tabindex", "-1");
+        }
+
         document.querySelector('.ql-source').addEventListener('click', () => {
           if (txtArea.style.display === 'inherit') {
             this.quill.clipboard.dangerouslyPasteHTML(txtArea.value);
@@ -71,7 +78,7 @@ export class TextAreaComponent extends TextFieldComponent {
 
         this.quill.on('text-change', () => {
           txtArea.value = this.quill.root.innerHTML;
-          this.updateValue(txtArea.value, true);
+          this.updateValue(true);
         });
 
         if (this.options.readOnly || this.component.disabled) {
@@ -91,32 +98,8 @@ export class TextAreaComponent extends TextFieldComponent {
 
     this.quillReady.then((quill) => {
       quill.clipboard.dangerouslyPasteHTML(value);
-      this.updateValue(value, flags);
+      this.updateValue(flags);
     });
-  }
-
-  updateValue(value, flags) {
-    if (!this.component.wysiwyg) {
-      return super.updateValue();
-    }
-
-    if (this.quill && value) {
-      if ( value == null ||
-        value == '<p></p>' ||
-        value == '<p><br></p>' ||
-        value == '<p>&nbsp;<br></p>' ||
-        value == '<p>&nbsp;</p>' ||
-        value == '&nbsp;<br>' ||
-        value == ' <br>' ||
-        value == '&nbsp;' ||
-        value == ' '
-      ) {
-        delete this.data[this.component.key]
-      }
-      else{
-        this.data[this.component.key] = value;
-      }
-    }
   }
 
   getValue() {
@@ -124,8 +107,19 @@ export class TextAreaComponent extends TextFieldComponent {
       return super.getValue();
     }
 
+    // FOR-998 Assigns default value
+    if(!this.data[this.component.key]){
+      this.data[this.component.key] = "<p></p>";
+      return this.data[this.component.key]
+    }
     if (this.quill && this.data[this.component.key]) {
-      return this.quill.root.innerHTML;
+      var innerHTML = this.quill.root.innerHTML;
+
+      // Required for pristine validation
+      if (this.data[this.component.key] === "<p></p>" && innerHTML === "<p><br></p>") {
+        return this.data[this.component.key]
+      }
+      return innerHTML;
     }
   }
 

--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -11,6 +11,7 @@ export class TextAreaComponent extends TextFieldComponent {
   wysiwygDefault() {
     return {
       theme: 'snow',
+      placeholder: this.component.placeholder,
       modules: {
         toolbar: [
           [{ 'size': ['small', false, 'large', 'huge'] }],  // custom dropdown
@@ -70,7 +71,7 @@ export class TextAreaComponent extends TextFieldComponent {
 
         this.quill.on('text-change', () => {
           txtArea.value = this.quill.root.innerHTML;
-          this.updateValue(true);
+          this.updateValue(true, txtArea.value);
         });
 
         if (this.options.readOnly || this.component.disabled) {
@@ -94,12 +95,36 @@ export class TextAreaComponent extends TextFieldComponent {
     });
   }
 
+  updateValue(flags, value) {
+    if (!this.component.wysiwyg) {
+      return super.updateValue();
+    }
+
+    if (this.quill && value) {
+      if ( value == null ||
+        value == '<p></p>' ||
+        value == '<p><br></p>' ||
+        value == '<p>&nbsp;<br></p>' ||
+        value == '<p>&nbsp;</p>' ||
+        value == '&nbsp;<br>' ||
+        value == ' <br>' ||
+        value == '&nbsp;' ||
+        value == ' '
+      ) {
+        delete this.data[this.component.key]
+      }
+      else{
+        this.data[this.component.key] = value;
+      }
+    }
+  }
+
   getValue() {
     if (!this.component.wysiwyg) {
       return super.getValue();
     }
 
-    if (this.quill) {
+    if (this.quill && this.data[this.component.key]) {
       return this.quill.root.innerHTML;
     }
   }


### PR DESCRIPTION
Added placeholder and addressed the error that was causing core WYSIWYG component to fail preventing several items form working.

[Resolved] FOR-976 Placeholders do not work with wysiwyg textarea.
[Resolved] FOR-977 The tab key into the text area captures the buttons of the editor.
[Resolved] FOR-998 WYSIWYG submitted while it is still in “focus” then the data isn’t saved.
[Resolved] FOR-1006 Core Renderer - Unable to backspace using the WYSIWYG component.
