### PR TITLE
Convert Flatpickr Timestamp `U` to Moment.js `X`

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -707,7 +707,9 @@ export function convertFormatToMoment(format) {
     // Day in week.
     .replace(/E/g, 'd')
     // AM/PM marker
-    .replace(/a/g, 'A');
+    .replace(/a/g, 'A')
+    // Unix Timestamp
+    .replace(/U/g, 'X');
 }
 
 export function convertFormatToMask(format) {


### PR DESCRIPTION
Flatpickr uses `U` for timestamps, but it doesn't get formatted in the submission object, since moment.js uses `X`.

https://github.com/formio/formio.js/issues/2242