### PR TITLE
Encode uri before a request

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -732,6 +732,8 @@ export default class Formio {
       opts = {};
     }
 
+    const encodedURI = encodeURI(url);
+
     const requestArgs = {
       url,
       method,
@@ -808,7 +810,7 @@ export default class Formio {
     }
 
     // Generate a cachekey.
-    const cacheKey = btoa(url);
+    const cacheKey = btoa(encodeURI(url));
 
     // Get the cached promise to save multiple loads.
     if (!opts.ignoreCache && method === 'GET' && Formio.cache.hasOwnProperty(cacheKey)) {
@@ -840,15 +842,17 @@ export default class Formio {
       options.body = JSON.stringify(data);
     }
 
+    // encode url
+    const encodedURL = encodeURI(url);
     // Allow plugins to alter the options.
-    options = Formio.pluginAlter('requestOptions', options, url);
+    options = Formio.pluginAlter('requestOptions', options, encodedURL);
     if (options.namespace || Formio.namespace) {
       opts.namespace = options.namespace ||  Formio.namespace;
     }
 
     const requestToken = options.headers['x-jwt-token'];
-    const result = Formio.pluginAlter('wrapFetchRequestPromise', Formio.fetch(url, options),
-      { url, method, data, opts }).then((response) => {
+    const result = Formio.pluginAlter('wrapFetchRequestPromise', Formio.fetch(encodedURL, options),
+      { encodedURL, method, data, opts }).then((response) => {
       // Allow plugins to respond.
       response = Formio.pluginAlter('requestResponse', response, Formio, data);
 


### PR DESCRIPTION
This adds url encoding to request made to an API. By encoding url, users will be able to enter any character in Unicode and not have to be limited to just ASCII, as `atob` and `btoa` methods throws a DOMException if the parameter passed to it is not valid base64 (so any character not matched with this regex [A-Za-z0-9+/=] will throw error). Encoding the url will escape any character not valid in  base64 with its base64 counterpart. 

Fix #2732 