### PR TITLE
Added component tooltip interpolation

### DIFF
--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -1201,7 +1201,7 @@ export default class BaseComponent extends Component {
       trigger: 'hover click',
       placement: 'right',
       html: true,
-      title: this.interpolate(component.tooltip.replace(/(?:\r\n|\r|\n)/g, '<br />'))
+      title: this.interpolate(component.tooltip).replace(/(?:\r\n|\r|\n)/g, '<br />')
     });
   }
 

--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -1201,7 +1201,7 @@ export default class BaseComponent extends Component {
       trigger: 'hover click',
       placement: 'right',
       html: true,
-      title: component.tooltip.replace(/(?:\r\n|\r|\n)/g, '<br />')
+      title: this.interpolate(component.tooltip.replace(/(?:\r\n|\r|\n)/g, '<br />'))
     });
   }
 


### PR DESCRIPTION
I have added interpolation for tooltips in order to use `instance.t()` to provide translation support for tooltips.

I have prioritized `this.interpolate()` above `this.t()` as it would be a challenge to deal with line breaks as this are not usually used when managing translations (and thus should be treated as if it where an html component content).