### PR TITLE
Don't replace choices when adding not found values

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -1009,7 +1009,7 @@ export default class SelectComponent extends Field {
 
     if (notFoundValuesToAdd.length) {
       if (this.choices) {
-        this.choices.setChoices(notFoundValuesToAdd, 'value', 'label', true);
+        this.choices.setChoices(notFoundValuesToAdd, 'value', 'label');
       }
       else {
         notFoundValuesToAdd.map(notFoundValue => {


### PR DESCRIPTION
This reverts a change in commit 2ebcb4fcf67e332c2ab81f9e03d16f21710ca91e which replaces items in a select menu when adding new items. We've found this causes a problem with one of our menus ever since this commit, whereby it does not populate as expected.

I have tested, and this remedies the issue, but please note I was not able to get unit tests to run (I was getting `Error: Not supported at requireOrImport`) - hopefully my suggestion here does not have any unwanted side effects :)