### PR TITLE
FJS-908 Cancel action on button does not clear out the validation warning

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -997,6 +997,7 @@ export default class Webform extends NestedDataComponent {
   resetValue() {
     _.each(this.getComponents(), (comp) => (comp.resetValue()));
     this.setPristine(true);
+    this.redraw();
   }
 
   /**


### PR DESCRIPTION
Fix (Webform): reset button click didn't hide validation error messages