### PR TITLE
Fix apply actions when action type is property

### DIFF
--- a/src/components/base/Base.js
+++ b/src/components/base/Base.js
@@ -1678,6 +1678,9 @@ export default class BaseComponent extends Component {
       switch (action.type) {
         case 'property':
           FormioUtils.setActionProperty(newComponent, action, this.data, data, newComponent, result, this);
+          if (!_.isEqual(this, newComponent)) {
+            changed = true;
+          }
           break;
         case 'value': {
           const oldValue = this.getValue();


### PR DESCRIPTION
When action type is "property", function applyActions does not update the "changed" variable.
Therefore, in the function attachLogic(), applyActions does not return true when action type is property and component is not redraw. 