### PR TITLE
Send user-visible text in templates through i18next.t() function

### DIFF
--- a/src/templates/bootstrap/builderEditForm/form.ejs
+++ b/src/templates/bootstrap/builderEditForm/form.ejs
@@ -1,10 +1,10 @@
 <div class="row">
   <div class="col col-sm-6">
-    <p class="lead">{{ctx.componentInfo.title}} {{ctx.t('Component')}}</p>
+    <p class="lead">{{ctx.t(ctx.componentInfo.title)}} {{ctx.t('Component')}}</p>
   </div>
   <div class="col col-sm-6">
     <div class="float-right" style="margin-right: 20px; margin-top: 10px">
-      <a href="{{ctx.componentInfo.documentation}}" target="_blank">
+      <a href="{{ctx.t(ctx.componentInfo.documentation)}}" target="_blank">
         <i class="{{ctx.iconClass('new-window')}}"> {{ctx.t('Help')}}</i>
       </a>
     </div>
@@ -37,7 +37,7 @@
     </div>
     {% if (ctx.componentInfo.help) { %}
     <div class="card card-body bg-light formio-settings-help">
-      {{ ctx.componentInfo.help }}
+      {{ ctx.t(ctx.componentInfo.help) }}
     </div>
     {% } %}
     <div style="margin-top: 10px;">

--- a/src/templates/bootstrap/builderPlaceholder/form.ejs
+++ b/src/templates/bootstrap/builderPlaceholder/form.ejs
@@ -5,5 +5,5 @@
   data-noattach="true"
   data-position="{{ctx.position}}"
 >
-  Drag and Drop a form component
+  {{ctx.t('Drag and Drop a form component')}}
 </div>

--- a/src/templates/bootstrap/builderSidebarGroup/form.ejs
+++ b/src/templates/bootstrap/builderSidebarGroup/form.ejs
@@ -11,7 +11,7 @@
         aria-controls="group-{{ctx.groupKey}}"
         ref="sidebar-anchor"
       >
-        {{ctx.group.title}}
+        {{ctx.t(ctx.group.title)}}
       </button>
     </h5>
   </div>
@@ -34,7 +34,7 @@
         {% if (ctx.group.components[componentKey].icon) { %}
           <i class="{{ctx.iconClass(ctx.group.components[componentKey].icon)}}" style="margin-right: 5px;"></i>
         {% } %}
-        {{ctx.group.components[componentKey].title}}
+        {{ctx.t(ctx.group.components[componentKey].title)}}
         </span>
       {% }) %}
       {{ctx.subgroups.join('')}}

--- a/src/templates/bootstrap/datagrid/form.ejs
+++ b/src/templates/bootstrap/datagrid/form.ejs
@@ -19,7 +19,7 @@
       <th>
         {% if (!ctx.builder && ctx.hasAddButton && ctx.hasTopSubmit) { %}
         <button class="btn btn-primary formio-button-add-row" ref="{{ctx.datagridKey}}-addRow">
-          <i class="{{ctx.iconClass('plus')}}"></i> Add Another
+          <i class="{{ctx.iconClass('plus')}}"></i>{{ctx.t('Add Another')}}
         </button>
         {% } %}
       </th>

--- a/src/templates/bootstrap/file/form.ejs
+++ b/src/templates/bootstrap/file/form.ejs
@@ -5,10 +5,10 @@
       {% if (!ctx.disabled) { %}
       <div class="col-md-1"></div>
       {% } %}
-      <div class="col-md-{% if (ctx.self.hasTypes) { %}7{% } else { %}9{% } %}"><strong>File Name</strong></div>
-      <div class="col-md-2"><strong>Size</strong></div>
+      <div class="col-md-{% if (ctx.self.hasTypes) { %}7{% } else { %}9{% } %}"><strong>{{ctx.t('File Name')}}</strong></div>
+      <div class="col-md-2"><strong>{{ctx.t('Size')}}</strong></div>
       {% if (ctx.self.hasTypes) { %}
-        <div class="col-md-2"><strong>Type</strong></div>
+        <div class="col-md-2"><strong>{{ctx.t('Type')}}</strong></div>
       {% } %}
     </div>
   </li>
