### PR TITLE
#1085 Disable submit button while file uploads in progress.

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -783,6 +783,42 @@ export default class FileComponent extends BaseComponent {
         this.uploadStatusList.appendChild(uploadStatus);
 
         if (fileUpload.status !== 'error') {
+          // Track uploads in progress.
+          if (fileService.uploadsInProgress === undefined) {
+            const cssClass = 'uploads-in-progress';
+            var submitButton = this.root.element
+                .querySelector('.formio-component-submit')
+                .querySelector('button');
+            var array = new Array();
+            fileService.uploadsInProgress = {
+              array: array,
+              add: function(item) {
+                if (cssClass && (array.length === 0)) {
+                  submitButton.classList.add(cssClass);
+                }
+                array.push(item);
+              },
+              remove: function(item) {
+                array.splice(array.indexOf(item), 1);
+                if (cssClass && (array.length === 0)) {
+                  submitButton.classList.remove(cssClass);
+                }
+              },
+              report: function() {
+                const n = array.length;
+                var msg = `Uploads in progress: ${n}`;
+                if (n>0) {
+                  const keys = array.map(x => x.component.key);
+                  msg += ` (${keys.join(', ')})`;
+                }
+                console.log(msg);
+              }
+            };
+          }
+          const uploadsInProgress = fileService.uploadsInProgress;
+          uploadsInProgress.add(this);
+          //uploadsInProgress.report();
+          //
           if (this.component.privateDownload) {
             file.private = true;
           }
@@ -808,6 +844,10 @@ export default class FileComponent extends BaseComponent {
               }
               files.push(fileInfo);
               this.setValue(this.dataValue);
+              // Track uploads in progress.
+              uploadsInProgress.remove(this);
+              //uploadsInProgress.report();
+              //
               this.triggerChange();
             })
             .catch(response => {

--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -120,6 +120,15 @@
   opacity: 1;
 }
 
+.formio-component-submit button.uploads-in-progress {
+    pointer-events: none;
+    cursor: not-allowed;
+    opacity: 0.65;
+    filter: alpha(opacity=65);
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}
+
 .form-control.flatpickr-input {
   background-color: #fff;
 }


### PR DESCRIPTION
Pull request for issue #1085 .

> As large file uploads take time, form submissions probably should be prevented when file uploads are still in progress.
> 
> Here is a partial solution that prevents accidental mouse clicks on a submit button in this case,
> [and the] corresponding CSS for disabling the accidental click on submit.

> As noted e.g. [here](https://bitsofco.de/theres-no-reason-to-use-pointer-events-for-html-elements/#disablinginteractiveelements), to prevent activating the submit button via keyboard, it needs to be properly disabled, so instead of using a CSS class and styling this should actually set disabled="disabled" on the button (and find a way to return to the original state once all uploads have finished). Probably best to integrate with other conditions causing the submit button to become disabled. Maybe combine with fix for issue #951 .