### PR TITLE
Fix bug with day adjustment when switching months

### DIFF
--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -110,8 +110,10 @@ export default class DayComponent extends BaseComponent {
 
   getInputValue(input, defaultValue) {
     if (_.isObject(input)) {
-      if (!_.isNaN(input.value)) {
-        return parseInt(input.value, 10);
+      const value = parseInt(input.value, 10);
+
+      if (!_.isNaN(value) && _.isNumber(value)) {
+        return value;
       }
     }
 
@@ -223,8 +225,10 @@ export default class DayComponent extends BaseComponent {
 
     // Ensure the day limits match up with the months selected.
     this.monthInput.onchange = function() {
-      self.dayInput.max = new Date(self.yearInput.value, this.value, 0).getDate();
-      if (self.dayInput.value > self.dayInput.max) {
+      const maxDay = parseInt(new Date(self.yearInput.value, this.value, 0).getDate(), 0);
+      const day = self.getInputValue(self.dayInput, 0);
+      self.dayInput.max = maxDay;
+      if (day > maxDay) {
         self.dayInput.value = self.dayInput.max;
       }
       self.updateValue();

--- a/src/components/day/Day.spec.js
+++ b/src/components/day/Day.spec.js
@@ -4,7 +4,8 @@ import Harness from '../../../test/harness';
 import DayComponent from './Day';
 
 import {
-  comp1
+  comp1,
+  comp2
 } from './fixtures';
 
 describe('Day Component', () => {
@@ -93,6 +94,53 @@ describe('Day Component', () => {
     Harness.testCreate(DayComponent, comp1).then((component) => {
       component.setValue('15/20/2017');
       assert.equal(component.getValue(), '00/20/2017');
+      done();
+    });
+  });
+
+  it('Should keep day value when switching months', (done) => {
+    Harness.testCreate(DayComponent, comp1).then((component) => {
+      component.setValue('01/05/2018');
+      assert.equal(component.getValue(), '01/05/2018');
+      component.on('componentChange', () => {
+        assert.equal(component.getValue(), '02/05/2018');
+        done();
+      });
+      component.monthInput.value = 2;
+      component.monthInput.dispatchEvent(new Event('change'));
+    });
+  });
+
+  it('Should adjust day value when day is great then maxDay of month', (done) => {
+    Harness.testCreate(DayComponent, comp1).then((component) => {
+      component.setValue('01/31/2018');
+      assert.equal(component.getValue(), '01/31/2018');
+      component.on('componentChange', () => {
+        assert.equal(component.getValue(), '02/28/2018');
+        done();
+      });
+      component.monthInput.value = 2;
+      component.monthInput.dispatchEvent(new Event('change'));
+    });
+  });
+
+  it('Should validate required fields', (done) => {
+    Harness.testCreate(DayComponent, comp2).then((component) => {
+      const valid = () => component.checkValidity(null, true);
+      const tests = {
+        '12/18/2018': true,
+        '12/00/0000': false,
+        '00/18/0000': false,
+        '00/00/2018': false,
+        '01/05/2018': true,
+      };
+
+      for (const v in tests) {
+        component.setValue(v);
+        console.log(valid(), tests[v]);
+        assert.equal(valid(), tests[v]);
+      }
+
       done();
     });
   });

--- a/src/components/day/fixtures/comp2.js
+++ b/src/components/day/fixtures/comp2.js
@@ -1,0 +1,39 @@
+export default {
+  'conditional': {
+    'eq': '',
+    'when': null,
+    'show': ''
+  },
+  'tags': [
+
+  ],
+  'type': 'day',
+  'validate': {
+    'custom': ''
+  },
+  'clearOnHide': true,
+  'persistent': true,
+  'protected': false,
+  'dayFirst': false,
+  'fields': {
+    'year': {
+      'required': true,
+      'placeholder': '',
+      'type': 'text'
+    },
+    'month': {
+      'required': true,
+      'placeholder': '',
+      'type': 'select'
+    },
+    'day': {
+      'required': true,
+      'placeholder': '',
+      'type': 'text'
+    }
+  },
+  'key': 'date',
+  'label': 'Date',
+  'tableView': true,
+  'input': true
+};

--- a/src/components/day/fixtures/index.js
+++ b/src/components/day/fixtures/index.js
@@ -1,1 +1,2 @@
 export comp1 from './comp1';
+export comp2 from './comp2';


### PR DESCRIPTION
- In `monthInput.onchange` expected that dayInput.value
  and maxDate will be `Numbers` but got `String`.

- `Dat.getInputValue` fixed.

- Day validation fixed.