### PR TITLE
VPAT-314 Removed role alert from error messages container

### DIFF
--- a/src/PDF.js
+++ b/src/PDF.js
@@ -276,7 +276,7 @@ export default class PDF extends Webform {
   showErrors(error, triggerEvent) {
     const helpBlock = document.getElementById('submit-error');
 
-    if (!helpBlock) {
+    if (!helpBlock && this.errors.length) {
       const p = this.ce('p', { class: 'help-block' });
 
       this.setContent(p, this.t('submitError'));

--- a/src/PDF.js
+++ b/src/PDF.js
@@ -294,10 +294,6 @@ export default class PDF extends Webform {
       helpBlock.remove();
     }
 
-    if (this.errors.length) {
-      this.focusOnComponent(this.errors[0].component.key);
-    }
-
     super.showErrors(error, triggerEvent);
   }
 }

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1045,7 +1045,6 @@ export default class Webform extends NestedDataComponent {
       this.alert = this.ce('div', {
         class: classes || `alert alert-${type}`,
         id: `error-list-${this.id}`,
-        role: 'alert'
       });
       if (message instanceof HTMLElement) {
         this.appendTo(message, this.alert);


### PR DESCRIPTION
Presence of this role in error section means screenreader announcements will get interrupted by error section announcement every time error section is redrawn, which should not be happening.