### PR TITLE
Check client side validity before beforeSubmit hook.

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1026,17 +1026,19 @@ export default class Webform extends NestedComponent {
 
       submission.state = options.state || 'submitted';
       const isDraft = (submission.state === 'draft');
+
+      // Run validations before submit hook.
+      if (!isDraft && !submission.data) {
+        return reject('Invalid Submission');
+      }
+
+      if (!isDraft && !this.checkValidity(submission.data, true)) {
+        return reject();
+      }
+
       this.hook('beforeSubmit', submission, (err) => {
         if (err) {
           return reject(err);
-        }
-
-        if (!isDraft && !submission.data) {
-          return reject('Invalid Submission');
-        }
-
-        if (!isDraft && !this.checkValidity(submission.data, true)) {
-          return reject();
         }
 
         this.loading = true;


### PR DESCRIPTION
The rationale for this is that customers who have server side validation only want to send the data to the server after the client side validation passes. The way it is currently written the client side validation only triggers AFTER the server side validation. The more common use case is to do client side validation, then if it passes do custom server side validation before saving to the form.io server.