### PR TITLE
Fixed custom Events not firing

### DIFF
--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -123,7 +123,7 @@ export class ButtonComponent extends BaseComponent {
           break;
         case 'event':
           this.emit(this.component.event, this.data);
-          this.event.emit(this.component.event, this.data);
+          this.events.emit(this.component.event, this.data);
           this.emit('customEvent', {
             type: this.component.event,
             component: this.component,

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -122,7 +122,7 @@ export class ButtonComponent extends BaseComponent {
           this.emit('submitButton');
           break;
         case 'event':
-          this.events.emit(this.component.event, this.data);
+          this.emit(this.component.event, this.data);
           this.emit('customEvent', {
             type: this.component.event,
             component: this.component,

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -123,6 +123,7 @@ export class ButtonComponent extends BaseComponent {
           break;
         case 'event':
           this.emit(this.component.event, this.data);
+          this.event.emit(this.component.event, this.data);
           this.emit('customEvent', {
             type: this.component.event,
             component: this.component,


### PR DESCRIPTION
"this.events.emit" should be "this.emit" otherwise customEvents set in portal will not call their named function when used in an application. 

https://www.screencast.com/t/WY8aMXlza46  