### PR TITLE
Increase default size of file component PDF overlay

### DIFF
--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -139,8 +139,8 @@ export default class PDFBuilder extends WebformBuilder {
     schema.overlay = {
       top: event.offsetY,
       left: event.offsetX,
-      width: 100,
-      height: 20
+      width: schema.defaultOverlayWidth || 100,
+      height: schema.defaultOverlayHeight || 20
     };
 
     this.addComponentTo(schema, this, this.getContainer());

--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -37,7 +37,9 @@ export default class FileComponent extends BaseComponent {
       filePattern: '*',
       fileMinSize: '0KB',
       fileMaxSize: '1GB',
-      uploadOnly: false
+      uploadOnly: false,
+      defaultOverlayWidth: 200,
+      defaultOverlayHeight: 200
     }, ...extend);
   }
 


### PR DESCRIPTION
Increased default PDF overlay size of the file component from 100x20 to 200x200 so the default sizing can at least render the file picker and/or the storage provider error message.

Builder only, no update propagation needed.