### PR TITLE
Headers availability check. Prevents build errors in Node environments

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -1264,7 +1264,11 @@ export default class Formio {
 // Define all the static properties.
 Formio.libraries = {};
 Formio.Promise = Promise;
-Formio.Headers = Headers;
+if (typeof Headers !== 'undefined') {
+  Formio.Headers = Headers;
+} else {
+  Formio.Headers = {}
+}
 Formio.baseUrl = 'https://api.form.io';
 Formio.projectUrl = Formio.baseUrl;
 Formio.projectUrlSet = false;


### PR DESCRIPTION
Fixed is based on this recommendation from Gatsby:
https://www.gatsbyjs.org/docs/debugging-html-builds/

supposedly also helps for NextJS