### PR TITLE
Fix Display of Help Link

### DIFF
--- a/src/templates/bootstrap/builderEditForm/form.ejs
+++ b/src/templates/bootstrap/builderEditForm/form.ejs
@@ -5,7 +5,7 @@
   <div class="col col-sm-6">
     <div class="float-right" style="margin-right: 20px; margin-top: 10px">
       <a href="{{ctx.t(ctx.componentInfo.documentation)}}" target="_blank">
-        <i class="{{ctx.iconClass('new-window')}}"> {{ctx.t('Help')}}</i>
+        <i class="{{ctx.iconClass('new-window')}}"></i> {{ctx.t('Help')}}
       </a>
     </div>
   </div>


### PR DESCRIPTION
Move text outside of `<i class"fa"></i>` icon declaration