### PR TITLE
 SELECT: Added option in Data tab to specify custom options that will be used in the Choices JS library

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -25,7 +25,7 @@ export default class SelectComponent extends BaseComponent {
       authenticate: false,
       template: '<span>{{ item.label }}</span>',
       selectFields: '',
-	  customOptions: {}
+      customOptions: '{}'
     }, ...extend);
   }
 
@@ -491,8 +491,19 @@ export default class SelectComponent extends BaseComponent {
 
     const useSearch = this.component.hasOwnProperty('searchEnabled') ? this.component.searchEnabled : true;
     const placeholderValue = this.t(this.component.placeholder);
+    let customOptions = this.component.customOptions || {};
+    if (typeof customOptions == 'string') {
+      try {
+        customOptions = JSON.parse(customOptions);
+      }
+      catch (err) {
+        console.warn(err.message);
+        customOptions = {};
+      }
+    }
+
     const choicesOptions = {
-		...this.component.customOptions,
+      ...customOptions,
       removeItemButton: this.component.disabled ? false : _.get(this.component, 'removeItemButton', true),
       itemSelectText: '',
       classNames: {

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -24,7 +24,8 @@ export default class SelectComponent extends BaseComponent {
       minSearch: 0,
       authenticate: false,
       template: '<span>{{ item.label }}</span>',
-      selectFields: ''
+      selectFields: '',
+	  customOptions: {}
     }, ...extend);
   }
 
@@ -491,6 +492,7 @@ export default class SelectComponent extends BaseComponent {
     const useSearch = this.component.hasOwnProperty('searchEnabled') ? this.component.searchEnabled : true;
     const placeholderValue = this.t(this.component.placeholder);
     const choicesOptions = {
+		...this.component.customOptions,
       removeItemButton: this.component.disabled ? false : _.get(this.component, 'removeItemButton', true),
       itemSelectText: '',
       classNames: {

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -25,7 +25,7 @@ export default class SelectComponent extends BaseComponent {
       authenticate: false,
       template: '<span>{{ item.label }}</span>',
       selectFields: '',
-      customOptions: '{}'
+      customOptions: {}
     }, ...extend);
   }
 

--- a/src/components/select/editForm/Select.edit.data.js
+++ b/src/components/select/editForm/Select.edit.data.js
@@ -344,5 +344,16 @@ export default [
     conditional: {
       json: { '===': [{ var: 'data.dataSrc' }, 'url'] }
     }
+  },
+  {
+    type: 'textarea',
+    as: 'json',
+    editor: 'ace',
+    weight: 22,
+    input: true,
+    key: 'customOptions',
+    label: 'Custom default options',
+    tooltip: 'A raw JSON object to use as default options for the Select component (Choices JS).',
+	defaultValue: {}
   }
 ];


### PR DESCRIPTION
This is useful if you want to override some default options without having to change the code. For example, the select's search result is limited to 4 items.

You can do this to override this default value:

![image](https://user-images.githubusercontent.com/22521614/50476041-e2843300-09c6-11e9-8b25-0d13d725e889.png)
