### PR TITLE
Fixed Select default value when multiple is true

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -321,7 +321,7 @@ export default class SelectComponent extends Field {
     }
     else {
       // If a default value is provided then select it.
-      const defaultValue = this.defaultValue;
+      const defaultValue = this.multiple ? this.defaultValue || [] : this.defaultValue;
       if (defaultValue) {
         this.setValue(defaultValue);
       }


### PR DESCRIPTION
Currently if a **Select Component** with the multiple flag set to `true` and no `defaultValue` set, it defaults to an empty string triggering a nonarray validation error.  This pull request sets an empty array as default value if no `defaultValue` is set.