### PR TITLE
FOR-1964: Fix bug with delimiter setting in Number

### DIFF
--- a/src/components/number/Number.js
+++ b/src/components/number/Number.js
@@ -158,15 +158,21 @@ export default class NumberComponent extends BaseComponent {
     return conformToMask(value.toString(), this.numberMask).conformedValue;
   }
 
-  build(state) {
-    super.build(state);
-    this.inputs.forEach((input, index) => {
-      this.addEventListener(input, 'blur', (event) => {
-        if (this.component.requireDecimal) {
-          this.setValueAt(index, event.target.value);
+  /** @override **/
+  createInput(...args) {
+    const input = super.createInput(...args);
+
+    if (this.component.requireDecimal) {
+      this.addEventListener(input, 'blur', () => {
+        const index = this.inputs.indexOf(input);
+
+        if (index !== -1) {
+          this.setValueAt(index, this.getValueAt(index));
         }
       });
-    });
+    }
+
+    return input;
   }
 
   getView(value) {

--- a/src/components/number/Number.spec.js
+++ b/src/components/number/Number.spec.js
@@ -1,11 +1,14 @@
+import assert from 'power-assert';
+import _ from 'lodash';
 import _merge from 'lodash/merge';
-
 import Harness from '../../../test/harness';
 import NumberComponent from './Number';
 
 import {
   comp1,
-  comp2
+  comp2,
+  comp3,
+  comp4
 } from './fixtures';
 
 describe('Number Component', () => {
@@ -145,5 +148,120 @@ describe('Number Component', () => {
       Harness.testSetInput(component, -12.123456789, -12.123456789, '-12,123456789');
       done();
     });
+  });
+
+  it('Should display default integer value', (done) => {
+    Harness.testCreate(NumberComponent, comp3).then(number => {
+      assert.deepEqual(_.get(number, ['inputs', '0', 'value']), '42');
+      done();
+    });
+  });
+
+  it('Should display default decimal value', (done) => {
+    const TEST_VAL = 4.2;
+    const comp = _.cloneDeep(comp3);
+
+    comp.defaultValue = TEST_VAL;
+    comp.decimalLimit = 2;
+    comp.requireDecimal = true;
+
+    Harness.testCreate(NumberComponent, comp).then(number => {
+      assert.deepEqual(_.get(number, ['inputs', '0', 'value']), '4.20');
+      done();
+    });
+  });
+
+  it('Should add trailing zeros on blur, if decimal required', (done) => {
+    const comp = _.cloneDeep(comp3);
+
+    comp.decimalLimit = 2;
+    comp.requireDecimal = true;
+
+    Harness.testCreate(NumberComponent, comp).then(number => {
+      const testset = [
+        // [inv, outv, display]
+        ['42',        42,       '42.00'],
+        ['42.1',      42.1,     '42.10'],
+        ['42.01',     42.01,    '42.01'],
+        ['4200',      4200,     '4200.00'],
+        ['4200.4',    4200.4,   '4200.40'],
+        ['4200.42',   4200.42,  '4200.42'],
+        ['4200.',     4200,     '4200.00'],
+        ['99999999.', 99999999, '99999999.00']
+      ];
+
+      testset.forEach((set, index) => {
+        try {
+          Harness.testNumberBlur(number, ...set);
+        }
+        catch (err) {
+          done(new Error(`Test case #${index}, set: ${set}, err: ${err.message}`));
+        }
+      });
+
+      done();
+    }, done);
+  });
+
+  it('Should add trailing zeros on blur, if decimal and delimiter is required', (done) => {
+    const comp = _.cloneDeep(comp3);
+
+    comp.decimalLimit = 2;
+    comp.requireDecimal = true;
+    comp.delimiter = true;
+
+    /* eslint-disable max-statements */
+    Harness.testCreate(NumberComponent, comp).then(number => {
+      const testset = [
+        // [inv, outv, display]
+        ['42',        42,       '42.00'],
+        ['42.1',      42.1,     '42.10'],
+        ['42.01',     42.01,    '42.01'],
+        ['4200',      4200,     '4,200.00'],
+        ['4200.4',    4200.4,   '4,200.40'],
+        ['4200.42',   4200.42,  '4,200.42'],
+        ['4200.',     4200,     '4,200.00'],
+        ['99999999.', 99999999, '99,999,999.00']
+      ];
+
+      testset.forEach((set, index) => {
+        try {
+          Harness.testNumberBlur(number, ...set);
+        }
+        catch (err) {
+          done(new Error(`Test case #${index}, set: ${set}, err: ${err.message}`));
+        }
+      });
+
+      done();
+    }, done);
+  });
+
+  it('Should add trailing zeros on blur with `multiple` flag', (done) => {
+    Harness.testCreate(NumberComponent, comp4).then(number => {
+      const testset = [
+        ['42',        42,       '42.00'],
+        ['42.1',      42.1,     '42.10'],
+        ['42.01',     42.01,    '42.01'],
+        ['4200',      4200,     '4,200.00'],
+        ['4200.4',    4200.4,   '4,200.40'],
+        ['4200.42',   4200.42,  '4,200.42'],
+        ['4200.',     4200,     '4,200.00'],
+        ['99999999.', 99999999, '99,999,999.00']
+      ];
+
+      testset.forEach((set, index) => {
+        try {
+          assert.strictEqual(number.inputs.length, index + 1);
+          Harness.testNumberBlur(number, ...set, index);
+          number.addValue();
+        }
+        catch (err) {
+          done(new Error(`Test case #${index}, set: ${set}, err: ${err.message}`));
+        }
+      });
+
+      done();
+    }, done);
   });
 });

--- a/src/components/number/fixtures/comp3.js
+++ b/src/components/number/fixtures/comp3.js
@@ -1,0 +1,13 @@
+export default {
+  label: 'Number',
+  mask: false,
+  tableView: true,
+  alwaysEnabled: false,
+  type: 'number',
+  input: true,
+  key: 'number',
+  delimiter: false,
+  requireDecimal: false,
+  encrypted: false,
+  defaultValue: 42
+};

--- a/src/components/number/fixtures/comp4.js
+++ b/src/components/number/fixtures/comp4.js
@@ -1,0 +1,14 @@
+export default {
+  label: 'Number',
+  multiple: true,
+  mask: false,
+  tableView: true,
+  alwaysEnabled: false,
+  type: 'number',
+  input: true,
+  key: 'number',
+  delimiter: true,
+  requireDecimal: true,
+  encrypted: false,
+  decimalLimit: 2
+};

--- a/src/components/number/fixtures/index.js
+++ b/src/components/number/fixtures/index.js
@@ -1,2 +1,4 @@
 export comp1 from './comp1';
 export comp2 from './comp2';
+export comp3 from './comp3';
+export comp4 from './comp4';

--- a/test/harness.js
+++ b/test/harness.js
@@ -254,6 +254,13 @@ const Harness = {
       form.on('nextPage', onNextPage);
     }
     return form.nextPage();
+  },
+  testNumberBlur(cmp, inv, outv, display, index = 0) {
+    const input = _.get(cmp, ['inputs', index], {});
+    input.value = inv;
+    input.dispatchEvent(new Event('blur'));
+    assert.strictEqual(cmp.getValueAt(index), outv);
+    assert.strictEqual(input.value, display);
   }
 };
 export default Harness;


### PR DESCRIPTION
Move blur attachment logic from `build` to `createInput`, because it
gets called from both `build` and `buildRows` methods, and independent
from `multiple` option, inputs react on `blur`.

Also switch value source from `event.target.value` to
`this.getValueAt`, because `getValueAt` utilize `parseNumber` and
don't corrupt the value.