### PR TITLE
Ensure we always load the correct form when setting a submission in t…

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -136,9 +136,9 @@ export default class FormComponent extends BaseComponent {
       this.subForm.parentVisible = this.visible;
       this.subForm.on('change', () => {
         this.subForm.off('change');
-        this.subForm.on('change', () => {
+        this.subForm.on('change', (event) => {
           this.dataValue = this.subForm.getValue();
-          this.triggerChange();
+          this.triggerChange(_.get(event, 'changed.flags', {}));
         });
       });
       this.subForm.url = this.formSrc;


### PR DESCRIPTION
…he renderer that has a different form revision id than what was currently loaded.