### PR TITLE
Custom var_search operator using dotty for accessing array of objects…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formiojs",
-  "version": "2.24.6",
+  "version": "2.25.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2164,6 +2164,11 @@
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
       }
+    },
+    "dotty": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/dotty/-/dotty-0.0.2.tgz",
+      "integrity": "sha1-4d6NRiZ7YvreErW1jCHKUUxKeqE="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -7526,9 +7531,6 @@
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
-    },
-    "text-mask-all": {
-      "version": "github:text-mask/text-mask#bd2316f909f11e13c02de8f26d11d28a9995a1a0"
     },
     "textextensions": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "browser-cookies": "^1.1.0",
     "choices.js": "^3.0.2",
     "dialog-polyfill": "^0.4.9",
+    "dotty": "0.0.2",
     "eventemitter2": "^5.0.0",
     "flatpickr": "^4.1.4",
     "i18next": "^10.0.3",

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -20,9 +20,16 @@ import compile from 'lodash/template';
 import jsonLogic from 'json-logic-js';
 import { lodashOperators } from './jsonlogic/operators';
 import momentModule from 'moment';
+import dotty from 'dotty';
 
 // Configure JsonLogic
 lodashOperators.forEach((name) => jsonLogic.add_operation(`_${name}`, _[name]));
+
+// Custom var_search operator for accessing Array of objects and more
+// https://github.com/deoxxa/dotty
+jsonLogic.add_operation('var_search', function(key){
+  return dotty.search(this, key);
+});
 
 const FormioUtils = {
   jsonLogic, // Share


### PR DESCRIPTION
This feature should be available in jsonLogic core in fact.

This feature in formio would especially be usefull when using the datagrid component that store data in an array of object.
If you want to calculate over some properties of this array without having to re-create a new Array of integers, this solution is the best way to archieve this.

The new operator will permit accessing deep json objects, which explains the use of dotty 'search' which will respond to more various use cases.
See dotty 'search' documentation: https://github.com/deoxxa/dotty

Example: if you want to calculate final total of every datagrid row totals (datagrid key: 'items')
```json
{
...
  calculateValue: {
    _sum: {
      var_search: "data.items.*.total"
    }
  }
}
```