### PR TITLE
Added private download check for image load

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -85,6 +85,9 @@ export default class FileComponent extends Field {
   }
 
   loadImage(fileInfo) {
+    if (this.component.privateDownload) {
+      fileInfo.private = true;
+    }
     return this.fileService.downloadFile(fileInfo).then((result) => result.url);
   }
 


### PR DESCRIPTION
When file component is set up to use private download (i.e. when using [formio/formio-upload](https://github.com/formio/formio-upload)), if the component is set to display file as image, the image does not load as the private property in `fileInfo` is not set (thus setting an invalid file url in the image src).

When displaying file as image, the image `src` attribute is set here:

https://github.com/formio/formio.js/blob/54b34f234ee5948592986decebd4eb09b161d643/src/components/file/File.js#L441-L443

Which in turn calls the `loadImage` method.  This pull request adds a private download check so that the component's file service returns the correct file download url.