### PR TITLE
Allow editor source url and settings to be provided in form options

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1649,7 +1649,8 @@ export default class Component extends Element {
       toolbar: ['imageTextAlternative', '|', 'imageStyle:full', 'imageStyle:alignLeft', 'imageStyle:alignCenter', 'imageStyle:alignRight'],
       styles: ['full', 'alignLeft', 'alignCenter', 'alignRight']
     };
-    return Formio.requireLibrary('ckeditor', 'ClassicEditor', CKEDITOR, true)
+    settings = _.merge(_.get(this.options, 'editors.ckeditor.settings', {}), settings);
+    return Formio.requireLibrary('ckeditor', 'ClassicEditor', _.get(this.options, 'editors.ckeditor.src', CKEDITOR), true)
       .then(() => {
         if (!element.parentNode) {
           return NativePromise.reject();
@@ -1663,6 +1664,7 @@ export default class Component extends Element {
 
   addQuill(element, settings, onChange) {
     settings = _.isEmpty(settings) ? this.wysiwygDefault : settings;
+    settings = _.merge(_.get(this.options, 'editors.quill.settings', {}), settings);
 
     // Lazy load the quill css.
     if (!settings.theme) {
@@ -1673,7 +1675,7 @@ export default class Component extends Element {
     ], true);
 
     // Lazy load the quill library.
-    return Formio.requireLibrary('quill', 'Quill', `${QUILL_URL}/quill.min.js`, true)
+    return Formio.requireLibrary('quill', 'Quill', _.get(this.options, 'editors.quill.src', `${QUILL_URL}/quill.min.js`), true)
       .then(() => {
         if (!element.parentNode) {
           return NativePromise.reject();
@@ -1715,7 +1717,8 @@ export default class Component extends Element {
   }
 
   addAce(element, settings, onChange) {
-    return Formio.requireLibrary('ace', 'ace', ACE_URL, true)
+    settings = _.merge(_.get(this.options, 'editors.ace.settings', {}), settings || {});
+    return Formio.requireLibrary('ace', 'ace', _.get(this.options, 'editors.ace.src', ACE_URL), true)
       .then((editor) => {
         editor = editor.edit(element);
         editor.removeAllListeners('change');


### PR DESCRIPTION
This allows a user to use the form options to set the source url and default settings for third-party editors. 

