### PR TITLE
fixing wizard builder layout semantic ui

### DIFF
--- a/src/templates/semantic/builderWizard/form.hbs
+++ b/src/templates/semantic/builderWizard/form.hbs
@@ -1,0 +1,17 @@
+<div class="formio builder ui grid formbuilder">
+  <div class="four wide column formcomponents">
+    {{sidebar}}
+  </div>
+  <div class="twelve wide column formarea">
+    <div class="ui breadcrumb" style="margin-bottom: 0.5em">
+      {% pages.forEach(function(page, pageIndex) { %}
+        <div title="{{page.title}}" class="{% if (pageIndex === self.currentPage) { %} active section {% } else { %} section {% } %} wizard-page-label" ref="gotoPage">{{page.title}}</div>
+        <div class="divider">/</div>
+      {% }) %}
+      <div title="{{t('Create Page')}}" class="section wizard-page-label" ref="addPage"><i class="{{iconClass('plus')}}"></i> {{t('Page')}}</div>
+    </div>
+    <div ref="form">
+      {{form}}
+    </div>
+  </div>
+</div>

--- a/src/templates/semantic/builderWizard/index.js
+++ b/src/templates/semantic/builderWizard/index.js
@@ -1,0 +1,3 @@
+import form from './form.hbs';
+
+export default { form };

--- a/src/templates/semantic/index.js
+++ b/src/templates/semantic/index.js
@@ -4,6 +4,7 @@ import builderComponents from './builderComponents';
 import builderEditForm from './builderEditForm';
 import builderPlaceholder from './builderPlaceholder';
 import builderSidebar from './builderSidebar';
+import builderWizard from './builderWizard';
 import button from './button';
 import checkbox from './checkbox';
 import columns from './columns';
@@ -74,6 +75,7 @@ export default {
   builderEditForm,
   builderPlaceholder,
   builderSidebar,
+  builderWizard,
   button,
   checkbox,
   columns,


### PR DESCRIPTION
![Screenshot 2019-06-06 at 13 49 58](https://user-images.githubusercontent.com/290639/59034101-380c1800-8862-11e9-96f7-97277e11d52a.png)

Should look like above. Slightly difficult to work how to test this locally. Any pointers would be appreciated.