### PR TITLE
Catch errros form 'vanilla-text-mask' to prevent form rejection on iOS

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -300,10 +300,17 @@ export default class Component {
     if (input && inputMask) {
       const mask = FormioUtils.getInputMask(inputMask);
       this._inputMask = mask;
-      input.mask = maskInput({
-        inputElement: input,
-        mask
-      });
+      try {
+        input.mask = maskInput({
+          inputElement: input,
+          mask
+        });
+      }
+      catch (e) {
+        // Don't pass error up, to prevent form rejection.
+        // Internal bug of vanilla-text-mask on iOS (`selectionEnd`);
+        console.warn(e);
+      }
       if (mask.numeric) {
         input.setAttribute('pattern', '\\d*');
       }


### PR DESCRIPTION
I'm failed a little bit. This bug actually solved on 4.x, but I found solution that will solve problem with `vanilla-text-mask`. Simple try/catch to avoid form rejection. Tested on 3.6.4