### PR TITLE
Fix the bug that asterisk does not show dynamically with custom validation based on other entries in the form

### DIFF
--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -2196,7 +2196,7 @@ export default class BaseComponent {
     }
     this.updateOnChange(flags, changed);
     this.root.components.forEach((c) => {
-      if (c.component.validate.required && c.component.validate.custom.indexof('component.validate.required') !== -1) {
+      if (c.component.validate.required && c.component.validate.custom.indexOf('component.validate.required') !== -1) {
         c.component.validate.required = false;
       }
       Validator.check(c, c.data);

--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -2200,7 +2200,6 @@ export default class BaseComponent {
         c.component.validate.required = false;
       }
       Validator.check(c, c.data);
-      console.log(c, c.data);
       var req = ' field-required';
       if (c.component.validate && c.component.validate.required) {
         if (c.labelElement.className.indexOf(req) === -1) {

--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -2194,8 +2194,23 @@ export default class BaseComponent {
     if (this.viewOnly) {
       this.updateViewOnlyValue(newValue);
     }
-
     this.updateOnChange(flags, changed);
+    this.root.components.forEach((c) => {
+      if (c.component.validate.required && c.component.validate.custom.indexof('component.validate.required') !== -1) {
+        c.component.validate.required = false;
+      }
+      Validator.check(c, c.data);
+      console.log(c, c.data);
+      var req = ' field-required';
+      if (c.component.validate && c.component.validate.required) {
+        if (c.labelElement.className.indexOf(req) === -1) {
+          c.labelElement.className += req;
+        }
+      }
+      else {
+        c.labelElement.className = c.labelElement.className.replace(req, '');
+      }
+    });
     return changed;
   }
 


### PR DESCRIPTION
This is to fix the bug that the red asterisk does not show dynamically with custom validation based on other entries in the form. In this way user can use "component.validate.required = (data['key'] == 'something')" in the custom validation.

Lets say if the user creates two text fields in a form, one has the key 'firstName' and one has 'lastName'. And user wants to set 'lastName' to be required if the firstName is filled in.

Before: User enters  "component.validate.required = (data['lastName'] !== '')" to the custom validation of 'lastName' in the builder. In the render, when the user puts things into the text field of firstName, lastName text field wouldn't show the red asterisk until the user clicks on the lastName field.

After: In the render, on change of every component, base.js goes through every other component in the form and checks if the field is required based on the custom validation script. If it is required then append the 'field-required' class name and remove this class if it is not required.

I can give more information about the issue if I am not clear enough.