### PR TITLE
Fix/fjs 836 normalize value

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -167,7 +167,7 @@ export default class RadioComponent extends Field {
    * @return {*}
    */
   normalizeValue(value) {
-    const dataType = _.get(this.component, 'dataType', 'auto');
+    const dataType = this.component['dataType'] || 'auto';
     switch (dataType) {
       case 'auto':
         if (!isNaN(parseFloat(value)) && isFinite(value)) {


### PR DESCRIPTION
Fix for storage type normalization in Select component.

Ticket: https://trello.com/c/eG0E5gsm/836-fjs-836-selects-component-storage-type-is-not-performed-for-options-its-working-only-for-selected-option-when-saving-data-in-sub