### PR TITLE
Improve event listener removal logic, add full argument to destroy()

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -172,14 +172,15 @@ export default class Component {
   /**
    * Removes all event listeners attached to this component.
    */
-  destroy() {
+  destroy(full = false) {
     _.each(this.events._events, (events, type) => {
-      _.each(events, (listener) => {
+      _.each(_.castArray(events), (listener) => {
         if (listener && (this.id === listener.id) && listener.internal) {
           this.events.off(type, listener);
         }
       });
     });
+
     _.each(this.eventHandlers, (handler) => {
       if ((this.id === handler.id) && handler.type && handler.obj && handler.obj.removeEventListener) {
         handler.obj.removeEventListener(handler.type, handler.func);
@@ -189,6 +190,10 @@ export default class Component {
     // Destroy the input masks.
     this.inputMasks.forEach(mask => mask.destroy());
     this.inputMasks = [];
+
+    if (full) {
+      this.events.removeAllListeners();
+    }
   }
 
   /**

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -951,6 +951,9 @@ export default class Webform extends NestedComponent {
    * Build the form.
    */
   build(state) {
+    // Clear any existing event handlers in case this is a rebuild
+    this.eventHandlers.forEach(h => this.removeEventListener(h.obj, h.type));
+
     this.on('submitButton', (options) => this.submit(false, options), true);
     this.on('checkValidity', (data) => this.checkValidity(null, true, data), true);
     this.addComponents(null, null, null, state);

--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -520,8 +520,8 @@ export default class WebformBuilder extends Webform {
     });
 
     this.addEventListener(this.dialog, 'close', () => {
-      this.editForm.destroy();
-      this.preview.destroy();
+      this.editForm.destroy(true);
+      this.preview.destroy(true);
       if (component.isNew) {
         this.deleteComponent(component);
       }

--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -1485,7 +1485,7 @@ export default class BaseComponent extends Component {
    * Remove all event handlers.
    */
   destroy() {
-    const state = super.destroy() || {};
+    const state = super.destroy(...arguments) || {};
     this.destroyInputs();
     state.calculatedValue = this.calculatedValue;
     return state;

--- a/src/components/nested/NestedComponent.js
+++ b/src/components/nested/NestedComponent.js
@@ -503,7 +503,7 @@ export default class NestedComponent extends BaseComponent {
    * @param state
    */
   destroy() {
-    const state = super.destroy() || {};
+    const state = super.destroy(...arguments) || {};
     this.destroyComponents(state);
     return state;
   }


### PR DESCRIPTION
Mitigates memory leak cited in #1229.

Didn't find a single large issue, but a potentially longer list of smaller ones. Knocked out the top two issues, which reduces the memory leak to about a third of its previous rate.

1) Iterating through the events assumed that each event listener was an array of listeners; actual structure begins as a single listener object that is converted to an array when a second listener is added; for single listenerers, `_.each()` was iterating through the object to no effect. Resolved with call to `_.castArray()` before iterating.

2) Base `destroy()` function opts not to destroy listeners unless they were explicitly added with the `internal` argument supplied; added a `full` argument to `destroy()` that disregards this and removes everything, for when we're sure we don't need them anymore.