### PR TITLE
Improve(editFormUtils): add option to override editForm builder options

### DIFF
--- a/src/components/_classes/component/editForm/utils.js
+++ b/src/components/_classes/component/editForm/utils.js
@@ -12,12 +12,12 @@ const EditFormUtils = {
       if (objValue.key === srcValue.key) {
         // Create complete objects by including missing keys.
         _.each(objValue, (value, prop) => {
-          if (!srcValue.hasOwnProperty(prop)) {
+          if (objValue.overrideEditForm || !srcValue.hasOwnProperty(prop)) {
             srcValue[prop] = value;
           }
         });
         _.each(srcValue, (value, prop) => {
-          if (!objValue.hasOwnProperty(prop)) {
+          if (srcValue.overrideEditForm || !objValue.hasOwnProperty(prop)) {
             objValue[prop] = value;
           }
         });

--- a/src/components/_classes/component/editForm/utils.spec.js
+++ b/src/components/_classes/component/editForm/utils.spec.js
@@ -32,5 +32,16 @@ describe('Edit Form Utils', function() {
         { key: 'b', one: 1, two: 2, ok: true },
       ]);
     });
+
+    it('should override with "override" flag', () => {
+      const components = [
+        { key: 'a', label: 1, ok: true },
+        { key: 'a', label: 2, overrideEditForm: true }
+      ];
+
+      expect(_.unionWith(components, utils.unifyComponents)).to.deep.equal([
+        { key: 'a', label: 2, ok: true, overrideEditForm: true }
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Ignore editForm api key validation? [#2280](https://github.com/formio/formio.js/issues/2280)

Now we can pass a overrideEditForm flag in options. example:
```
const options = {
  builder: {
    data: false,
    premium: false,
  },
  editForm: {
    textfield: [
      {
        key: 'api',
        ignore: false,
        components: [
          {
            key: 'key',
            overrideEditForm: true,
            validate:{}
          }
        ]
      }
    ]
  }
};
```