### PR TITLE
Fix clearOnHide while updating submission

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1218,6 +1218,11 @@ export default class Webform extends NestedDataComponent {
     super.onChange(flags, true);
     const value = _.clone(this.submission);
     flags.changed = value.changed = changed;
+
+    if (modified && this.pristine) {
+      this.setPristine(false);
+    }
+
     value.isValid = this.checkData(value.data, flags);
     this.loading = false;
     if (this.submitted) {
@@ -1226,10 +1231,6 @@ export default class Webform extends NestedDataComponent {
     // See if we need to save the draft of the form.
     if (modified && this.options.saveDraft) {
       this.triggerSaveDraft();
-    }
-
-    if (modified && this.pristine) {
-      this.pristine = false;
     }
 
     if (!flags || !flags.noEmit) {


### PR DESCRIPTION
If set pristine of the Webform after checkData was called, when clearOnHide is called, rootPristine would be false and then the value would not be deleted
This also fix an issue with not working clearOnHide inside dataGrid