### PR TITLE
Fix github #1953: Override .defaultValue of subcomponents.

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -282,7 +282,10 @@ export default class FormComponent extends Component {
       }
 
       // Iterate through every component and hide the submit button.
+      // Override defaultValue with respective parts from old dataValue.
+      const oldData = this.dataValue ? this.dataValue.data : {};
       eachComponent(form.components, (component) => {
+        component.defaultValue = _.get(oldData, component.key, component.defaultValue);
         if (
           (component.type === 'button') &&
           ((component.action === 'submit') || !component.action)


### PR DESCRIPTION
Not sure about side-effects, but this appears to fix the problematic behavior.  Fixes #1953 .