### PR TITLE
Added Role API methods

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -1201,7 +1201,7 @@ export default class Formio {
 
   static projectRoles(formio) {
     const projectUrl = formio ? formio.projectUrl : Formio.projectUrl;
-    return Formio.makeRequest(formio, 'roles', `${projectUrl}/role`);
+    return Formio.makeRequest(formio, 'projectRoles', `${projectUrl}/role`);
   }
 
   static currentUser(formio, options) {

--- a/src/Formio.js
+++ b/src/Formio.js
@@ -52,6 +52,9 @@ export default class Formio {
     this.projectsUrl = '';
     this.projectUrl = '';
     this.projectId = '';
+    this.roleUrl = '';
+    this.rolesUrl = '';
+    this.roleId = '';
     this.formUrl = '';
     this.formsUrl = '';
     this.formId = '';
@@ -180,8 +183,11 @@ export default class Formio {
       this.projectsUrl = this.projectsUrl || `${this.base}/project`;
     }
 
+    // Configure Role urls and role ids.
+    registerItems(['role'], this.projectUrl);
+
     // Configure Form urls and form ids.
-    if ((path.search(/(^|\/)(form)($|\/)/) !== -1)) {
+    if (/(^|\/)(form)($|\/)/.test(path)) {
       registerItems(['form', ['submission', 'action', 'v']], this.projectUrl);
     }
     else {
@@ -284,6 +290,22 @@ export default class Formio {
       query = `?${Formio.serialize(query.params)}`;
     }
     return Formio.makeStaticRequest(`${Formio.baseUrl}/project${query}`, 'GET', null, opts);
+  }
+
+  loadRole(opts) {
+    return this.load('role', null, opts);
+  }
+
+  saveRole(data, opts) {
+    return this.save('role', data, opts);
+  }
+
+  deleteRole(opts) {
+    return this.delete('role', opts);
+  }
+
+  loadRoles(opts) {
+    return this.index('roles', null, opts);
   }
 
   loadForm(query, opts) {
@@ -1175,6 +1197,11 @@ export default class Formio {
   static accessInfo(formio) {
     const projectUrl = formio ? formio.projectUrl : Formio.projectUrl;
     return Formio.makeRequest(formio, 'accessInfo', `${projectUrl}/access`);
+  }
+
+  static projectRoles(formio) {
+    const projectUrl = formio ? formio.projectUrl : Formio.projectUrl;
+    return Formio.makeRequest(formio, 'roles', `${projectUrl}/role`);
   }
 
   static currentUser(formio, options) {


### PR DESCRIPTION
The following methods have been added to interact with the project role endpoint:

- loadRoles
- loadRole
- saveRole
- deleteRole

The following properties are also registered:

- rolesUrl
- roleUrl (only when full role url is passed as path)
- roleId (only when full role url is passed as path)

Finally, changed a string regex search with a regex test method which is more efficient.