### PR TITLE
Release readme

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -158,6 +158,9 @@ gulp.task('types-index', () => gulp.src(['index.d.ts']).pipe(gulp.dest('lib')));
 gulp.task('types-folder', () => gulp.src(['types/**/*.*']).pipe(gulp.dest('lib/types')));
 gulp.task('types', gulp.parallel('types-index', 'types-folder'));
 
+// Copy over the readme and changelog files
+gulp.task('readme', () => gulp.src(['README.md', 'Changelog.md']).pipe(gulp.dest('lib')));
+
 // Watch for changes.
 gulp.task('watch', () => gulp.watch(['./src/*.js', './src/**/*.js'], gulp.series('scripts-full')));
 
@@ -189,7 +192,8 @@ gulp.task('build', gulp.series(
     'scripts-full'
   ),
   'dist',
-  'types'
+  'types',
+  'readme'
 ));
 
 // Create a new build (scripts only)


### PR DESCRIPTION
Fixing the "Unable to find a readme for formiojs@4.2.5" message on the npm page