### PR TITLE
Allow translating other Choice.js labels.

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -499,6 +499,8 @@ export default class SelectComponent extends BaseComponent {
       addItemText: false,
       placeholder: !!this.component.placeholder,
       placeholderValue: placeholderValue,
+      noResultsText: this.t('No results found'),
+      noChoicesText: this.t('No choices to choose from'),
       searchPlaceholderValue: this.t('Type to search'),
       shouldSort: false,
       position: (this.component.dropdown || 'auto'),


### PR DESCRIPTION
As of now, only the 'Type to search' label is translatable. This patch allows translating also 'No results found' and 'No choices to choose from'.