### PR TITLE
FOR-1693: Update datagrid setValue method.

### DIFF
--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -328,7 +328,7 @@ export default class DataGridComponent extends NestedComponent {
     const changed = this.hasChanged(value, this.dataValue);
 
     //always should build if not built yet OR is trying to set empty value (in order to prevent deleting last row)
-    let shouldBuildRows = !this.isBuilt || _.isEqual(this.emptyValue, value);
+    let shouldBuildRows = !this.isBuilt || _.isEqual(this.emptyValue, value) || this.dataValue !== value;
     //check if visible columns changed
     let visibleColumnsAmount = 0;
     _.forEach(this.visibleColumns, (value) => {


### PR DESCRIPTION
Force rebuild rows if provided value and current dataValue are
different references.