### PR TITLE
FJS-547: 

### DIFF
--- a/src/widgets/CalendarWidget.js
+++ b/src/widgets/CalendarWidget.js
@@ -102,11 +102,16 @@ export default class CalendarWidget extends InputWidget {
     this.settings.disableWeekdays ? this.settings.disable.push(this.disableWeekdays) : '';
     this.settings.disableFunction ? this.settings.disable.push(this.disableFunction) : '';
     this.settings.maxDate = getDateSetting(this.settings.maxDate);
+    this.settings.wasDefaultValueChanged = false;
+    this.settings.defaultValue = '';
     this.settings.altFormat = convertFormatToFlatpickr(this.settings.format);
     this.settings.dateFormat = convertFormatToFlatpickr(this.settings.dateFormat);
     this.settings.onChange = () => this.emit('update');
     this.settings.onClose = () => {
       this.closedOn = Date.now();
+      if (this.settings.wasDefaultValueChanged) {
+        this.calendar._input.value = this.settings.defaultValue;
+      }
       if (this.calendar) {
         this.emit('blur');
       }
@@ -127,7 +132,13 @@ export default class CalendarWidget extends InputWidget {
     if (this._input) {
       // Create a new flatpickr.
       this.calendar = new Flatpickr(this._input, this.settings);
-
+      this.calendar.altInput.addEventListener('input', (event) => {
+        if (event.target.value === '') {
+          this.settings.wasDefaultValueChanged = true;
+          this.settings.defaultValue = event.target.value;
+          this.calendar.clear();
+        }
+      });
       // Enforce the input mask of the format.
       this.setInputMask(this.calendar._input, convertFormatToMask(this.settings.format));
 


### PR DESCRIPTION
added event on alternative input change and, if its value is an empty string, flatpickr wouldnt override inputs value.
It's a bit ugly, but I guess it's the only way to save default value, since flatpickr overrirdes input before any of its callbacks. And onChange callback is not called when we change input directly.