@@ -57,24 +57,24 @@
 <input type="file" style="opacity: 0; position: absolute;" tabindex="-1" ref="hiddenFileInputElement">
 {% if (ctx.self.useWebViewCamera) { %}
 <div class="fileSelector">
-  <button class="btn btn-primary" ref="galleryButton"><i class="fa fa-book"></i> Gallery</button>
-  <button class="btn btn-primary" ref="cameraButton"><i class="fa fa-camera"></i> Camera</button>
+  <button class="btn btn-primary" ref="galleryButton"><i class="fa fa-book"></i> {{ctx.t('Gallery')}}</button>
+  <button class="btn btn-primary" ref="cameraButton"><i class="fa fa-camera"></i> {{ctx.t('Camera')}}</button>
 </div>
 {% } else if (!ctx.self.cameraMode) { %}
 <div class="fileSelector" ref="fileDrop">
-  <i class="{{ctx.iconClass('cloud-upload')}}"></i> Drop files to attach,
+  <i class="{{ctx.iconClass('cloud-upload')}}"></i> {{ctx.t('Drop files to attach,')}}
     {% if (ctx.component.image) { %}
-      <a href="#" ref="toggleCameraMode"><i class="fa fa-camera"></i> Use Camera</a>,
+      <a href="#" ref="toggleCameraMode"><i class="fa fa-camera"></i> {{ctx.t('Use Camera,')}}</a>
     {% } %}
-    or <a href="#" ref="fileBrowse" class="browse">browse</a>
+    {{ctx.t('or')}} <a href="#" ref="fileBrowse" class="browse">{{ctx.t('browse')}}</a>
 </div>
 {% } else { %}
 <div>
   <video class="video" autoplay="true" ref="videoPlayer"></video>
   <canvas style="display: none" ref="videoCanvas"></canvas>
 </div>
-<button class="btn btn-primary" ref="takePictureButton"><i class="fa fa-camera"></i> Take Picture</button>
-<button class="btn btn-primary" ref="toggleCameraMode">Switch to file upload</button>
+<button class="btn btn-primary" ref="takePictureButton"><i class="fa fa-camera"></i> {{ctx.t('Take Picture')}}</button>
+<button class="btn btn-primary" ref="toggleCameraMode">{{ctx.t('Switch to file upload')}}</button>
 {% } %}
 {% } %}
 {% ctx.statuses.forEach(function(status) { %}
@@ -88,11 +88,11 @@
       {% if (status.status === 'progress') { %}
       <div class="progress">
         <div class="progress-bar" role="progressbar" aria-valuenow="{{status.progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{status.progress}}">
-          <span class="sr-only">{{status.progress}}% Complete</span>
+          <span class="sr-only">{{status.progress}}% {{ctx.t('Complete')}}</span>
         </div>
       </div>
       {% } else { %}
-      <div class="bg-{{status.status}}">{{status.message}}</div>
+      <div class="bg-{{status.status}}">{{ctx.t(status.message)}}</div>
       {% } %}
     </div>
   </div>
@@ -101,16 +101,16 @@
 {% if (!ctx.component.storage || ctx.support.hasWarning) { %}
 <div class="alert alert-warning">
   {% if (!ctx.component.storage) { %}
-    <p>No storage has been set for this field. File uploads are disabled until storage is set up.</p>
+    <p>{{ctx.t('No storage has been set for this field. File uploads are disabled until storage is set up.')}}</p>
   {% } %}
   {% if (!ctx.support.filereader) { %}
-    <p>File API & FileReader API not supported.</p>
+    <p>{{ctx.t('File API & FileReader API not supported.')}}</p>
   {% } %}
   {% if (!ctx.support.formdata) { %}
-    <p>XHR2's FormData is not supported.</p>
+    <p>{{ctx.t("XHR2's FormData is not supported.")}}</p>
   {% } %}
   {% if (!ctx.support.progress) { %}
-    <p>XHR2's upload progress isn't supported.</p>
+    <p>{{ctx.t("XHR2's upload progress isn't supported.")}}</p>
   {% } %}
 </div>
 {% } %}

--- a/src/templates/bootstrap/multiValueTable/form.ejs
+++ b/src/templates/bootstrap/multiValueTable/form.ejs
@@ -4,7 +4,7 @@
   {% if (!ctx.disabled) { %}
   <tr>
     <td colspan="2">
-      <button class="btn btn-primary formio-button-add-another" ref="addButton"><i class="{{ctx.iconClass('plus')}}"></i> {{ctx.addAnother}}</button>
+      <button class="btn btn-primary formio-button-add-another" ref="addButton"><i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t(ctx.addAnother)}}</button>
     </td>
   </tr>
   {% } %}

