### PR TITLE
Fixed issue with appearance of unnecessary loading option

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -660,7 +660,7 @@ export default class SelectComponent extends Field {
         label: `<i class="${this.iconClass('refresh')}" style="font-size:1.3em;"></i>`
       }], 'value', 'label', true);
     }
-    else {
+    else if (this.component.dataSrc === 'url' || this.component.dataSrc === 'resource') {
       this.addOption('', this.t('loading...'));
     }
     this.triggerUpdate();


### PR DESCRIPTION
If select component uses a static type of data source a loading option shouldn't appear