### PR TITLE
Custom default value

### DIFF
--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -793,7 +793,7 @@ export default class BaseComponent extends Component {
     if (this.component.defaultValue) {
       defaultValue = this.component.defaultValue;
     }
-    else if (this.component.customDefaultValue) {
+    if (this.component.customDefaultValue) {
       defaultValue = this.evaluate(
         this.component.customDefaultValue,
         { value: '' },

--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -793,7 +793,7 @@ export default class BaseComponent extends Component {
     if (this.component.defaultValue) {
       defaultValue = this.component.defaultValue;
     }
-    if (this.component.customDefaultValue) {
+    if (this.component.customDefaultValue && !this.options.preview) {
       defaultValue = this.evaluate(
         this.component.customDefaultValue,
         { value: '' },


### PR DESCRIPTION
Previously the custom default value would calculate and set the default value on the form definition. This would then hard code the value in component.defaultValue and prevent component.customDefaultValue from ever firing again. This makes the following changes:

1. If component.customDefaultValue is set, it will override the component.defaultValue setting.
2. component.customDefaultValue is NOT evaluated in webform builder default preview so it will not automatically set.