### PR TITLE
Skip supplying `form` during FormioUtils.evaluate() unless we need it

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -50,8 +50,7 @@ export function evaluate(func, args, ret, tokenize) {
   }
 
   // Deeply cloning the form is expensive - only do it if it looks like the function needs it
-  if ((typeof func === 'string'   && func.includes('form')) ||
-      (typeof func === 'function' && func.toString().includes('form'))) {
+  if (func.toString().includes('form')) {
     args.form = _.cloneDeep(args.form);
   }
   else {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -48,7 +48,16 @@ export function evaluate(func, args, ret, tokenize) {
   if (!args.form && args.instance) {
     args.form = _.get(args.instance, 'root._form', {});
   }
-  args.form = _.cloneDeep(args.form);
+
+  // Deeply cloning the form is expensive - only do it if it looks like the function needs it
+  if ((typeof func === 'string'   && func.includes('form')) ||
+      (typeof func === 'function' && func.toString().includes('form'))) {
+    args.form = _.cloneDeep(args.form);
+  }
+  else {
+    delete args.form;
+  }
+
   const componentKey = args.component.key;
   if (typeof func === 'string') {
     if (ret) {


### PR DESCRIPTION
`_.cloneDeep()` against the whole form is expensive, and since it's done for every component with a custom conditional via `FormioUtils.evaluate()`, performance degradation on forms that make heavy use of custom conditionals approaches `O(n^2)`.

Since we don't really need to do this unless the custom conditional makes use of the `form` variable, we can do a quick check and skip over it if it looks like we don't need it, which dramatically improves performance of `FormioUtils.evaluate()`. This has some limitations (e.g. it won't catch things like `eval("fo"+"rm").components`), but I think it's a reasonable tradeoff.