### PR TITLE
feature(components): Add property dataGridLabel to components and add setting to form builder

### DIFF
--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -86,6 +86,11 @@ export default class BaseComponent {
       tableView: true,
 
       /**
+       * If true, will show label when component is in a datagrid.
+       */
+      dataGridLabel: false,
+
+      /**
        * The input label provided to this component.
        */
       label: '',

--- a/src/components/base/editForm/Base.edit.display.js
+++ b/src/components/base/editForm/Base.edit.display.js
@@ -189,6 +189,14 @@ export default [
     input: true
   },
   {
+    weight: 1300,
+    type: 'checkbox',
+    label: 'Show Label in DataGrid',
+    tooltip: 'Show the label when in a Datagrid.',
+    key: 'dataGridLabel',
+    input: false
+  },
+  {
     weight: 1400,
     type: 'checkbox',
     label: 'Disabled',

--- a/src/components/panel/Panel.js
+++ b/src/components/panel/Panel.js
@@ -13,6 +13,7 @@ export default class PanelComponent extends NestedComponent {
       clearOnHide: false,
       input: false,
       tableView: false,
+      dataGridLabel: false,
       persistent: false
     }, ...extend);
   }


### PR DESCRIPTION
### Change
This commit will add a checkbox in the form builder settings section and will add a property in the component object called dataGridLabel. 

### Reason
When a Panel component is added into a Datagrid component the title or property key is shown in the Datagrid header.

### Screenshots
[image - 1](http://take.ms/1CNm9)
