### PR TITLE
stop video stream on destroy

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -679,4 +679,9 @@ export default class FileComponent extends Field {
       this.refs.fileBrowse.focus();
     }
   }
+
+  destroy() {
+    this.stopVideo();
+    super.destroy();
+  }
 }


### PR DESCRIPTION
If webcam video stream is active and the component is destroyed, the video stream does not stop (see issue https://github.com/formio/formio.js/issues/2633).  

This is a simple fix which calls `stopVideo` when the component is destroyed just to make sure to stop any active video stream.