### PR TITLE
Removed placeholder from defaultWysiwyg settings for "ace" editor

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1810,7 +1810,7 @@ export default class Component extends Element {
   get wysiwygDefault() {
     return {
       theme: 'snow',
-      placeholder: this.t(this.component.placeholder),
+      placeholder: this.component.editor === 'ace' ? '' : this.t(this.component.placeholder),
       modules: {
         toolbar: [
           [{ 'size': ['small', false, 'large', 'huge'] }],  // custom dropdown


### PR DESCRIPTION
Placeholders for 'ace' editor are added with checkAcePlaceholder method