### PR TITLE
Add tests for Select component

### DIFF
--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -1,3 +1,4 @@
+import assert from 'power-assert';
 import Harness from '../../../test/harness';
 import SelectComponent from './Select';
 
@@ -27,6 +28,34 @@ describe('Select Component', () => {
       const element = component.element.getElementsByClassName('choices__list choices__list--single')[0];
       Harness.testElementAttribute(element, 'tabindex', '0');
       done();
+    });
+  });
+
+  describe('#setValue', () => {
+    it('should set component value', (done) => {
+      Harness.testCreate(SelectComponent, comp1).then((component) => {
+        assert.equal(component.dataValue, '');
+        component.setValue('red');
+        assert.equal(component.dataValue, 'red');
+        done();
+      });
+    });
+
+    it('should reset input value when called with empty value', (done) => {
+      const comp = Object.assign({}, comp1);
+      delete comp.placeholder;
+
+      Harness.testCreate(SelectComponent, comp).then((component) => {
+        assert.equal(component.dataValue, '');
+        assert.equal(component.inputs[0].value, '');
+        component.setValue('red');
+        assert.equal(component.dataValue, 'red');
+        assert.equal(component.inputs[0].value, 'red');
+        component.setValue('');
+        assert.equal(component.dataValue, '');
+        assert.equal(component.inputs[0].value, '');
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
Add `SelectComponent.setValue` tests to ensure that
input value and component value get cleared when
`setValue` called with empty value.