--- a/src/templates/bootstrap/pdf/form.ejs
+++ b/src/templates/bootstrap/pdf/form.ejs
@@ -6,5 +6,5 @@
 		<i class="{{ ctx.iconClass('zoom-out') }}"></i>
 	</span>
   <div ref="iframeContainer"></div>
-  <button type="button" class="btn btn-primary" ref="submitButton">Submit</button>
+  <button type="button" class="btn btn-primary" ref="submitButton">{{ctx.t('Submit')}}</button>
 </div>

--- a/src/templates/bootstrap/pdfBuilderUpload/form.ejs
+++ b/src/templates/bootstrap/pdfBuilderUpload/form.ejs
@@ -1,9 +1,8 @@
 <div class="pdf-upload formio-component-file">
-  <h3 class="label">Upload a PDF File</h3>
+  <h3 class="label">{{ctx.t('Upload a PDF File')}}</h3>
   <input type="file" style="opacity: 0; position: absolute;" tabindex="-1" accept=".pdf" ref="hiddenFileInputElement">
   <div class="fileSelector" ref="fileDrop">
-    <i class="{{ctx.iconClass('cloud-upload')}}"></i> Drop pdf to start,
-    or <a href="#" ref="fileBrowse" class="browse">browse</a>
+    <i class="{{ctx.iconClass('cloud-upload')}}"></i>{{ctx.t('Drop pdf to start, or')}}<a href="#" ref="fileBrowse" class="browse">{{ctx.t('browse')}}</a>
   </div>
   <div class="alert alert-danger" ref="uploadError">
 

--- a/src/templates/bootstrap/sketchpad/form.ejs
+++ b/src/templates/bootstrap/sketchpad/form.ejs
@@ -1,4 +1,4 @@
 <div class="formio-view-sketchpad-container" ref="sketchpadContainer">
   <div class="formio-view-sketchpad-canvas" ref="sketchpadCanvas"></div>
-  <div class="formio-view-sketpad-background" ref="sketchpadBackground">SVG Background missing</div>
+  <div class="formio-view-sketpad-background" ref="sketchpadBackground">{{ctx.t('SVG Background missing')}}</div>
 </div>

--- a/src/templates/bootstrap3/builderPlaceholder/form.ejs
+++ b/src/templates/bootstrap3/builderPlaceholder/form.ejs
@@ -5,5 +5,5 @@
   data-noattach="true"
   data-position="{{ctx.position}}"
 >
-  Drag and Drop a form component
+  {{ctx.t('Drag and Drop a form component')}}
 </div>

--- a/src/templates/bootstrap3/builderSidebarGroup/form.ejs
+++ b/src/templates/bootstrap3/builderSidebarGroup/form.ejs
@@ -10,7 +10,7 @@
         href="#group-{{ctx.groupKey}}"
         ref="sidebar-anchor"
       >
-        {{ctx.group.title}}
+        {{ctx.t(ctx.group.title)}}
       </button>
     </h5>
   </div>
@@ -32,7 +32,7 @@
         {% if (ctx.group.components[componentKey].icon) { %}
           <i class="{{ctx.iconClass(ctx.group.components[componentKey].icon)}}" style="margin-right: 5px;"></i>
         {% } %}
-        {{ctx.group.components[componentKey].title}}
+        {{ctx.t(ctx.group.components[componentKey].title)}}
       </span>
       {% }) %}
       {{ctx.subgroups.join('')}}

--- a/src/templates/bootstrap3/datagrid/form.ejs
+++ b/src/templates/bootstrap3/datagrid/form.ejs
@@ -19,7 +19,7 @@
       <th>
         {% if (!ctx.builder && ctx.hasAddButton && ctx.hasTopSubmit) { %}
         <button class="btn btn-primary formio-button-add-row" ref="{{ctx.datagridKey}}-addRow">
-          <i class="{{ctx.iconClass('plus')}}"></i> Add Another
+          <i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t('Add Another')}}
         </button>
         {% } %}
       </th>

--- a/src/templates/bootstrap3/file/form.ejs
+++ b/src/templates/bootstrap3/file/form.ejs
@@ -5,10 +5,10 @@
       {% if (!ctx.disabled) { %}
       <div class="col-md-1"></div>
       {% } %}
