### PR TITLE
Fixed EditGrid not setting Nested Components values on edit

### DIFF
--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -691,7 +691,12 @@ export default class EditGridComponent extends NestedComponent {
   }
 
   restoreRowContext(editRow) {
-    editRow.components.forEach((component) => component.data = editRow.data);
+    editRow.components.forEach((component) => {
+      component.data = editRow.data;
+      if (_.has(editRow.data, component.key)) {
+        component.setValue(editRow.data[component.key]);
+      }
+    });
   }
 }
 


### PR DESCRIPTION
Related to https://github.com/formio/formio.js/issues/2024

When restoring a row data context, it sets the context global data. Unfortunately, on nested components it does not sets the values of its components.  This pull request sets the component's value if it is present in the row context, thus correctly initializing nested component's components.