### PR TITLE
added-choices-rtl-support

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -514,6 +514,7 @@ export default class SelectComponent extends BaseComponent {
 
     const tabIndex = input.tabIndex;
     this.addPlaceholder(input);
+    input.setAttribute('dir', this.i18next.dir());
     this.choices = new Choices(input, choicesOptions);
 
     if (this.component.multiple) {

--- a/src/components/tags/Tags.js
+++ b/src/components/tags/Tags.js
@@ -47,6 +47,7 @@ export default class TagsComponent extends BaseComponent {
     if (!input) {
       return;
     }
+    input.setAttribute('dir', this.i18next.dir());
     this.choices = new Choices(input, {
       delimiter: (this.component.delimeter || ','),
       editItems: true,

--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -219,6 +219,12 @@ td > .form-group {
   padding: 2px;
 }
 
+/* fix for choices.js .choices__input container in rtl */
+.choices[dir="rtl"] > * {
+  text-align: right;
+}
+/* end fix for choices.js .choices__input container in rtl */
+
 /* fix for choices.js deletable items in rtl */
 .choices[dir="rtl"] .choices__list--multiple .choices__item[data-deletable] {
   padding-left: 5px;


### PR DESCRIPTION
Added `dir` attribute to component's input element to provide Choices.js RTL support (see issue https://github.com/formio/formio.js/issues/847)