### PR TITLE
fix: wizard changing next page doesn't update buttons

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -558,12 +558,13 @@ export default class Wizard extends Webform {
     // If the pages change, need to redraw the header.
     const currentPanels = this.pages.map(page => page.component.key);
     const panels = this.establishPages().map(panel => panel.key);
+    const currentNextPage = this.currentNextPage;
     if (!_.isEqual(panels, currentPanels)) {
       this.redrawHeader();
     }
 
     // If the next page changes, then make sure to redraw navigation.
-    if (this.currentNextPage !== this.getNextPage()) {
+    if (currentNextPage !== this.getNextPage()) {
       this.redrawNavigation();
     }
   }


### PR DESCRIPTION
When wizard uses advanced logic to make pages conditional, the buttons don't update when the page shown.

this.currentNextPage is updated inside redrawHeader. The following comparison is always false

Issue can be seen here:
https://codesandbox.io/s/vigilant-panini-d6999
Select option A in combobox
-> Page 2 is added to wizard
-> Buttons are not updated