### PR TITLE
Interpolate & translate labels.

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -603,6 +603,19 @@ export default class Component extends Element {
   }
 
   /**
+   * Interpolate a template with data & row made available.
+   *
+   * @param {string} template - The template to interpolate.
+   */
+  i(template) {
+    const ctx = {
+      data: this.rootValue,
+      row:  this.data
+    };
+    return this.interpolate(template, ctx);
+  }
+
+  /**
    * Translate a text using the i18n system.
    *
    * @param {string} text - The i18n identifier.
@@ -709,6 +722,7 @@ export default class Component extends Element {
     data.options = this.options;
     data.readOnly = this.options.readOnly;
     data.iconClass = this.iconClass.bind(this);
+    data.i = this.i.bind(this);
     data.t = this.t.bind(this);
     data.transform = this.transform;
     data.id = data.id || this.id;
@@ -2178,6 +2192,8 @@ export default class Component extends Element {
   set label(value) {
     this.component.label = value;
     if (this.labelElement) {
+      // How do we get here at all?
+      // Maybe this should be: ...= this.i(this.t(value));
       this.labelElement.innerText = value;
     }
   }

--- a/src/templates/bootstrap/checkbox/form.ejs
+++ b/src/templates/bootstrap/checkbox/form.ejs
@@ -7,7 +7,7 @@
       {% } %}
       {% if (ctx.checked) { %}checked=true{% } %}
       >
-    {% if (!ctx.self.labelIsHidden()) { %}<span>{{ctx.input.label}}</span>{% } %}
+    {% if (!ctx.self.labelIsHidden()) { %}<span>{{ctx.i(ctx.t(ctx.input.label))}}</span>{% } %}
     {% if (ctx.component.tooltip) { %}
       <i ref="tooltip" class="{{ctx.iconClass('question-sign')}} text-muted"></i>
     {% } %}

--- a/src/templates/bootstrap/checkbox/html.ejs
+++ b/src/templates/bootstrap/checkbox/html.ejs
@@ -1,5 +1,5 @@
 <label class="{{ctx.input.labelClass}}">
     {{ctx.input.content}}
-    {% if (!ctx.self.labelIsHidden()) { %}<span>{{ctx.input.label}}</span>{% } %}
+    {% if (!ctx.self.labelIsHidden()) { %}<span>{{ctx.i(ctx.t(ctx.input.label))}}</span>{% } %}
 </label>
 <div ref="value">{% if (ctx.checked) { %}True{% } else { %}False{% } %}</div>

--- a/src/templates/bootstrap/datagrid/form.ejs
+++ b/src/templates/bootstrap/datagrid/form.ejs
@@ -9,7 +9,7 @@
       {% if (ctx.component.reorder) { %}<th></th>{% } %}
       {% ctx.columns.forEach(function(col) { %}
         <th class="{{col.validate && col.validate.required ? 'field-required' : ''}}">
-          {{ col.hideLabel ? '' : ctx.t(col.label || col.title) }}
+          {{ col.hideLabel ? '' : ctx.i(ctx.t(col.label || col.title)) }}
           {% if (col.tooltip) { %} <i ref="tooltip" data-title="{{col.tooltip}}" class="{{ctx.iconClass('question-sign')}} text-muted"></i>{% } %}
         </th>
       {% }) %}
@@ -32,7 +32,7 @@
       <td
         ref="{{ctx.datagridKey}}-group-label"
         colspan="{{ctx.numColumns}}"
-        class="datagrid-group-label">{{ctx.groups[index].label}}</td>
+        class="datagrid-group-label">{{ctx.i(ctx.t(ctx.groups[index].label))}}</td>
     </tr>
     {% } %}
     <tr ref="{{ctx.datagridKey}}-row">

--- a/src/templates/bootstrap/datagrid/html.ejs
+++ b/src/templates/bootstrap/datagrid/html.ejs
@@ -8,7 +8,7 @@
     <tr>
       {% ctx.columns.forEach(function(col) { %}
         <th class="{{col.validate && col.validate.required ? 'field-required' : ''}}">
-          {{ col.hideLabel ? '' : ctx.t(col.label || col.title) }}
+          {{ col.hideLabel ? '' : ctx.i(ctx.t(col.label || col.title)) }}
           {% if (col.tooltip) { %} <i ref="tooltip" data-title="{{col.tooltip}}" class="{{ctx.iconClass('question-sign')}} text-muted"></i>{% } %}
         </th>
       {% }) %}

--- a/src/templates/bootstrap/field/form.ejs
+++ b/src/templates/bootstrap/field/form.ejs
@@ -8,7 +8,7 @@
 
 {{ctx.element}}
 {% if (!ctx.label.hidden && ctx.label.labelPosition === 'bottom') { %}
-  <label class="{{ctx.label.className}}">{{ctx.t(ctx.component.label)}}
+  <label class="{{ctx.label.className}}">{{ctx.i(ctx.t(ctx.component.label))}}
   {% if (ctx.component.tooltip) { %}
     <i ref="tooltip" class="{{ctx.iconClass('question-sign')}} text-muted"></i>
   {% } %}

--- a/src/templates/bootstrap/label/form.ejs
+++ b/src/templates/bootstrap/label/form.ejs
@@ -1,5 +1,5 @@
 <label class="col-form-label {{ctx.label.className}}">
-  {{ ctx.t(ctx.component.label) }}
+  {{ ctx.i(ctx.t(ctx.component.label)) }}
   {% if (ctx.component.tooltip) { %}
     <i ref="tooltip" class="{{ctx.iconClass('question-sign')}} text-muted"></i>
   {% } %}

--- a/src/templates/bootstrap/multipleMasksInput/form.ejs
+++ b/src/templates/bootstrap/multipleMasksInput/form.ejs
@@ -7,7 +7,7 @@
     id="{{ctx.key}}-mask"
     ref="select">
     {% ctx.selectOptions.forEach(function(option) { %}
-    <option value="{{option.value}}">{{option.label}}</option>
+    <option value="{{option.value}}">{{ctx.i(ctx.t(option.label))}}</option>
     {% }); %}
   </select>
   <input

--- a/src/templates/bootstrap/radio/form.ejs
+++ b/src/templates/bootstrap/radio/form.ejs
@@ -3,7 +3,7 @@
   <div class="form-check{{ctx.inline ? '-inline' : ''}}" ref="wrapper">
     <label class="form-check-label label-position-{{ ctx.component.optionsLabelPosition }}" for="{{ctx.id}}{{ctx.row}}-{{item.value}}">
       {% if (ctx.component.optionsLabelPosition === 'left' || ctx.component.optionsLabelPosition === 'top') { %}
-      <span>{{ctx.t(item.label)}}</span>
+      <span>{{ctx.i(ctx.t(item.label))}}</span>
       {% } %}
       <{{ctx.input.type}}
         ref="input"
@@ -20,7 +20,7 @@
         id="{{ctx.id}}{{ctx.row}}-{{item.value}}"
       >
       {% if (!ctx.component.optionsLabelPosition || ctx.component.optionsLabelPosition === 'right' || ctx.component.optionsLabelPosition === 'bottom') { %}
-      <span>{{ctx.t(item.label)}}</span>
+      <span>{{ctx.i(ctx.t(item.label))}}</span>
       {% } %}
     </label>
   </div>

--- a/src/templates/bootstrap/radio/html.ejs
+++ b/src/templates/bootstrap/radio/html.ejs
@@ -1,4 +1,4 @@
 <div ref="value">
-  {% var filtered = ctx.values.filter(function(item) {return ctx.value === item.value || (typeof ctx.value === 'object' && ctx.value.hasOwnProperty(item.value) && ctx.value[item.value])}).map(function(item) { return ctx.t(item.label)}).join(', ') %}
+  {% var filtered = ctx.values.filter(function(item) {return ctx.value === item.value || (typeof ctx.value === 'object' && ctx.value.hasOwnProperty(item.value) && ctx.value[item.value])}).map(function(item) { return ctx.i(ctx.t(item.label))}).join(', ') %}
   {{ filtered }}
   </div>

--- a/src/templates/bootstrap/selectOption/form.ejs
+++ b/src/templates/bootstrap/selectOption/form.ejs
@@ -4,5 +4,5 @@
   {{attr}}="{{ctx.attrs[attr]}}"
   {% } %}
   >
-  {{ctx.t(ctx.option.label)}}
+  {{ctx.i(ctx.t(ctx.option.label))}}
 </option>

--- a/src/templates/bootstrap/selectOption/html.ejs
+++ b/src/templates/bootstrap/selectOption/html.ejs
@@ -1,1 +1,1 @@
-{% if (ctx.selected) { %}{{ctx.t(ctx.option.label)}}{% } %}
+{% if (ctx.selected) { %}{{ctx.i(ctx.t(ctx.option.label))}}{% } %}

--- a/src/templates/bootstrap/survey/form.ejs
+++ b/src/templates/bootstrap/survey/form.ejs
@@ -3,14 +3,14 @@
     <tr>
       <th></th>
       {% ctx.component.values.forEach(function(value) { %}
-      <th style="text-align: center;">{{ctx.t(value.label)}}</th>
+      <th style="text-align: center;">{{ctx.i(ctx.t(value.label))}}</th>
       {% }) %}
     </tr>
   </thead>
   <tbody>
     {% ctx.component.questions.forEach(function(question) { %}
     <tr>
-      <td>{{ctx.t(question.label)}}</td>
+      <td>{{ctx.i(ctx.t(question.label))}}</td>
       {% ctx.component.values.forEach(function(value) { %}
       <td style="text-align: center;">
         <input type="radio" name="{{ ctx.self.getInputName(question) }}" value="{{value.value}}" id="{{ctx.key}}-{{question.value}}-{{value.value}}" ref="input">

--- a/src/templates/bootstrap/survey/html.ejs
+++ b/src/templates/bootstrap/survey/html.ejs
@@ -2,11 +2,11 @@
   <tbody>
     {% ctx.component.questions.forEach(function(question) { %}
     <tr>
-      <th>{{ctx.t(question.label)}}</th>
+      <th>{{ctx.i(ctx.t(question.label))}}</th>
       <td>
       {% ctx.component.values.forEach(function(item) { %}
         {% if (ctx.value && ctx.value.hasOwnProperty(question.value) && ctx.value[question.value] === item.value) { %}
-          {{ctx.t(item.label)}}
+          {{ctx.i(ctx.t(item.label))}}
         {% } %}
       {% }) %}
       </td>

--- a/src/templates/bootstrap/tab/flat.ejs
+++ b/src/templates/bootstrap/tab/flat.ejs
@@ -1,7 +1,7 @@
 {% ctx.component.components.forEach(function(tab, index) { %}
   <div class="mb-2 card border">
     <div class="card-header bg-default">
-      <h4 class="mb-0 card-title">{{ ctx.t(tab.label) }}</h4>
+      <h4 class="mb-0 card-title">{{ ctx.i(ctx.t(tab.label)) }}</h4>
     </div>
     <div class="card-body">
       {{ ctx.tabComponents[index] }}

--- a/src/templates/bootstrap/tab/form.ejs
+++ b/src/templates/bootstrap/tab/form.ejs
@@ -3,7 +3,7 @@
     <ul class="nav nav-tabs card-header-tabs">
       {% ctx.component.components.forEach(function(tab, index) { %}
       <li class="nav-item{{ ctx.currentTab === index ? ' active' : ''}}" role="presentation" ref="{{ctx.tabLikey}}">
-        <a class="nav-link{{ ctx.currentTab === index ? ' active' : ''}}" href="#{{tab.key}}" ref="{{ctx.tabLinkKey}}">{{ctx.t(tab.label)}}</a>
+        <a class="nav-link{{ ctx.currentTab === index ? ' active' : ''}}" href="#{{tab.key}}" ref="{{ctx.tabLinkKey}}">{{ctx.i(ctx.t(tab.label))}}</a>
       </li>
       {% }) %}
     </ul>


### PR DESCRIPTION
Fixes #2117 . Needs review & testing.

In an earlier version of this patch, this seemed to work well (tested with ordinary Text Field component labels):
![testLabelTemplate](https://user-images.githubusercontent.com/46748541/69752134-e11c3700-1150-11ea-8c1c-4bf219086b1b.png)

