### PR TITLE
Fixed radio button wrapping issue

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -15,7 +15,9 @@ export class RadioComponent extends BaseComponent {
   }
 
   createInput(container) {
-    const inputGroup = this.ce('div');
+    const inputGroup = this.ce('div', {
+      class: 'input-group'
+    });
     const labelOnTheTopOrOnTheLeft = this.optionsLabelOnTheTopOrLeft();
     var wrappers = [];
 


### PR DESCRIPTION
Radio button lacked input-group class causing the container to break. Added the class which is inline with how ngFormio handles the radio button grouping. 

ngFormio Expected:
https://www.screencast.com/t/EUiYBUJwq9

Formio.js - Broken:
https://www.screencast.com/t/mUhYRPNYQo 

Formio.js - With Fix:
https://www.screencast.com/t/ZXcAhJqK
