### PR TITLE
Fix issue with drop events not firing

### DIFF
--- a/src/sass/formio.form.builder.scss
+++ b/src/sass/formio.form.builder.scss
@@ -65,6 +65,10 @@
     display: inherit;
   }
 
+  .formio-drop-zone.enabled + .formio-pdf-builder {
+    pointer-events: none;
+  }
+
   .component-settings-button-paste {
     display: none;
   }


### PR DESCRIPTION
Disable pointer events on the iframe container while the dropzone is active; iframe container was intercepting pointer events.