### PR TITLE
Cleanup Choices.searchFields & add config for search in Resource components

### DIFF
--- a/src/components/resource/editForm/Resource.edit.display.js
+++ b/src/components/resource/editForm/Resource.edit.display.js
@@ -41,15 +41,6 @@ export default [
     weight: 51.6
   },
   {
-    type: 'tags',
-    input: true,
-    key: 'searchFields',
-    label: 'Search Fields',
-    tooltip: 'A list of search filters based on the fields of the resource. See the <a target=\'_blank\' href=\'https://github.com/travist/resourcejs#filtering-the-results\'>Resource.js documentation</a> for the format of these filters.',
-    placeholder: 'The fields to query on the server',
-    weight: 52
-  },
-  {
     type: 'textarea',
     input: true,
     key: 'template',
@@ -59,5 +50,73 @@ export default [
     rows: 3,
     weight: 53,
     tooltip: 'The HTML template for the result data items.'
+  },
+  {
+    type: 'checkbox',
+    input: true,
+    weight: 54,
+    key: 'searchEnabled',
+    label: 'Enable Search',
+    defaultValue: true,
+    tooltip: 'When checked, the select dropdown will allow for searching.'
+  },
+  {
+    type: 'textfield',
+    input: true,
+    key: 'searchField',
+    label: 'Search Field for Query',
+    weight: 55,
+    description: 'Name of URL query parameter (leave blank for client-side search)',
+    tooltip: 'The name of the search querystring parameter used when sending a request to filter results with. The server at the URL must handle this query parameter with \'__rege
+x\' appended. Leave empty to use client-side search within the list of choices.',
+    conditional: {
+      json: { '!=': [{ var: 'data.searchEnabled' }, ''] }
+    }
+  },
+  {
+    type: 'number',
+    input: true,
+    key: 'minSearch',
+    weight: 56,
+    label: 'Server-Side Search: Minimum Input Length',
+    tooltip: 'The minimum amount of characters to be typed before a search query is made.',
+    defaultValue: 0,
+    conditional: {
+      json: {
+        and: [
+          { '!=': [{ var: 'data.searchEnabled' }, ''] },
+          { '!=': [{ var: 'data.searchField' }, ''] }
+        ]
+      }
+    }
+  },
+  {
+    label: 'Client-Side Search Threshold',
+    mask: false,
+    tableView: true,
+    alwaysEnabled: false,
+    type: 'number',
+    input: true,
+    key: 'searchThreshold',
+    validate: {
+      min: 0,
+      customMessage: '',
+      json: '',
+      max: 1
+    },
+    delimiter: false,
+    requireDecimal: false,
+    encrypted: false,
+    defaultValue: 0.1,
+    weight: 57,
+    tooltip: 'At what point does the match algorithm for static search give up. A threshold of 0.0 requires a perfect match, a threshold of 1.0 would match anything.',
+    conditional: {
+      json: {
+        and: [
+          { '!=': [{ var: 'data.searchEnabled' }, ''] },
+          { '==': [{ var: 'data.searchField' }, ''] }
+        ]
+      }
+    }
   }
 ];

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -615,6 +615,7 @@ export default class SelectComponent extends BaseComponent {
       }
     }
 
+    const searchField = this.component.searchField;
     const choicesOptions = {
       removeItemButton: this.component.disabled ? false : _.get(this.component, 'removeItemButton', true),
       itemSelectText: '',
@@ -631,8 +632,9 @@ export default class SelectComponent extends BaseComponent {
       shouldSort: false,
       position: (this.component.dropdown || 'auto'),
       searchEnabled: useSearch,
-      searchChoices: !this.component.searchField,
-      searchFields: _.get(this, 'component.searchFields', ['label']),
+      searchChoices: !searchField,
+      searchFields: this.component.searchFields
+        || (searchField ? [`value.${searchField}`] : ['label']),
       fuseOptions: Object.assign({
         include: 'score',
         threshold: _.get(this, 'component.searchThreshold', 0.3),


### PR DESCRIPTION
Continuation of #1254.

regarding Select.js: It turns out that for Choices.searchFields to understand SelectComponent.searchField, it needs a 'value.' prefix.

regarding: Resource Config UI: This patch makes existing configuration available for both variants of search (local client-side search in Choices, and web-request-based search queries). The latter might still be buggy, e.g.
- In multiple-selection components, previously added items sometimes disappear. (And sometimes these gone-missing items show up again when the search "finds" them.)
- Once a search query has been done, even removing the entire search input via backspace key does not bring back the full list of resources to select from.

(Those bugs were observed in a version derived from 3.19.4.)