### PR TITLE
Allow attributes to be passed to modal creation in the form builder

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1055,7 +1055,7 @@ export default class WebformBuilder extends Component {
       preview: this.preview ? this.preview.render() : false,
     }));
 
-    this.dialog = this.createModal(this.componentEdit);
+    this.dialog = this.createModal(this.componentEdit, _.get(this.options, 'dialogAttr', {}));
 
     // This is the attach step.
     this.editForm.attach(this.componentEdit.querySelector('[ref="editForm"]'));

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1087,8 +1087,8 @@ export default class Component extends Element {
     this.onChange(...args);
   }
 
-  createModal(element) {
-    const dialog = this.ce('div');
+  createModal(element, attr) {
+    const dialog = this.ce('div', attr || {});
     this.setContent(dialog, this.renderTemplate('dialog'));
 
     // Add refs to dialog, not "this".


### PR DESCRIPTION
Passing attributes to the modal allows for CSS namespacing on the modal div. Necessary for including formio in a site which doesn't use bootstrap as the CSS framework. 