### PR TITLE
Event listener no longer fires unintentionally.

### DIFF
--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -69,12 +69,14 @@ export class TextAreaComponent extends TextFieldComponent {
           elm[i].setAttribute("tabindex", "-1");
         }
 
-        document.querySelector('.ql-source').addEventListener('click', () => {
-          if (txtArea.style.display === 'inherit') {
-            this.quill.clipboard.dangerouslyPasteHTML(txtArea.value);
-          }
-          txtArea.style.display = (txtArea.style.display === 'none') ? 'inherit' : 'none';
-        });
+        if (document.querySelector('.ql-source')) {
+          document.querySelector('.ql-source').addEventListener('click', () => {
+            if (txtArea.style.display === 'inherit') {
+              this.quill.clipboard.dangerouslyPasteHTML(txtArea.value);
+            }
+            txtArea.style.display = (txtArea.style.display === 'none') ? 'inherit' : 'none';
+          });
+        }
         /** END CODEBLOCK **/
 
         this.quill.on('text-change', () => {


### PR DESCRIPTION
The Event listener inside the Quill object could fail if the WYSIWYG configuration  were changed to exclude certain modules. This would prevent WYSIWYG data from updating field values correctly. 

FOR-990
Video Before & After fix (For Testing)
https://www.screencast.com/t/PBEAfe3Vn41P