-      <div class="col-md-{% if (ctx.self.hasTypes) { %}7{% } else { %}9{% } %}"><strong>File Name</strong></div>
-      <div class="col-md-2"><strong>Size</strong></div>
+      <div class="col-md-{% if (ctx.self.hasTypes) { %}7{% } else { %}9{% } %}"><strong>{{ctx.t('File Name')}}</strong></div>
+      <div class="col-md-2"><strong>{{ctx.t('Size')}}</strong></div>
       {% if (ctx.self.hasTypes) { %}
-        <div class="col-md-2"><strong>Type</strong></div>
+        <div class="col-md-2"><strong>{{ctx.t('Type')}}</strong></div>
       {% } %}
     </div>
   </li>
@@ -57,24 +57,24 @@
 <input type="file" style="opacity: 0; position: absolute;" tabindex="-1" ref="hiddenFileInputElement">
 {% if (ctx.self.useWebViewCamera) { %}
 <div class="fileSelector">
-  <button class="btn btn-primary" ref="galleryButton"><i class="fa fa-book"></i> Gallery</button>
-  <button class="btn btn-primary" ref="cameraButton"><i class="fa fa-camera"></i> Camera</button>
+  <button class="btn btn-primary" ref="galleryButton"><i class="fa fa-book"></i> {{ctx.t('Gallery')}}</button>
+  <button class="btn btn-primary" ref="cameraButton"><i class="fa fa-camera"></i> {{ctx.t('Camera')}}</button>
 </div>
 {% } else if (!ctx.self.cameraMode) { %}
 <div class="fileSelector" ref="fileDrop">
-  <i class="{{ctx.iconClass('cloud-upload')}}"></i> Drop files to attach,
+  <i class="{{ctx.iconClass('cloud-upload')}}"></i> {{ctx.t('Drop files to attach,')}}
     {% if (ctx.component.image) { %}
-      <a href="#" ref="toggleCameraMode"><i class="fa fa-camera"></i> Use Camera</a>,
+      <a href="#" ref="toggleCameraMode"><i class="fa fa-camera"></i> {{ctx.t('Use Camera,')}}</a>
     {% } %}
-    or <a href="#" ref="fileBrowse" class="browse">browse</a>
+    {{ctx.t('or')}} <a href="#" ref="fileBrowse" class="browse">{{ctx.t('browse')}}</a>
 </div>
 {% } else { %}
 <div>
   <video class="video" autoplay="true" ref="videoPlayer"></video>
   <canvas style="display: none" ref="videoCanvas"></canvas>
 </div>
-<button class="btn btn-primary" ref="takePictureButton"><i class="fa fa-camera"></i> Take Picture</button>
-<button class="btn btn-primary" ref="toggleCameraMode">Switch to file upload</button>
+<button class="btn btn-primary" ref="takePictureButton"><i class="fa fa-camera"></i> {{ctx.t('Take Picture')}}</button>
+<button class="btn btn-primary" ref="toggleCameraMode">{{ctx.t('Switch to file upload')}}</button>
 {% } %}
 {% } %}
 {% ctx.statuses.forEach(function(status) { %}
@@ -88,11 +88,11 @@
       {% if (status.status === 'progress') { %}
       <div class="progress">
         <div class="progress-bar" role="progressbar" aria-valuenow="{{status.progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{status.progress}}">
-          <span class="sr-only">{{status.progress}}% Complete</span>
+          <span class="sr-only">{{status.progress}}% {{ctx.t('Complete')}}</span>
         </div>
       </div>
       {% } else { %}
-      <div class="bg-{{status.status}}">{{status.message}}</div>
+      <div class="bg-{{status.status}}">{{ctx.t(status.message)}}</div>
       {% } %}
     </div>
   </div>
@@ -101,16 +101,16 @@
 {% if (!ctx.component.storage || ctx.support.hasWarning) { %}
 <div class="alert alert-warning">
   {% if (!ctx.component.storage) { %}
-    <p>No storage has been set for this field. File uploads are disabled until storage is set up.</p>
+    <p>{{ctx.t('No storage has been set for this field. File uploads are disabled until storage is set up.')}}</p>
   {% } %}
   {% if (!ctx.support.filereader) { %}
-    <p>File API & FileReader API not supported.</p>
+    <p>{{ctx.t('File API & FileReader API not supported.')}}</p>
   {% } %}
   {% if (!ctx.support.formdata) { %}
-    <p>XHR2's FormData is not supported.</p>
+    <p>{{ctx.t("XHR2's FormData is not supported.")}}</p>
   {% } %}
   {% if (!ctx.support.progress) { %}
-    <p>XHR2's upload progress isn't supported.</p>
+    <p>{{ctx.t("XHR2's upload progress isn't supported.")}}</p>
   {% } %}
 </div>
 {% } %}

--- a/src/templates/bootstrap3/multiValueTable/form.ejs
+++ b/src/templates/bootstrap3/multiValueTable/form.ejs
@@ -4,7 +4,7 @@
   {% if (!ctx.disabled) { %}
   <tr>
     <td colspan="2">
-      <button class="btn btn-primary formio-button-add-another" ref="addButton"><i class="{{ctx.iconClass('plus')}}"></i> {{ctx.addAnother}}</button>
+      <button class="btn btn-primary formio-button-add-another" ref="addButton"><i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t(ctx.addAnother)}}</button>
     </td>
   </tr>
   {% } %}

