### PR TITLE
Using DataGrid & DataMap inside EditGrid

### DIFF
--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -43,6 +43,20 @@ export default class DataGridComponent extends NestedComponent {
     this.checkColumns();
   }
 
+  get data() {
+    return this._data;
+  }
+
+  set data(value) {
+    this._data = value;
+    const componentData = this.component && this.component.key ? this._data[this.component.key] : this._data;
+    if (this.rows) {
+      this.rows.forEach((row, rowIndex) => {
+        Object.entries(row).forEach(([key, component]) => component.data = componentData[rowIndex]);
+      });
+    }
+  }
+
   get allowData() {
     return true;
   }
@@ -354,6 +368,8 @@ export default class DataGridComponent extends NestedComponent {
   removeRow(index) {
     this.splice(index);
     this.rows.splice(index, 1);
+    // Splice the components Array when the row is spliced
+    this.components.splice(index, 1);
     this.redraw();
   }
 

--- a/src/components/datamap/DataMap.js
+++ b/src/components/datamap/DataMap.js
@@ -63,6 +63,18 @@ export default class DataMapComponent extends DataGridComponent {
     this.component.valueComponent.hideLabel = true;
   }
 
+  get data() {
+    return this._data;
+  }
+
+  set data(value) {
+    this._data = value;
+    this.eachComponent((component) => {
+      const rowData = this.component && this.component.key ? this._data[this.component.key] : this._data;
+      component.data = component.data['__key']  ?   component.data :  rowData;
+    });
+  }
+
   get defaultSchema() {
     return DataMapComponent.schema();
   }
@@ -210,6 +222,9 @@ export default class DataMapComponent extends DataGridComponent {
       delete this.dataValue[keys[index]];
     }
     this.rows.splice(index, 1);
+    // Splice the components Array when the row is spliced
+    // this.components is a flat array,  with 2 components for each row, index should be incremented
+    this.components.splice(index++, 2);
     this.redraw();
     this.triggerChange();
   }


### PR DESCRIPTION
Issue : #2024 
When DataGrid / DataMap is used inside Editgrid , the data is lost in the iterations.

Fix : 
- Included set data() & get data() implementation for DataGrid & DataMap.
- removeRow - should also remove the component from the components array.

