### PR TITLE
Fix invalid html in example

### DIFF
--- a/app/examples/custombuilder.md
+++ b/app/examples/custombuilder.md
@@ -14,7 +14,7 @@ To see this in action, you can use the pre-built formio builder libraries as fol
 ```html
 <link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.builder.min.css">
 <script src="https://unpkg.com/formiojs@latest/dist/formio.builder.min.js"></script>
-<div id="builder"></formio>
+<div id="builder"></div>
 ```
 
 ```js


### PR DESCRIPTION
<div> tag should be terminated with </div> tag, not </formio>