### PR TITLE
Add a submit button on forms that are initially created via PDF builder

### DIFF
--- a/src/PDF.js
+++ b/src/PDF.js
@@ -156,7 +156,7 @@ export default class PDF extends Webform {
 
     if (
       !this.options.readOnly &&
-      _.find(this.form.components, (component) => component.type === 'button' && component.action === 'submit')
+      _.find(this.form.components, (component) => component.type === 'button' && component.action === 'submit' && !component.hidden)
     ) {
       this.submitButton = this.ce('button', {
         type: 'button',

--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -224,6 +224,20 @@ export default class PDFBuilder extends WebformBuilder {
   }
 
   setForm(form) {
+    // If this is a brand new form, make sure it has a submit button component
+    if (!form.created && !_.find(form.components || [], { type: 'button', action: 'submit' })) {
+      form.components.push({
+        type: 'button',
+        label: this.t('Submit'),
+        key: 'submit',
+        size: 'md',
+        block: false,
+        action: 'submit',
+        disableOnInvalid: true,
+        theme: 'primary'
+      });
+    }
+
     return super.setForm(form).then(() => {
       return this.ready.then(() => {
         if (this.pdfForm) {


### PR DESCRIPTION
A submit button component is automatically added during the initial `PDFBuilder.setForm()` call when the form has not yet been saved.

The submit button can still be removed in Form builder mode, and PDF mode will honor it per FOR-1803.

PDF rendering will now honor the "hidden" setting when rendering the Submit button, ensuring that nested PDF forms will have their submit button hidden (consistent with regular nested forms), and accommodating users who might want to simply hide the Submit button rather than remove it altogether.