### PR TITLE
ie10 issue: "Unable to get property '1' of undefined or null reference"

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -700,7 +700,7 @@ var FormioUtils = {
     var formattedNumberString = 12345.6789.toLocaleString(lang);
     return {
       delimiter: formattedNumberString.match(/12(.*)345/)[1],
-      decimalSeparator: formattedNumberString.match(/345(.*)67/)[1]
+      decimalSeparator: formattedNumberString.match(/345(.*)6[78]/)[1]
     };
   },
   getNumberDecimalLimit: function getNumberDecimalLimit(component) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -704,7 +704,7 @@ const FormioUtils = {
     const formattedNumberString = (12345.6789).toLocaleString(lang);
     return {
       delimiter: formattedNumberString.match(/12(.*)345/)[1],
-      decimalSeparator: formattedNumberString.match(/345(.*)67/)[1]
+      decimalSeparator: formattedNumberString.match(/345(.*)6[78]/)[1]
     };
   },
   getNumberDecimalLimit(component) {


### PR DESCRIPTION
ie10 rounds up number to 12345.68 thus the decimalSeparator is not set and the browser console is spoiled by message: '"Unable to get property '1' of undefined or null reference" '.
