### PR TITLE
Enable localization of field prefix and suffix

### DIFF
--- a/src/templates/bootstrap/input/form.ejs
+++ b/src/templates/bootstrap/input/form.ejs
@@ -4,7 +4,7 @@
 {% if (ctx.component.prefix) { %}
 <div class="input-group-prepend" ref="prefix">
   <span class="input-group-text">
-    {{ctx.component.prefix}}
+    {{ ctx.t(ctx.component.prefix) }}
   </span>
 </div>
 {% } %}
@@ -28,7 +28,7 @@
 {% if (ctx.component.suffix) { %}
 <div class="input-group-append" ref="suffix">
   <span class="input-group-text">
-    {{ctx.component.suffix}}
+    {{ ctx.t(ctx.component.suffix) }}
   </span>
 </div>
 {% } %}


### PR DESCRIPTION
My team discovered recently that they were adding localizations for field prefixes and suffixes but not seeing them translated. Turns out that the `input` template wasn't wrapping the prefix and suffix text in `ctx.t()`, so they're un-localizable!

Here's a fix. ❤️ 