### PR TITLE
Add use(plugin) method for typescript

### DIFF
--- a/types/formio.d.ts
+++ b/types/formio.d.ts
@@ -85,6 +85,7 @@ export class Formio {
   downloadFile(file: any, options?: Object): any;
   canSubmit(): any;
   getUrlParts(url: any): any;
+  use(plugin: any): any;
   static getUrlParts(url: any, formio?: Formio): any;
   static serialize(obj: any, _interpolate: any): any;
   static getRequestArgs(formio: Formio, type: string, url: string, method?: string, data?: any, opts?: any): any;


### PR DESCRIPTION
To fix: 
error TS2339: Property 'use' does not exist on type 'typeof Formio'.