### PR TITLE
Fix issue with the way server errors are resolved.

### DIFF
--- a/src/formio.js
+++ b/src/formio.js
@@ -717,7 +717,7 @@ class Formio {
             ? response.json()
             : response.text())
             .then((error) => {
-              return Promse.reject(error);
+              return Promise.reject(error);
             });
         }
 

--- a/src/formio.js
+++ b/src/formio.js
@@ -717,7 +717,7 @@ class Formio {
             ? response.json()
             : response.text())
             .then((error) => {
-              throw error;
+              return Promse.reject(error);
             });
         }
 


### PR DESCRIPTION
Instead of throwing an error we should send a rejected promise. Some libraries override the default promise handler and catch the error weird. By returning a rejected promise we ensure things catch in the promise libraries.