### PR TITLE
Fix/validation error messages contain html chars

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -363,6 +363,10 @@ export function setActionProperty(component, action, result, row, data, instance
  * @returns {string}
  */
 export function unescapeHTML(str) {
+  if (!global.window) {
+    return str;
+  }
+
   const doc = new global.window.DOMParser().parseFromString(str, 'text/html');
   return doc.documentElement.textContent;
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -358,6 +358,16 @@ export function setActionProperty(component, action, result, row, data, instance
 }
 
 /**
+ * Unescape HTML characters like &lt, &gt, &amp and etc.
+ * @param str
+ * @returns {string}
+ */
+export function unescapeHTML(str) {
+  const doc = new DOMParser().parseFromString(str, 'text/html');
+  return doc.documentElement.textContent;
+}
+
+/**
  * Make a filename guaranteed to be unique.
  * @param name
  * @param template

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -363,7 +363,7 @@ export function setActionProperty(component, action, result, row, data, instance
  * @returns {string}
  */
 export function unescapeHTML(str) {
-  const doc = new DOMParser().parseFromString(str, 'text/html');
+  const doc = new global.window.DOMParser().parseFromString(str, 'text/html');
   return doc.documentElement.textContent;
 }
 

--- a/src/utils/utils.unit.js
+++ b/src/utils/utils.unit.js
@@ -815,5 +815,10 @@ describe('Util Tests', () => {
         done(error);
       }
     });
+
+    it('Should return string without HTML characters', () => {
+      const unescapedString = utils.unescapeHTML('&lt;p&gt;ampersand &amp; &#34;quotes&#34; test&lt;&#47;p&gt;');
+      expect(unescapedString).to.equal('<p>ampersand & "quotes" test</p>');
+    });
   });
 });

--- a/src/validator/Validator.js
+++ b/src/validator/Validator.js
@@ -6,7 +6,7 @@ import {
   getDateSetting,
   escapeRegExCharacters,
   interpolate,
-  convertFormatToMoment, getArrayFromComponentPath
+  convertFormatToMoment, getArrayFromComponentPath, unescapeHTML
 } from '../utils/utils';
 import moment from 'moment';
 import NativePromise from 'native-promise-only';
@@ -814,7 +814,7 @@ class ValidationChecker {
 
     const processResult = result => {
       return result ? {
-        message: _.get(result, 'message', result),
+        message: unescapeHTML(_.get(result, 'message', result)),
         level: _.get(result, 'level') === 'warning' ? 'warning' : 'error',
         path: getArrayFromComponentPath(component.path || ''),
         context: {


### PR DESCRIPTION
Relates to the issue discover in angular material.
Before:
![image](https://user-images.githubusercontent.com/54106407/84890501-2b401800-b0a3-11ea-8826-b03e0eb6eb2f.png)

After:
![image](https://user-images.githubusercontent.com/54106407/84890028-80c7f500-b0a2-11ea-88c4-be731e430bb9.png)

Is safe for XSS attacks, works for IE since 10th version.