### PR TITLE
Fix bugs with Select and Checkbox component

### DIFF
--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -71,7 +71,7 @@ export default class CheckBoxComponent extends BaseComponent {
   }
 
   get emptyValue() {
-    return false;
+    return undefined;
   }
 
   createElement() {
@@ -129,10 +129,6 @@ export default class CheckBoxComponent extends BaseComponent {
         marginLeft: 0
       });
     }
-  }
-
-  isEmpty(value) {
-    return super.isEmpty(value) || value === false;
   }
 
   createLabel(container, input) {

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -525,7 +525,9 @@ export default class SelectComponent extends BaseComponent {
     else {
       this.focusableElement = this.choices.containerInner;
       this.choices.containerOuter.setAttribute('tabIndex', '-1');
-      this.addEventListener(this.choices.containerOuter, 'focus', () => this.focusableElement.focus());
+      if (useSearch) {
+        this.addEventListener(this.choices.containerOuter, 'focus', () => this.focusableElement.focus());
+      }
     }
     this.addFocusBlurEvents(this.focusableElement);
     this.focusableElement.setAttribute('tabIndex', tabIndex);


### PR DESCRIPTION
FOR-1646:
Because of tricky focus redirection to focusableElement, Choices onBlur
handler was triggered and this behavior forced dropdown to be closed.
Now we add this focus redirection only when search is enabled.

FOR-1647:
Because false was considered as empty value for Checkbox component,
all newly created checkboxes was set to true due to restoreValue
method. Now undefined is considered as empty value for Checkbox.