### PR TITLE
Fix CSS rule for white-space:pre-wrap

### DIFF
--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -52,9 +52,12 @@
 }
 
 /* Force native + Ace textareas to use pre-wrap whitespace in readonly mode (preserves visual linebreaks) */
-.formio-disabled-input.formio-component-nativeTextArea > .well,
-.formio-disabled-input.formio-component-ace            > .well {
+.formio-disabled-input.formio-component-textarea > .well {
   white-space: pre-wrap;
+}
+
+.formio-disabled-input.formio-component-textarea > .well * {
+  white-space: initial;
 }
 
 /* Force all textareas to break long words when overflowing (if width is set) */


### PR DESCRIPTION
Resolves FOR-2417.

Needs to be propagated to formio-viewer and formio-files-core.