### PR TITLE
enabling users to override fileService and delete a file

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -3,9 +3,10 @@ import { uniqueName } from '../../utils/utils';
 import download from 'downloadjs';
 import _ from 'lodash';
 import Formio from '../../Formio';
+import NativePromise from 'native-promise-only';
+
 let Camera;
 const webViewCamera = navigator.camera || Camera;
-import NativePromise from 'native-promise-only';
 
 // canvas.toBlob polyfill.
 if (!HTMLCanvasElement.prototype.toBlob) {
@@ -265,8 +266,15 @@ export default class FileComponent extends Field {
     this.refs.removeLink.forEach((removeLink, index) => {
       this.addEventListener(removeLink, 'click', (event) => {
         const fileInfo = this.dataValue[index];
+
         if (fileInfo && (this.component.storage === 'url')) {
-          this.options.formio.makeRequest('', fileInfo.url, 'delete');
+          const fileService = this.fileService;
+          if (fileService && typeof fileService.deleteFile === 'function') {
+            fileService.deleteFile(fileInfo);
+          }
+          else {
+            this.options.formio.makeRequest('', fileInfo.url, 'delete');
+          }
         }
         event.preventDefault();
         this.splice(index);
@@ -355,6 +363,7 @@ export default class FileComponent extends Field {
   fileSize(a, b, c, d, e) {
     return `${(b = Math, c = b.log, d = 1024, e = c(a) / c(d) | 0, a / b.pow(d, e)).toFixed(2)} ${e ? `${'kMGTPEZY'[--e]}B` : 'Bytes'}`;
   }
+
   /* eslint-enable max-len */
 
   /* eslint-disable max-depth */
@@ -394,6 +403,7 @@ export default class FileComponent extends Field {
     }
     return { regexp: regexp, excludes: excludes };
   }
+
   /* eslint-enable max-depth */
 
   translateScalars(str) {

--- a/src/providers/storage/url.js
+++ b/src/providers/storage/url.js
@@ -109,6 +109,22 @@ const url = (formio) => {
         return uploadRequest();
       }
     },
+    deleteFile(fileInfo) {
+      return new NativePromise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('DELETE', fileInfo.url, true);
+        xhr.onload = () => {
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve('File deleted');
+          }
+          else {
+            reject(xhr.response || 'Unable to delete file');
+          }
+        };
+        xhr.send(null);
+      });
+    },
+
     downloadFile(file) {
       if (file.private) {
         if (formio.submissionId && file.data) {


### PR DESCRIPTION
Currently attach and download file can be overridden by passing in fileService into the options configuration. However delete is being handled not in the same way. This PR enables the option to override the delete file by using fileService.  Happy to discuss this further. Our use case means we need to configure our fileService to do some pre processing.