### PR TITLE
NestedComponent.checkData: no change trigger when resetting the value

### DIFF
--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -466,12 +466,14 @@ export default class NestedComponent extends Field {
   checkData(data, flags, source) {
     flags = flags || {};
     let valid = true;
+    let changed = false;
+
     if (flags.noCheck) {
       return;
     }
 
     // Update the value.
-    let changed = this.updateValue(null, {
+    this.updateValue(null, {
       noUpdateEvent: true
     }, source);
 


### PR DESCRIPTION
I think this is relevant for the behaviour described
in #1652: without this change v4.0.3 loops. With it,
the firing of change events stops without any observable
adverse effects.