### PR TITLE
fix: Don't regenerate component.id when the component have an existing id

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -29,7 +29,7 @@ export default class Element {
      * can also be provided from the component.id value passed into the constructor.
      * @type {string}
      */
-    this.id = FormioUtils.getRandomComponentId();
+    this.id = this.options.id || FormioUtils.getRandomComponentId();
     /**
      * An array of event handlers so that the destry command can deregister them.
      * @type {Array}

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -197,6 +197,7 @@ export default class Component extends Element {
   /* eslint-disable max-statements */
   constructor(component, options, data) {
     super(Object.assign({
+      id: _.get(component, 'id'),
       renderMode: 'form',
       attachMode: 'full'
     }, options || {}));

--- a/src/components/_classes/component/Component.unit.js
+++ b/src/components/_classes/component/Component.unit.js
@@ -25,6 +25,13 @@ describe('Component', () => {
     });
   });
 
+  it('Should keep id component when id exists', () => {
+    return Harness.testCreate(Component, { id: 'componentId', type: 'base' })
+      .then((component) => {
+        assert.equal(component.id, 'componentId');
+      });
+  });
+
   it('Should provide required validation', (done) => {
     Harness.testCreate(Component, _merge({}, comp1, {
       validate: { required: true }


### PR DESCRIPTION
Should resolve the bug #2153 