### PR TITLE
semantic-ui wizard

### DIFF
--- a/src/templates/semantic/cssClasses.js
+++ b/src/templates/semantic/cssClasses.js
@@ -3,5 +3,7 @@ export default {
   'is-invalid': 'error',
   'formio-tab-panel-active': 'active',
   'formio-tab-link-active': 'active',
-  'formio-tab-link-container-active': 'active'
+  'formio-tab-link-container-active': 'active',
+  'formio-wizard-builder-component-title': 'color:#6c757d; text-align:center; padding: 0.5rem',
+  'formio-wizard-position': 'position: relative'
 };

--- a/src/templates/semantic/index.js
+++ b/src/templates/semantic/index.js
@@ -31,6 +31,7 @@ import tab from './tab';
 import table from './table';
 import webform from './webform';
 import well from './well';
+import wizard from './wizard';
 import cssClasses from './cssClasses';
 
 export default {
@@ -99,4 +100,5 @@ export default {
   table,
   webform,
   well,
+  wizard
 };

--- a/src/templates/semantic/wizard/builder.hbs
+++ b/src/templates/semantic/wizard/builder.hbs
@@ -1,1 +1,1 @@
-<div style="color:#6c757d; text-align:center; padding: 0.5rem">{{ t(component.title) }}</div>
+<div class="formio-wizard-builder-component-title">{{ t(component.title) }}</div>

--- a/src/templates/semantic/wizard/builder.hbs
+++ b/src/templates/semantic/wizard/builder.hbs
@@ -1,0 +1,1 @@
+<div style="color:#6c757d; text-align:center; padding: 0.5rem">{{ t(component.title) }}</div>

--- a/src/templates/semantic/wizard/form.hbs
+++ b/src/templates/semantic/wizard/form.hbs
@@ -1,0 +1,38 @@
+<div style="position: relative;">
+  <nav aria-label="navigation">
+    <div class="ui steps">
+      {% panels.forEach(function(panel, index) { %}
+      <a class="{{currentPage === index ? ' active' : ''}} step" ref="{{wizardKey}}-link">
+        <div class="content">
+          <div class="title">{{panel.title}}</div>
+        </div>
+      </a>
+      {% }) %}
+    </div>
+  </nav>
+  <div class="wizard-page" ref="{{wizardKey}}">
+    {{components}}
+  </div>
+  <ul class="ui horizontal list">
+    {% if (buttons.cancel) { %}
+    <li class="item">
+      <button class="ui button secondary btn-wizard-nav-cancel" ref="{{wizardKey}}-cancel">{{t('cancel')}}</button>
+    </li>
+    {% } %}
+    {% if (buttons.previous) { %}
+    <li class="item">
+      <button class="ui button primary btn-wizard-nav-previous" ref="{{wizardKey}}-previous">{{t('previous')}}</button>
+    </li>
+    {% } %}
+    {% if (buttons.next) { %}
+    <li class="item">
+      <button class="ui button primary btn-wizard-nav-next" ref="{{wizardKey}}-next">{{t('next')}}</button>
+    </li>
+    {% } %}
+    {% if (buttons.submit) { %}
+    <li class="item">
+      <button class="ui button primary btn-wizard-nav-submit" ref="{{wizardKey}}-submit">{{t('submit')}}</button>
+    </li>
+    {% } %}
+  </ul>
+</div>

--- a/src/templates/semantic/wizard/form.hbs
+++ b/src/templates/semantic/wizard/form.hbs
@@ -1,4 +1,4 @@
-<div style="position: relative;">
+<div class="formio-wizard-position">
   <nav aria-label="navigation">
     <div class="ui steps">
       {% panels.forEach(function(panel, index) { %}

--- a/src/templates/semantic/wizard/index.js
+++ b/src/templates/semantic/wizard/index.js
@@ -1,0 +1,4 @@
+import form from './form.hbs';
+import builder from './builder.hbs';
+
+export default { form, builder };


### PR DESCRIPTION
Attempt at adding semantic ui for wizard. 

Wizard steps should look:
![Screenshot 2019-05-26 at 08 47 25](https://user-images.githubusercontent.com/290639/58381976-2dc56080-7fbc-11e9-809c-fa6e6de9ee48.png)

and buttons should look:
![Screenshot 2019-05-26 at 08 47 38](https://user-images.githubusercontent.com/290639/58381981-39188c00-7fbc-11e9-96d3-9c550a6bc924.png)
