### PR TITLE
Fixed unstranslated component label in Webform

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1152,7 +1152,7 @@ export default class Webform extends NestedDataComponent {
         };
 
         if (err.messages && err.messages.length) {
-          err.messages.forEach(({ message }) => createListItem(`${err.component.label}. ${message}`));
+          err.messages.forEach(({ message }) => createListItem(`${this.t(err.component.label)}. ${message}`));
         }
         else if (err) {
           const message = _.isObject(err) ? err.message || '' : err;


### PR DESCRIPTION
Labels are not currently translated when displayed at the top of the form