### PR TITLE
Stop different component editforms from mutating each other.

### DIFF
--- a/src/components/_classes/component/Component.form.js
+++ b/src/components/_classes/component/Component.form.js
@@ -62,7 +62,7 @@ export default function(...extend) {
   ]).concat(extend.map((items) => ({
     type: 'tabs',
     key: 'tabs',
-    components: items
+    components: _.cloneDeep(items),
   })));
   return {
     components: _.unionWith(components, EditFormUtils.unifyComponents).concat({


### PR DESCRIPTION
You can see this by editing a form.
1. Open a a textfield component. You will see "Allow multiple masks"
2. Close and open a number component. You will not see "Allow multiple masks"
3. Close and re-open the textfield component. You will no longer see "Allow multiple masks"