### PR TITLE
Fix types

### DIFF
--- a/types/formio.d.ts
+++ b/types/formio.d.ts
@@ -36,7 +36,7 @@ export class Formio {
   index(type: any, query?: any, opts?: any): any;
   save(type: any, data: any, opts?: any): any;
   load(type: any, query?: any, opts?: any): any;
-  makeRequest(...args): any;
+  makeRequest(...args: any[]): any;
   loadProject(query?: any, opts?: any): any;
   saveProject(data: any, opts?: any): any;
   deleteProject(opts?: any): any;
@@ -102,9 +102,9 @@ export class Formio {
   static deregisterPlugin(plugin: any): any;
   static registerPlugin(plugin: any, name: string): any;
   static getPlugin(name: any | string): any;
-  static pluginWait(pluginFn: any, ...args): any;
-  static pluginGet(pluginFn: any, ...args): any;
-  static pluginAlter(pluginFn: any, value: any, ...args): any;
+  static pluginWait(pluginFn: any, ...args: any[]): any;
+  static pluginGet(pluginFn: any, ...args: any[]): any;
+  static pluginAlter(pluginFn: any, value: any, ...args: any[]): any;
   static accessInfo(formio?: Formio): any;
   static pageQuery(): any;
   static oAuthCurrentUser(formio?: Formio, token?: any): any;


### PR DESCRIPTION
Fix types to avoid error messages like this:
`../../node_modules/formiojs/types/formio.d.ts:107:49 - error TS7019: Rest parameter 'args' implicitly has an 'any[]' type.`

_(We have `"noImplicitAny": true` option switched on.)_