### PR TITLE
Choice.js dropdown opens now on first click

### DIFF
--- a/src/utils/ChoicesWrapper.js
+++ b/src/utils/ChoicesWrapper.js
@@ -51,7 +51,6 @@ class ChoicesWrapper extends Choices {
 
     this._onTabKey = this._onTabKey.bind(this);
     this.isDirectionUsing = false;
-    this.shouldOpenDropDown = true;
   }
 
   _handleButtonAction(activeItems, element) {
@@ -68,7 +67,6 @@ class ChoicesWrapper extends Choices {
       return;
     }
 
-    this.shouldOpenDropDown = true;
     super._handleButtonAction(activeItems, element);
   }
 
@@ -184,11 +182,6 @@ class ChoicesWrapper extends Choices {
   }
 
   showDropdown(...args) {
-    if (!this.shouldOpenDropDown) {
-      this.shouldOpenDropDown = true;
-      return;
-    }
-
     super.showDropdown(...args);
   }
 

--- a/src/utils/ChoicesWrapper.js
+++ b/src/utils/ChoicesWrapper.js
@@ -68,7 +68,7 @@ class ChoicesWrapper extends Choices {
       return;
     }
 
-    this.shouldOpenDropDown = false;
+    this.shouldOpenDropDown = true;
     super._handleButtonAction(activeItems, element);
   }
 


### PR DESCRIPTION
When clearing the selected item in a dropdown using `choice.js` and then clicking the dropdown, the dropdown didn't open. It only came into focus. 

With this change, the dropdown opens on the first click and not the second 

Closes #2801 