### PR TITLE
Fix #2191: invalid identity escape in numberPattern.

### DIFF
--- a/src/components/number/Number.js
+++ b/src/components/number/Number.js
@@ -106,8 +106,8 @@ export default class NumberComponent extends Input {
 
   setInputMask(input) {
     let numberPattern = '[0-9';
-    numberPattern += this.decimalSeparator ? `\\${this.decimalSeparator}` : '';
-    numberPattern += this.delimiter ? `\\${this.delimiter}` : '';
+    numberPattern += this.decimalSeparator || '';
+    numberPattern += this.delimiter || '';
     numberPattern += ']*';
     input.setAttribute('pattern', numberPattern);
     input.mask = maskInput({


### PR DESCRIPTION
Fixes #2191 .

Typical delimiter or decimalSeparator characters for numbers (e.g. dot and comma) can occur directly in `[`...`]` character classes in regexps without problems.