### PR TITLE
Highlight and persist custom error messages.

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -888,7 +888,7 @@ export default class Webform extends NestedComponent {
 
     // Mark any components as invalid if in a custom message.
     this.customErrors.forEach(err => {
-      if (err.custom && err.component) {
+      if (err.component) {
         const component = this.getComponent(err.component);
         if (component) {
           component.setCustomValidity(err.message, true);

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1048,13 +1048,7 @@ export default class Webform extends NestedComponent {
       const isDraft = (submission.state === 'draft');
       this.hook('beforeSubmit', submission, (err) => {
         if (err) {
-          // Ensure err is an array.
-          err = Array.isArray(err) ? err : [err];
-
-          // Set as custom errors.
-          this.customErrors = err;
-
-          return reject();
+          return reject(err);
         }
 
         if (!isDraft && !submission.data) {
@@ -1065,27 +1059,46 @@ export default class Webform extends NestedComponent {
           return reject();
         }
 
-        this.loading = true;
+        this.hook('customValidation', submission, (err) => {
+          if (err) {
+            // If string is returned, cast to object.
+            if (typeof err === 'string') {
+              err = {
+                message: err
+              };
+            }
 
-        // Use the form action to submit the form if available.
-        let submitFormio = this.formio;
-        if (this._form && this._form.action) {
-          submitFormio = new Formio(this._form.action, this.formio ? this.formio.options : {});
-        }
+            // Ensure err is an array.
+            err = Array.isArray(err) ? err : [err];
 
-        if (this.nosubmit || !submitFormio) {
-          return resolve({
-            submission: submission,
-            saved: false
-          });
-        }
+            // Set as custom errors.
+            this.customErrors = err;
 
-        // If this is an actionUrl, then make sure to save the action and not the submission.
-        const submitMethod = submitFormio.actionUrl ? 'saveAction' : 'saveSubmission';
-        submitFormio[submitMethod](submission).then(result => resolve({
-          submission: result,
-          saved: true
-        })).catch(reject);
+            return reject();
+          }
+
+          this.loading = true;
+
+          // Use the form action to submit the form if available.
+          let submitFormio = this.formio;
+          if (this._form && this._form.action) {
+            submitFormio = new Formio(this._form.action, this.formio ? this.formio.options : {});
+          }
+
+          if (this.nosubmit || !submitFormio) {
+            return resolve({
+              submission: submission,
+              saved: false
+            });
+          }
+
+          // If this is an actionUrl, then make sure to save the action and not the submission.
+          const submitMethod = submitFormio.actionUrl ? 'saveAction' : 'saveSubmission';
+          submitFormio[submitMethod](submission).then(result => resolve({
+            submission: result,
+            saved: true
+          })).catch(reject);
+        });
       });
     });
   }

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -103,6 +103,7 @@ export default class Webform extends NestedComponent {
     this._loading = false;
     this._submission = {};
     this._form = {};
+    this.customErrors = [];
 
     /**
      * Determines if this form should submit the API on submit.
@@ -877,10 +878,24 @@ export default class Webform extends NestedComponent {
         errors.push(error);
       }
     }
+
+    errors = errors.concat(this.customErrors);
+
     if (!errors.length) {
       this.setAlert(false);
       return;
     }
+
+    // Mark any components as invalid if in a custom message.
+    this.customErrors.forEach(err => {
+      if (err.custom && err.component) {
+        const component = this.getComponent(err.component);
+        if (component) {
+          component.setCustomValidity(err.message, true);
+        }
+      }
+    });
+
     const message = `
       <p>${this.t('error')}</p>
       <ul>
@@ -949,6 +964,11 @@ export default class Webform extends NestedComponent {
    * @param flags
    */
   onChange(flags, changed) {
+    // For any change events, clear any custom errors for that component.
+    if (changed && changed.component) {
+      this.customErrors = this.customErrors.filter(err => err.component && err.component !== changed.component.key);
+    }
+
     super.onChange(flags, true);
     const value = _.clone(this._submission);
     value.changed = changed;
@@ -1028,7 +1048,18 @@ export default class Webform extends NestedComponent {
       const isDraft = (submission.state === 'draft');
       this.hook('beforeSubmit', submission, (err) => {
         if (err) {
-          return reject(err);
+          // Ensure err is an array.
+          err = Array.isArray(err) ? err : [err];
+
+          // Mark each error as custom so they won't clear.
+          err.forEach(err => {
+            err.custom = true;
+          });
+
+          // Set as custom errors.
+          this.customErrors = err;
+
+          return reject();
         }
 
         if (!isDraft && !submission.data) {

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1051,11 +1051,6 @@ export default class Webform extends NestedComponent {
           // Ensure err is an array.
           err = Array.isArray(err) ? err : [err];
 
-          // Mark each error as custom so they won't clear.
-          err.forEach(err => {
-            err.custom = true;
-          });
-
           // Set as custom errors.
           this.customErrors = err;
 


### PR DESCRIPTION
When custom error messages are set, they do not highlight associated components and disappear on the first change.

This PR makes the following changes:
1. Highlight any components listed in {component: 'mykey'} in the error message.
2. Persist error messages associated with specific fields until that field has a change event.