### PR TITLE
Unbreak search in resources

### DIFF
--- a/src/components/resource/editForm/Resource.edit.display.js
+++ b/src/components/resource/editForm/Resource.edit.display.js
@@ -41,13 +41,25 @@ export default [
     weight: 51.6
   },
   {
-    type: 'tags',
+    type: 'textfield',
     input: true,
-    key: 'searchFields',
-    label: 'Search Fields',
-    tooltip: 'A list of search filters based on the fields of the resource. See the <a target=\'_blank\' href=\'https://github.com/travist/resourcejs#filtering-the-results\'>Resource.js documentation</a> for the format of these filters.',
-    placeholder: 'The fields to query on the server',
-    weight: 52
+    key: 'searchField',
+    label: 'Search Query Name',
+    weight: 52,
+    description: 'Name of URL query parameter',
+    tooltip: 'The name of the search querystring parameter used when sending a request to filter results with. The server at the URL must handle this query parameter.'
+  },
+  {
+    type: 'number',
+    input: true,
+    key: 'minSearch',
+    weight: 52.5,
+    label: 'Minimum Search Length',
+    tooltip: 'The minimum amount of characters they must type before a search is made.',
+    defaultValue: 0,
+    conditional: {
+      json: { '!=': [{ var: 'data.searchField' }, ''] }
+    }
   },
   {
     type: 'textarea',

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -632,7 +632,7 @@ export default class SelectComponent extends BaseComponent {
       position: (this.component.dropdown || 'auto'),
       searchEnabled: useSearch,
       searchChoices: !this.component.searchField,
-      searchFields: _.get(this, 'component.searchFields', ['label']),
+      searchFields: [_.get(this, 'component.searchField', 'label')],
       fuseOptions: Object.assign({
         include: 'score',
         threshold: _.get(this, 'component.searchThreshold', 0.3),


### PR DESCRIPTION
Currently, search in resources appears to be broken because of some left-over references to `.searchFields` which should be `.searchField` (without s).  These changes appear to fix it.
(Although I should say that the purpose of the line in Select.js is not clear to me.)

Some problems still remain with these changes applied, but they appear to be necessary to start debugging.
