### PR TITLE
fix: fix webformbuilder default editform options mutation.

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -353,7 +353,7 @@ export default class WebformBuilder extends Webform {
     const overrides = _.get(this.options, `editForm.${componentCopy.component.type}`, {});
 
     // Get the editform for this component.
-    const editForm = componentClass.editForm(overrides);
+    const editForm = componentClass.editForm(_.cloneDeep(overrides));
 
     // Change the defaultValue component to be reflective.
     this.defaultValueComponent = getComponent(editForm.components, 'defaultValue');


### PR DESCRIPTION
a fix to prevent edit form default options mutation.

When editing fields in Form builder options passed with constructor are being overwritten by options options merged from previous edit form.

STR:

1. Run webformbuilder with custom editform options configuration for two fields (button, textfield).
2. Add button to the form area.
3. Add textfield to the form area.
4. Open button editform.
5. Save changes.
6. Open textfield editform.

Actual result: 
textfeld editform includes button editform elements.

Expected result:
textfeld editform contains only textfield editform.