--- a/src/templates/bootstrap3/pdf/form.ejs
+++ b/src/templates/bootstrap3/pdf/form.ejs
@@ -6,5 +6,5 @@
 		<i class="{{ ctx.iconClass('zoom-in') }}"></i>
 	</span>
   <div ref="iframeContainer"></div>
-  <button type="button" class="btn btn-primary" ref="submitButton">Submit</button>
+  <button type="button" class="btn btn-primary" ref="submitButton">{{ctx.t('Submit')}}</button>
 </div>

--- a/src/templates/semantic/builderSidebarGroup/form.ejs
+++ b/src/templates/semantic/builderSidebarGroup/form.ejs
@@ -9,7 +9,7 @@
         data-parent="{{ctx.groupId}}"
         ref="sidebar-anchor"
       >
-        {{ctx.group.title}}
+        {{ctx.t(ctx.group.title)}}
       </button>
     </h5>
   </div>
@@ -33,7 +33,7 @@
         {% if (ctx.group.components[componentKey].icon) { %}
           <i class="{{ctx.iconClass(ctx.group.components[componentKey].icon)}}" style="margin-right: 5px;"></i>
         {% } %}
-        {{ctx.group.components[componentKey].title}}
+        {{ctx.t(ctx.group.components[componentKey].title)}}
         </span>
       {% }) %}
       {{ctx.subgroups.join('')}}

--- a/src/templates/semantic/datagrid/form.ejs
+++ b/src/templates/semantic/datagrid/form.ejs
@@ -22,7 +22,7 @@
       <th>
         {% if (ctx.hasAddButton && ctx.hasTopSubmit) { %}
         <button class="ui button primary" ref="{{ctx.datagridKey}}-addRow">
-          <i class="{{ctx.iconClass('plus')}}"></i> Add Another
+          <i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t('Add Another')}}
         </button>
         {% } %}
       </th>

--- a/src/templates/semantic/file/form.ejs
+++ b/src/templates/semantic/file/form.ejs
@@ -5,10 +5,10 @@
       {% if (!ctx.disabled) { %}
       <div class="one wide column"></div>
       {% } %}
-      <div class="{% if (ctx.self.hasTypes) { %}nine{% } else { %}twelve{% } %} wide column"><strong>File Name</strong></div>
-      <div class="three wide column"><strong>Size</strong></div>
+      <div class="{% if (ctx.self.hasTypes) { %}nine{% } else { %}twelve{% } %} wide column"><strong>{{ctx.t('File Name')}}</strong></div>
+      <div class="three wide column"><strong>{{ctx.t('Size')}}</strong></div>
       {% if (ctx.self.hasTypes) { %}
-        <div class="three wide column"><strong>Type</strong></div>
+        <div class="three wide column"><strong>{{ctx.t('Type')}}</strong></div>
       {% } %}
     </div>
   </div>
