### PR TITLE
Misc fixes for pdf builder

### DIFF
--- a/src/PDF.js
+++ b/src/PDF.js
@@ -174,7 +174,7 @@ export default class PDF extends Webform {
 window.addEventListener('message', (event) => {
   let eventData = null;
   try {
-    eventData = JSON.parse(event.data);
+    eventData = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
   }
   catch (err) {
     eventData = null;

--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -91,7 +91,7 @@ export default class PDFBuilder extends WebformBuilder {
   }
 
   addComponent(component, element, data, before, noAdd, state) {
-    return super.addComponent(component, element, data, before, noAdd, state);
+    return super.addComponent(component, element, data, before, true, state);
   }
 
   deleteComponent(component) {

--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -81,8 +81,8 @@ export default class PDFBuilder extends WebformBuilder {
     }
   }
 
-  addComponentTo(parent, schema, element, sibling) {
-    const comp = super.addComponentTo(parent, schema, element, sibling);
+  addComponentTo(schema, parent, element, sibling) {
+    const comp = super.addComponentTo(schema, parent, element, sibling);
     comp.isNew = true;
     if (this.pdfForm && schema.overlay) {
       this.pdfForm.postMessage({ name: 'addElement', data: schema });
@@ -91,7 +91,7 @@ export default class PDFBuilder extends WebformBuilder {
   }
 
   addComponent(component, element, data, before, noAdd, state) {
-    return super.addComponent(component, element, data, before, true, state);
+    return super.addComponent(component, element, data, before, noAdd, state);
   }
 
   deleteComponent(component) {
@@ -142,7 +142,7 @@ export default class PDFBuilder extends WebformBuilder {
       height: 20
     };
 
-    this.addComponentTo(this, schema, this.getContainer());
+    this.addComponentTo(schema, this, this.getContainer());
     this.disableDropZone();
     return false;
   }
@@ -173,7 +173,7 @@ export default class PDFBuilder extends WebformBuilder {
       this.pdfForm = new PDF(this.element, this.options);
       this.addClass(this.pdfForm.element, 'formio-pdf-builder');
     }
-    this.pdfForm.destroy();
+    this.pdfForm.destroy(true);
     this.pdfForm.on('iframe-elementUpdate', schema => {
       const component = this.getComponentById(schema.id);
       if (component && component.component) {

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -334,8 +334,10 @@ export default class Webform extends NestedComponent {
     });
   }
 
-  destroy() {
-    delete Formio.forms[this.id];
+  destroy(preserveGlobal = false) {
+    if (!preserveGlobal) {
+      delete Formio.forms[this.id];
+    }
     return super.destroy();
   }
 


### PR DESCRIPTION
1. Fix issue with `message` event listener deserializing too aggressively
2. Fix issue with transposed parameters in `PDFBuilder.addComponentTo` signature (now matches parent class function `WebformBuilder.addComponentTo`)
3. Fix issue with PDFBuilder's form destruction preventing `iframe-ready` and subsequent cross-frame communication