### PR TITLE
Set file component to image mode by default when added via PDF builder

### DIFF
--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -136,6 +136,11 @@ export default class PDFBuilder extends WebformBuilder {
       return false;
     }
 
+    // Special case for file components - default to image mode when added via PDF builder
+    if (schema.type === 'file') {
+      schema.image = true;
+    }
+
     schema.overlay = {
       top: event.offsetY,
       left: event.offsetX,


### PR DESCRIPTION
Resolves FOR-2415.

Builder-only change, no update propagation needed.