@@ -57,24 +57,24 @@
 <input type="file" style="opacity: 0; position: absolute;" tabindex="-1" ref="hiddenFileInputElement">
 {% if (ctx.self.useWebViewCamera) { %}
 <div class="fileSelector">
-  <button class="btn btn-primary" ref="galleryButton"><i class="fa fa-book"></i> Gallery</button>
-  <button class="btn btn-primary" ref="cameraButton"><i class="fa fa-camera"></i> Camera</button>
+  <button class="btn btn-primary" ref="galleryButton"><i class="fa fa-book"></i> {{ctx.t('Gallery')}}</button>
+  <button class="btn btn-primary" ref="cameraButton"><i class="fa fa-camera"></i> {{ctx.t('Camera')}}</button>
 </div>
 {% } else if (!ctx.self.cameraMode) { %}
 <div class="fileSelector" ref="fileDrop">
-  <i class="{{ctx.iconClass('cloud-upload')}}"></i> Drop files to attach,
+  <i class="{{ctx.iconClass('cloud-upload')}}"></i> {{ctx.t('Drop files to attach,')}}
     {% if (ctx.component.image) { %}
-      <a href="#" ref="toggleCameraMode"><i class="fa fa-camera"></i> Use Camera</a>,
+      <a href="#" ref="toggleCameraMode"><i class="fa fa-camera"></i> {{ctx.t('Use Camera,')}}</a>
     {% } %}
-    or <a href="#" ref="fileBrowse" class="browse">browse</a>
+    {{ctx.t('or')}} <a href="#" ref="fileBrowse" class="browse">{{ctx.t('browse')}}</a>
 </div>
 {% } else { %}
 <div>
   <video class="video" autoplay="true" ref="videoPlayer"></video>
   <canvas style="display: none" ref="videoCanvas"></canvas>
 </div>
-<button class="btn btn-primary" ref="takePictureButton"><i class="fa fa-camera"></i> Take Picture</button>
-<button class="btn btn-primary" ref="toggleCameraMode">Switch to file upload</button>
+<button class="btn btn-primary" ref="takePictureButton"><i class="fa fa-camera"></i> {{ctx.t('Take Picture')}}</button>
+<button class="btn btn-primary" ref="toggleCameraMode">{{ctx.t('Switch to file upload')}}</button>
 {% } %}
 {% } %}
 {% ctx.statuses.forEach(function(status) { %}
@@ -88,11 +88,11 @@
       {% if (status.status === 'progress') { %}
       <div class="progress">
         <div class="progress-bar" role="progressbar" aria-valuenow="{{status.progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{status.progress}}">
-          <span class="sr-only">{{status.progress}}% Complete</span>
+          <span class="sr-only">{{status.progress}}% {{ctx.t('Complete')}}</span>
         </div>
       </div>
       {% } else { %}
-      <div class="bg-{{status.status}}">{{status.message}}</div>
+      <div class="bg-{{status.status}}">{{ctx.t(status.message)}}</div>
       {% } %}
     </div>
   </div>
@@ -101,16 +101,16 @@
 {% if (!ctx.component.storage || ctx.support.hasWarning) { %}
 <div class="alert alert-warning">
   {% if (!ctx.component.storage) { %}
-    <p>No storage has been set for this field. File uploads are disabled until storage is set up.</p>
+    <p>{{ctx.t('No storage has been set for this field. File uploads are disabled until storage is set up.')}}</p>
   {% } %}
   {% if (!ctx.support.filereader) { %}
-    <p>File API & FileReader API not supported.</p>
+    <p>{{ctx.t('File API & FileReader API not supported.')}}</p>
   {% } %}
   {% if (!ctx.support.formdata) { %}
-    <p>XHR2's FormData is not supported.</p>
+    <p>{{ctx.t("XHR2's FormData is not supported.")}}</p>
   {% } %}
   {% if (!ctx.support.progress) { %}
-    <p>XHR2's upload progress isn't supported.</p>
+    <p>{{ctx.t("XHR2's upload progress isn't supported.")}}</p>
   {% } %}
 </div>
 {% } %}

--- a/src/templates/semantic/multiValueTable/form.ejs
+++ b/src/templates/semantic/multiValueTable/form.ejs
@@ -4,7 +4,7 @@
   {% if (!ctx.disabled) { %}
   <tr>
     <td colspan="2">
-      <button class="ui button primary" ref="addButton"><i class="{{ctx.iconClass('plus')}}"></i> {{ctx.addAnother}}</button>
+      <button class="ui button primary" ref="addButton"><i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t(ctx.addAnother)}}</button>
     </td>
   </tr>
   {% } %}

--- a/src/templates/semantic/webform/builder.ejs
+++ b/src/templates/semantic/webform/builder.ejs
@@ -1,1 +1,1 @@
-<div class="ui visible message"><p>{{ ctx.component.title }}</p></div>
+<div class="ui visible message"><p>{{ ctx.t(ctx.component.title) }}</p></div>


### PR DESCRIPTION
This is related to #520 and #1639. The localisation
strategy using i18next which is described in

https://github.com/formio/formio.js/wiki/Translations

can only work if the text is actually passed to
i18next.t(). This change sends some additional
user-visible strings to i18next.t() for localisation.