### PR TITLE
cut reference for values stored in cache

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -820,6 +820,11 @@ export default class Formio {
           return result;
         }
 
+        // Cache the response.
+        if (method === 'GET') {
+          Formio.cache[cacheKey] = _cloneDeep(result);
+        }
+
         let resultCopy = {};
 
         // Shallow copy result so modifications don't end up in cache
@@ -851,11 +856,6 @@ export default class Formio {
 
         return Promise.reject(err);
       });
-
-    // Cache the response.
-    if (method === 'GET') {
-      Formio.cache[cacheKey] = _cloneDeep(result);
-    }
 
     return result;
   }

--- a/src/Formio.js
+++ b/src/Formio.js
@@ -10,6 +10,7 @@ import cookies from 'browser-cookies';
 import copy from 'shallow-copy';
 import * as providers from './providers';
 import _get from 'lodash/get';
+import _cloneDeep from 'lodash/cloneDeep';
 
 const isBoolean = (val) => typeof val === typeof true;
 const isNil = (val) => val === null || val === undefined;
@@ -697,7 +698,7 @@ export default class Formio {
 
     // Get the cached promise to save multiple loads.
     if (!opts.ignoreCache && method === 'GET' && Formio.cache.hasOwnProperty(cacheKey)) {
-      return Formio.cache[cacheKey];
+      return _cloneDeep(Formio.cache[cacheKey]);
     }
 
     // Set up and fetch request
@@ -853,7 +854,7 @@ export default class Formio {
 
     // Cache the response.
     if (method === 'GET') {
-      Formio.cache[cacheKey] = result;
+      Formio.cache[cacheKey] = _cloneDeep(result);
     }
 
     return result;


### PR DESCRIPTION
## Problem

_There are some problems with references when formio library getting values from cache. Let's assume scenario - in first view you use form in read and view only mode but after click on edit button you render the same form but without read only flags. What is unexpected that submit button is hidden. Why? Because in the first view - formio library hide submit button due to read only mode. It will be proper if not the fact that formio library works on reference so it change original value. When we go to the second view - hidden flag is set because we get this changed definition from cache._


## Solution

_In proposed solution We assume that cache should work as immutable object so when we get or put values we need to use cloneDeep to remove linking reference. Without that - in app we will be using still original value due to reference._

Of course I am open to another solution which should resolve the problem.