### PR TITLE
Update Select.js

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -228,7 +228,7 @@ export class SelectComponent extends BaseComponent {
 
     if (!_isEmpty(query)) {
       // Add the query string.
-      url += '?' + Formio.serialize(query);
+      url += (!(url.indexOf('?') !== -1) ? '?' : '&') + Formio.serialize(query);
     }
 
     // Make the request.


### PR DESCRIPTION
change the generated url in order to avoid two '?' in the query.
That can happened if you tried to show a form with a select that filters resources