### PR TITLE
Select: do not trigger an update when setting a provided value (#1652)

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -320,7 +320,9 @@ export default class SelectComponent extends Field {
 
     // If a value is provided, then select it.
     if (this.dataValue) {
-      this.setValue(this.dataValue, true);
+      this.setValue(this.dataValue, {
+        noUpdateEvent: true
+      });
     }
     else {
       // If a default value is provided then select it.


### PR DESCRIPTION
The argument to `setValue` is not passed to `getFlags` any more, so
`true` as second argument is never translated to `noUpdateEvent:
true`.

With this change, the described behaviour in #1652 is resolved.