### PR TITLE
Don't skip validation for disabled components

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2668,6 +2668,8 @@ export default class Component extends Element {
 
   shouldSkipValidation(data, dirty, row) {
     const rules = [
+      // Force valid if component is read-only
+      () => this.options.readOnly,
       // Check to see if we are editing and if so, check component persistence.
       () => this.isValueHidden(),
       // Force valid if component is hidden.

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2668,8 +2668,6 @@ export default class Component extends Element {
 
   shouldSkipValidation(data, dirty, row) {
     const rules = [
-      // Skip validatoin for disabled componoents.
-      () => this.shouldDisabled,
       // Check to see if we are editing and if so, check component persistence.
       () => this.isValueHidden(),
       // Force valid if component is hidden.


### PR DESCRIPTION
This reverts a change made in https://github.com/formio/formio.js/commit/129e5c8fcc81195dd5318fd726cbb2b680d14444 and is a fix for https://github.com/formio/formio.js/issues/2613.