### PR TITLE
Force PDF.setForm to push supplied form to iframe

### DIFF
--- a/src/PDF.js
+++ b/src/PDF.js
@@ -55,6 +55,8 @@ export default class PDF extends Webform {
   }
 
   setForm(form) {
+    const formCopy = _.cloneDeep(form);
+
     return super.setForm(form).then(() => {
       if (this.formio) {
         form.projectUrl = this.formio.projectUrl;
@@ -62,7 +64,8 @@ export default class PDF extends Webform {
         form.base = this.formio.base;
         this.postMessage({ name: 'token', data: this.formio.getToken() });
       }
-      this.postMessage({ name: 'form', data: form });
+
+      this.postMessage({ name: 'form', data: formCopy });
 
       return form;
     });


### PR DESCRIPTION
Resolves pass-by-reference issue with `PDF.setForm`'s input being modified (component IDs stripped out) by the time it was posted to the iframe, causing component IDs to desync across parent and child.