### PR TITLE
Revert "Fixed currency trailing zeros issue in currancy component"

### DIFF
--- a/src/components/currency/Currency.js
+++ b/src/components/currency/Currency.js
@@ -70,9 +70,7 @@ export default class CurrencyComponent extends NumberComponent {
   }
 
   formatValue(value) {
-    const decimalLimit = _.get(this.component, 'decimalLimit', 2);
-
-    return value ? (+value).toFixed(decimalLimit) : value;
+    return super.formatValue(this.stripPrefixSuffix(value));
   }
 
   stripPrefixSuffix(value) {


### PR DESCRIPTION
Reverts formio/formio.js#2449

This breaks the currency tests. Please run them locally (since circleci is not working atm) to see yourself.