### PR TITLE
Fix emit event on drop

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -750,31 +750,39 @@ export default class WebformBuilder extends Component {
     const parent = target.formioComponent;
     const path = this.getComponentsPath(info, parent.component);
     const index = _.findIndex(_.get(parent.schema, path), { key: info.key }) || 0;
-    this.emit('addComponent', info, parent, path, index, isNew);
 
     if (isNew && !this.options.noNewEdit) {
       this.editComponent(info, target, isNew);
     }
 
     // Only rebuild the parts needing to be rebuilt.
+    let rebuild;
     if (target !== source) {
       if (source.formioContainer && source.contains(target)) {
-        source.formioComponent.rebuild();
+        rebuild = source.formioComponent.rebuild();
       }
       else if (target.contains(source)) {
-        target.formioComponent.rebuild();
+        rebuild = target.formioComponent.rebuild();
       }
       else {
         if (source.formioContainer) {
-          source.formioComponent.rebuild();
+          rebuild = source.formioComponent.rebuild();
         }
-        target.formioComponent.rebuild();
+        rebuild = target.formioComponent.rebuild();
       }
     }
     else {
       // If they are the same, only rebuild one.
-      target.formioComponent.rebuild();
+      rebuild = target.formioComponent.rebuild();
     }
+
+    if (!rebuild) {
+      rebuild = NativePromise.resolve();
+    }
+
+    return rebuild.then(() => {
+      this.emit('addComponent', info, parent, path, index, isNew);
+    });
   }
 
   setForm(form) {


### PR DESCRIPTION
The angular-formio lib reads the form definition from `instance.schema` on events, but after moving a field (with drag&drop) it read the previous definition since the event was emitted before the actual update of `instance.schema`.

You can test the issue at https://formio.github.io/angular-demo/#/forms/builder