### PR TITLE
Fix adding new resource from within multiple-values select.

### DIFF
--- a/src/components/resource/Resource.js
+++ b/src/components/resource/Resource.js
@@ -62,6 +62,9 @@ export default class ResourceComponent extends SelectComponent {
       dialog.body.appendChild(formioForm);
       const form = new Webform(formioForm);
       form.on('submit', (submission) => {
+        if (this.component.multiple) {
+          submission = [...this.dataValue, submission];
+        }
         this.setValue(submission);
         form.destroy();
         dialog.close();


### PR DESCRIPTION
When a user adds a new resource via button from within a
multiple-values select component, any previously selected
options must be preserved.