### PR TITLE
Allow custom components to control the Fuse search behavior

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -28,6 +28,10 @@ export default class SelectComponent extends BaseComponent {
       template: '<span>{{ item.label }}</span>',
       selectFields: '',
       searchThreshold: 0.3,
+      fuseOptions: {
+        include: 'score',
+        threshold: 0.3,
+      },
       customOptions: {}
     }, ...extend);
   }
@@ -629,8 +633,11 @@ export default class SelectComponent extends BaseComponent {
       searchChoices: !this.component.searchField,
       searchFields: ['label'],
       fuseOptions: {
-        include: 'score',
-        threshold: _.get(this, 'component.searchThreshold', 0.3),
+        ...{
+          include: 'score',
+          threshold: _.get(this, 'component.searchThreshold', 0.3),
+        },
+        _.get(this, 'component.fuseOptions', {})
       },
       itemComparer: _.isEqual
     };

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -631,7 +631,7 @@ export default class SelectComponent extends BaseComponent {
       position: (this.component.dropdown || 'auto'),
       searchEnabled: useSearch,
       searchChoices: !this.component.searchField,
-      searchFields: ['label'],
+      searchFields: _.get(this, 'component.searchFields', ['label']),
       fuseOptions: {
         ...{
           include: 'score',


### PR DESCRIPTION
This allows custom components to control the Fuse search behavior, and not only the search threshold, and it's backward-compatible.