### PR TITLE
Update File.js for S3 image uploads

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -363,8 +363,8 @@ export default class FileComponent extends Field {
           window.resolveLocalFileSystemURL(success, (fileEntry) => {
               fileEntry.file((file) => {
                 var reader = new FileReader();
-                reader.onloadend = function() {
-                  var blob = new Blob([new Uint8Array(this.result)], { type: file.type });
+                reader.onloadend = (evt) => {
+                  var blob = new Blob([new Uint8Array(evt.target.result)], { type: file.type });
                   blob.name = file.name;
                   this.upload([blob]);
                 };
@@ -387,8 +387,8 @@ export default class FileComponent extends Field {
           window.resolveLocalFileSystemURL(success, (fileEntry) => {
               fileEntry.file((file) => {
                 var reader = new FileReader();
-                reader.onloadend = function() {
-                  var blob = new Blob([new Uint8Array(this.result)], { type: file.type });
+                reader.onloadend = (evt) => {
+                  var blob = new Blob([new Uint8Array(evt.target.result)], { type: file.type });
                   blob.name = file.name;
                   this.upload([blob]);
                 };

--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -362,9 +362,9 @@ export default class FileComponent extends Field {
         webViewCamera.getPicture((success) => {
           window.resolveLocalFileSystemURL(success, (fileEntry) => {
               fileEntry.file((file) => {
-                var reader = new FileReader();
+                let reader = new FileReader();
                 reader.onloadend = (evt) => {
-                  var blob = new Blob([new Uint8Array(evt.target.result)], { type: file.type });
+                  let blob = new Blob([new Uint8Array(evt.target.result)], { type: file.type });
                   blob.name = file.name;
                   this.upload([blob]);
                 };
@@ -386,9 +386,9 @@ export default class FileComponent extends Field {
         webViewCamera.getPicture((success) => {
           window.resolveLocalFileSystemURL(success, (fileEntry) => {
               fileEntry.file((file) => {
-                var reader = new FileReader();
+                let reader = new FileReader();
                 reader.onloadend = (evt) => {
-                  var blob = new Blob([new Uint8Array(evt.target.result)], { type: file.type });
+                  let blob = new Blob([new Uint8Array(evt.target.result)], { type: file.type });
                   blob.name = file.name;
                   this.upload([blob]);
                 };


### PR DESCRIPTION
Resolve issue with formio/formio.js#2874 whereby this.upload couldn't be invoked due to incorrect scoping. 

- Changed syntax to arrow function to ensure correct binding of 'this', allowing the upload function to be called from within reader.onloadend.
- Declare 'reader' and 'blob' as block scoped variables.