### PR TITLE
Show default value in preview 

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -878,6 +878,7 @@ export default class WebformBuilder extends Component {
   }
 
   updateComponent(component, changed) {
+    const defaultValueComponent = getComponent(this.editForm.components, 'defaultValue');
     // Update the preview.
     if (this.preview) {
       this.preview.form = { components: [_.omit(component, [
@@ -890,13 +891,15 @@ export default class WebformBuilder extends Component {
       ])] };
       const previewElement = this.componentEdit.querySelector('[ref="preview"]');
       if (previewElement) {
+        if (defaultValueComponent) {
+          this.preview.components[0].setValue(defaultValueComponent.data.defaultValue);
+        }
         this.setContent(previewElement, this.preview.render());
         this.preview.attach(previewElement);
       }
     }
 
     // Change the "default value" field to be reflective of this component.
-    const defaultValueComponent = getComponent(this.editForm.components, 'defaultValue');
     const defaultChanged = changed && changed.component && changed.component.key === 'defaultValue';
     if (defaultValueComponent && !defaultChanged) {
       _.assign(defaultValueComponent.component, _.omit(component, [
@@ -962,6 +965,7 @@ export default class WebformBuilder extends Component {
       submissionData = submissionData.componentJson || submissionData;
       if (parentContainer) {
         parentContainer[index] = submissionData;
+        parentComponent.components[index].setValue(submissionData.defaultValue);
       }
       else if (parentComponent && parentComponent.saveChildComponent) {
         parentComponent.saveChildComponent(submissionData);

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1799,11 +1799,11 @@ export default class Component extends Element {
       return this.emptyValue;
     }
     if (!this.hasValue()) {
-      const empty = this.component.multiple ? [] : this.emptyValue;
+      const defaultValue = this.component.multiple ? [] : this.defaultValue;
       if (!this.rootPristine) {
-        this.dataValue = empty;
+        this.dataValue = defaultValue;
       }
-      return empty;
+      return defaultValue;
     }
     return _.get(this.data, this.key);
   }


### PR DESCRIPTION
This updates the preview component when editing and in the form builder so that the default value appears. 

Setting the dataValue to default rather than explicitly empty ensures that the field always shows the default value. 