### PR TITLE
Fixed Wizard checkData validation order

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -425,7 +425,7 @@ export default class Wizard extends Webform {
 
   checkData(data, flags) {
     const dirty = this.currentPage.components.some(component => !component.isEmpty());
-    return this.checkValidity(data, dirty, true) && super.checkData(data, flags);
+    return super.checkData(data, flags) &&this.checkValidity(data, dirty, true);
   }
 
   cancel(noconfirm) {

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -425,7 +425,7 @@ export default class Wizard extends Webform {
 
   checkData(data, flags) {
     const dirty = this.currentPage.components.some(component => !component.isEmpty());
-    return super.checkData(data, flags) &&this.checkValidity(data, dirty, true);
+    return super.checkData(data, flags) && this.checkValidity(data, dirty, true);
   }
 
   cancel(noconfirm) {


### PR DESCRIPTION
Currently wizard checkData function performs validation checks before checking data, thus failing even when calculateValue is defined.  The order should be reversed and first check the component wizard data (thus triggering data evaluations) and then check the data's validity.