### PR TITLE
language is lost when WebForm is created

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -366,7 +366,7 @@ export default class WebformBuilder extends Webform {
     ]));
 
     // Create the form instance.
-    this.editForm = new Webform(formioForm);
+    this.editForm = new Webform(formioForm, { language: this.options.language });
 
     // Set the form to the edit form.
     this.editForm.form = editForm;


### PR DESCRIPTION
If one drops component in the builder, the language settings is lost. 