### PR TITLE
Update Checkbox to add checkbox-checked class like Radio adds radio-selected class

### DIFF
--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -250,19 +250,21 @@ export default class CheckBoxComponent extends BaseComponent {
       this.input.value = 0;
       this.input.checked = 0;
     }
+
     if (this.input.checked) {
       this.input.setAttribute('checked', true);
     }
     else {
       this.input.removeAttribute('checked');
     }
+
     return value;
   }
 
   setValue(value, flags) {
     flags = this.getFlags.apply(this, arguments);
     if (this.setCheckedState(value) !== undefined) {
-      return this.updateValue(flags);
+      return this.updateValue(flags, value);
     }
   }
 
@@ -273,5 +275,19 @@ export default class CheckBoxComponent extends BaseComponent {
   destroy() {
     super.destroy();
     this.removeShortcut();
+  }
+
+  updateValue(flags, value) {
+    const changed = super.updateValue(flags, value);
+    if (changed) {
+      const checkedClass = 'checkbox-checked';
+      if (this.getValue()) {
+        this.addClass(this.element, checkedClass);
+      }
+      else {
+        this.removeClass(this.element, checkedClass);
+      }
+    }
+    return changed;
   }
 }

--- a/src/components/checkbox/Checkbox.spec.js
+++ b/src/components/checkbox/Checkbox.spec.js
@@ -41,4 +41,19 @@ describe('Checkbox Component', () => {
       done();
     });
   });
+
+  it('Should set the checkbox-checked class on wrapper of checked checkbox', done => {
+    Harness.testCreate(CheckBoxComponent, comp1).then((component) => {
+      assert(
+        component.element.getAttribute('class').indexOf('checkbox-checked') === -1,
+        'Checkbox wrapper does not have checkbox-checked class.'
+      );
+      Harness.clickElement(component, 'input[type="checkbox"]');
+      assert(
+        component.element.getAttribute('class').indexOf('checkbox-checked') !== -1,
+        'Checkbox wrapper has checkbox-checked class.'
+      );
+      done();
+    });
+  });
 });

--- a/src/components/checkbox/Checkbox.spec.js
+++ b/src/components/checkbox/Checkbox.spec.js
@@ -56,4 +56,24 @@ describe('Checkbox Component', () => {
       done();
     });
   });
+
+  it('Should unset the checkbox-checked class on wrapper of checked checkbox', done => {
+    Harness.testCreate(CheckBoxComponent, comp1).then((component) => {
+      assert(
+        component.element.getAttribute('class').indexOf('checkbox-checked') === -1,
+        'Checkbox wrapper does not have checkbox-checked class.'
+      );
+      Harness.clickElement(component, 'input[type="checkbox"]');
+      assert(
+        component.element.getAttribute('class').indexOf('checkbox-checked') !== -1,
+        'Checkbox wrapper has checkbox-checked class.'
+      );
+      Harness.clickElement(component, 'input[type="checkbox"]');
+      assert(
+        component.element.getAttribute('class').indexOf('checkbox-checked') === -1,
+        'Checkbox wrapper does not have checkbox-checked class.'
+      );
+      done();
+    });
+  });
 });

--- a/src/components/radio/Radio.spec.js
+++ b/src/components/radio/Radio.spec.js
@@ -29,4 +29,21 @@ describe('Radio Component', () => {
       done();
     });
   });
+
+  it('Should set the radio-selected class on wrapper of selected radio', done => {
+    Harness.testCreate(RadioComponent, comp1).then((component) => {
+      const selector = '.radio:nth-child(1)';
+      const firstRadioWrapper = component.element.querySelector(selector);
+      assert(
+        firstRadioWrapper.getAttribute('class').indexOf('radio-selected') === -1,
+        'Radio wrapper does not have radio-selected class.'
+      );
+      Harness.clickElement(component, `${selector} input`);
+      assert(
+        firstRadioWrapper.getAttribute('class').indexOf('radio-selected') !== -1,
+        'Radio wrapper has radio-selected class.'
+      );
+      done();
+    });
+  });
 });

--- a/src/components/radio/Radio.spec.js
+++ b/src/components/radio/Radio.spec.js
@@ -46,4 +46,26 @@ describe('Radio Component', () => {
       done();
     });
   });
+
+  it('Should unset the radio-selected class on wrapper of selected radio', done => {
+    Harness.testCreate(RadioComponent, comp1).then((component) => {
+      const selector = number => `.radio:nth-child(${number})`;
+      const radioWrapper = component.element.querySelector(selector(1));
+      assert(
+        radioWrapper.getAttribute('class').indexOf('radio-selected') === -1,
+        'Radio wrapper does not have radio-selected class.'
+      );
+      Harness.clickElement(component, `${selector(1)} input`);
+      assert(
+        radioWrapper.getAttribute('class').indexOf('radio-selected') !== -1,
+        'Radio wrapper has radio-selected class.'
+      );
+      Harness.clickElement(component, `${selector(2)} input`);
+      assert(
+        radioWrapper.getAttribute('class').indexOf('radio-selected') === -1,
+        'Radio wrapper does not have radio-selected class.'
+      );
+      done();
+    });
+  });
 });


### PR DESCRIPTION
I'm making use of the `radio-selected` class to do some styling and I'd like to do the same thing for checkboxes however I noticed that no class is set on the component/wrapper div (in the checkbox case, the div with class formio-component-checkbox) when the checkbox is checked.

I did these things:
- [x] added test to Radio for it setting `radio-selected`
- [x] added test to Checkbox for setting `checkbox-checked`
- [x] updated Checkbox to set `checkbox-checked` when the checkbox is checked
- [x] per linting rules, added some whitespace to Checkbox to get linting to pass
- [x] add tests to Checkbox and Radio for clicking them on and off again (that classes change as expected)