### PR TITLE
Allow ready promise on hidden subforms to be resolved

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -151,8 +151,16 @@ export default class FormComponent extends BaseComponent {
 
   show(...args) {
     const state = super.show(...args);
-    if (state && !this.subFormLoaded) {
-      this.loadSubForm();
+
+    if (!this.subFormLoaded) {
+      if (state) {
+        this.loadSubForm();
+      }
+      // If our parent is no longer loading and we still haven't been asked to load a subform,
+      // consider our subform loading promise resolved
+      else if (!this.parent.loading) {
+        this.subFormReadyResolve(this.subForm);
+      }
     }
 
     return state;

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -156,9 +156,9 @@ export default class FormComponent extends BaseComponent {
       if (state) {
         this.loadSubForm();
       }
-      // If our parent is no longer loading and we still haven't been asked to load a subform,
-      // consider our subform loading promise resolved
-      else if (!this.parent.loading) {
+      // If our parent is read-only and is done loading, and we were never asked
+      // to load a subform, consider our subform loading promise resolved
+      else if (this.parent.options.readOnly && !this.parent.loading) {
         this.subFormReadyResolve(this.subForm);
       }
     }


### PR DESCRIPTION
Loading promises on hidden subforms were being left unresolved (since loading was never requested), which propagated up to root level and caused all forms with hidden subforms to hit the rendering timeout during PDF generation, even if the form state had fully settled.

This check allows hidden subforms of fully loaded read-only parents to mark themselves as ready, so that the parent form(s) aren't left with unresolved loading promises.

Needs to be propagated to `formio-viewer`. Should coincide with formio/formio-viewer#16.