### PR TITLE
Bugfix: updated ul to use div for lists for semantic ui wizard

### DIFF
--- a/src/templates/semantic/wizard/form.hbs
+++ b/src/templates/semantic/wizard/form.hbs
@@ -13,26 +13,26 @@
   <div class="wizard-page" ref="{{wizardKey}}">
     {{components}}
   </div>
-  <ul class="ui horizontal list">
+  <div class="ui horizontal list">
     {% if (buttons.cancel) { %}
-    <li class="item">
+    <div class="item">
       <button class="ui button secondary btn-wizard-nav-cancel" ref="{{wizardKey}}-cancel">{{t('cancel')}}</button>
-    </li>
+    </div>
     {% } %}
     {% if (buttons.previous) { %}
-    <li class="item">
+    <div class="item">
       <button class="ui button primary btn-wizard-nav-previous" ref="{{wizardKey}}-previous">{{t('previous')}}</button>
-    </li>
+    </div>
     {% } %}
     {% if (buttons.next) { %}
-    <li class="item">
+    <div class="item">
       <button class="ui button primary btn-wizard-nav-next" ref="{{wizardKey}}-next">{{t('next')}}</button>
-    </li>
+    </div>
     {% } %}
     {% if (buttons.submit) { %}
-    <li class="item">
+    <div class="item">
       <button class="ui button primary btn-wizard-nav-submit" ref="{{wizardKey}}-submit">{{t('submit')}}</button>
-    </li>
+    </div>
     {% } %}
-  </ul>
+  </div>
 </div>


### PR DESCRIPTION
![Screenshot 2019-06-01 at 15 29 50](https://user-images.githubusercontent.com/290639/58749780-1dacf580-8482-11e9-99de-6842fa8e948f.png)

The buttons still have the ul bullet points so updated to use div with class. 

The only issue is the margin between the steps, components and buttons.  Trying to avoid inline css so I'm not sure what the right approach should be here to create a gap between each. @randallknutson happy to get some feedback on the approach. 