### PR TITLE
Fix FOR-400 for false conditionals and null values

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -387,7 +387,7 @@ const FormioUtils = {
       }
       // FOR-400 - Fix issue where falsey values were being evaluated as show=true
       if (_isNil(value)) {
-        return false;
+        value = '';
       }
       // Special check for selectboxes component.
       if (_isObject(value) && _has(value, cond.eq)) {


### PR DESCRIPTION
Create a component with simple conditional where,
This component should Display: is false,
When the form component: is some other Text component with no default value,
Has the value: is any non-empty string.

View form and refresh browser.
Component will not display even though Text component referred to is empty (null).

FOR-400 returns false for null values regardless of setting of `component.conditional.show`.
Better to convert null value to empty string so normal logic can precede which takes into account setting of `component.conditional.show`.
