### PR TITLE
Don't interpolate content when in builder mode so that it won't throw…

### DIFF
--- a/src/components/content/Content.js
+++ b/src/components/content/Content.js
@@ -29,6 +29,9 @@ export default class ContentComponent extends Component {
   }
 
   get content() {
+    if (this.builderMode) {
+      return this.component.html;
+    }
     const submission = _.get(this.root, 'submission', {});
     return this.component.html ? this.interpolate(this.component.html, {
       metadata: submission.metadata || {},

--- a/src/components/html/HTML.js
+++ b/src/components/html/HTML.js
@@ -30,6 +30,9 @@ export default class HTMLComponent extends Component {
   }
 
   get content() {
+    if (this.builderMode) {
+      return this.component.content;
+    }
     const submission = _.get(this.root, 'submission', {});
     return this.component.content ? this.interpolate(this.component.content, {
       metadata: submission.metadata || {},


### PR DESCRIPTION
… errors and shows the interpolation options.