### PR TITLE
is breadcrumb clickable moved to top nav instead of buttons

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -201,15 +201,15 @@ export default class Wizard extends Webform {
   }
 
   attachHeader() {
-    this.refs[`${this.wizardKey}-link`].forEach((link, index) => {
-      if (this.isBreadcrumbClickable()) {
+    if (this.isBreadcrumbClickable()) {
+      this.refs[`${this.wizardKey}-link`].forEach((link, index) => {
         this.addEventListener(link, 'click', (event) => {
           this.emit('wizardNavigationClicked', this.pages[index]);
           event.preventDefault();
           this.setPage(index);
         });
-      }
-    });
+      });
+    }
   }
 
   detachNav() {

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -106,6 +106,7 @@ export default class Wizard extends Webform {
   get renderContext() {
     return {
       wizardKey: this.wizardKey,
+      isBreadcrumbClickable: this.isBreadcrumbClickable(),
       panels: this.pages.map(page => page.component),
       buttons: this.buttons,
       currentPage: this.page,
@@ -172,38 +173,42 @@ export default class Wizard extends Webform {
     return promises;
   }
 
+  isBreadcrumbClickable() {
+    return _.get(this.options, 'breadcrumbSettings.clickable', true);
+  }
+
   attachNav() {
-    const isClickable = _.get(this.options, 'breadcrumbSettings.clickable', true);
-    if (isClickable) {
-      _.each(this.buttons, (button) => {
-        const buttonElement = this.refs[`${this.wizardKey}-${button.name}`];
-        this.addEventListener(buttonElement, 'click', (event) => {
-          event.preventDefault();
+    _.each(this.buttons, (button) => {
+      const buttonElement = this.refs[`${this.wizardKey}-${button.name}`];
+      this.addEventListener(buttonElement, 'click', (event) => {
+        event.preventDefault();
 
-          // Disable the button until done.
-          buttonElement.setAttribute('disabled', 'disabled');
-          this.setLoading(buttonElement, true);
+        // Disable the button until done.
+        buttonElement.setAttribute('disabled', 'disabled');
+        this.setLoading(buttonElement, true);
 
-          // Call the button method, then re-enable the button.
-          this[button.method]().then(() => {
-            buttonElement.removeAttribute('disabled');
-            this.setLoading(buttonElement, false);
-          }).catch(() => {
-            buttonElement.removeAttribute('disabled');
-            this.setLoading(buttonElement, false);
-          });
+        // Call the button method, then re-enable the button.
+        this[button.method]().then(() => {
+          buttonElement.removeAttribute('disabled');
+          this.setLoading(buttonElement, false);
+        }).catch(() => {
+          buttonElement.removeAttribute('disabled');
+          this.setLoading(buttonElement, false);
         });
       });
-    }
+    });
+
   }
 
   attachHeader() {
     this.refs[`${this.wizardKey}-link`].forEach((link, index) => {
-      this.addEventListener(link, 'click', (event) => {
-        this.emit('wizardNavigationClicked', this.pages[index]);
-        event.preventDefault();
-        this.setPage(index);
-      });
+      if (this.isBreadcrumbClickable()) {
+        this.addEventListener(link, 'click', (event) => {
+          this.emit('wizardNavigationClicked', this.pages[index]);
+          event.preventDefault();
+          this.setPage(index);
+        });
+      }
     });
   }
 


### PR DESCRIPTION
Moved the check if breadcrumb is clickable to the top nav instead of the buttons (next, previous). The option breadcrumbSettings.clickable doesn't related to the buttons (in my opinion). If you set the value as true then the top breadcrumb header is clickable but the buttons became un-clickable. 
Also passing the option into the template context so people can override the look at feel of the breadcrumb with that option