### PR TITLE
Use this.i18next instance instead of imported module

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -280,11 +280,11 @@ export default class Webform extends NestedDataComponent {
   set language(lang) {
     return new NativePromise((resolve, reject) => {
       this.options.language = lang;
-      if (i18next.language === lang) {
+      if (this.i18next.language === lang) {
         return resolve();
       }
       try {
-        i18next.changeLanguage(lang, (err) => {
+        this.i18next.changeLanguage(lang, (err) => {
           if (err) {
             return reject(err);
           }
@@ -308,7 +308,7 @@ export default class Webform extends NestedDataComponent {
    * @return {*}
    */
   addLanguage(code, lang, active = false) {
-    i18next.addResourceBundle(code, 'translation', lang, true, true);
+    this.i18next.addResourceBundle(code, 'translation', lang, true, true);
     if (active) {
       this.language = code;
     }
@@ -319,19 +319,19 @@ export default class Webform extends NestedDataComponent {
    * @returns {*}
    */
   localize() {
-    if (i18next.initialized) {
-      return NativePromise.resolve(i18next);
+    if (this.i18next.initialized) {
+      return NativePromise.resolve(this.i18next);
     }
-    i18next.initialized = true;
+    this.i18next.initialized = true;
     return new NativePromise((resolve, reject) => {
       try {
-        i18next.init(this.options.i18n, (err) => {
+        this.i18next.init(this.options.i18n, (err) => {
           // Get language but remove any ;q=1 that might exist on it.
-          this.options.language = i18next.language.split(';')[0];
+          this.options.language = this.i18next.language.split(';')[0];
           if (err) {
             return reject(err);
           }
-          resolve(i18next);
+          resolve(this.i18next);
         });
       }
       catch (err) {

--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import _ from 'lodash';
 import each from 'lodash/each';
+import i18next from 'i18next';
 import Harness from '../test/harness';
 import FormTests from '../test/forms';
 import Webform from './Webform';
@@ -393,6 +394,44 @@ describe('Webform tests', () => {
     simpleForm.submit().then((submission) => {
       assert.deepEqual(submission.data, { name: 'noname' });
       done();
+    });
+  });
+
+  it('Should not mutate the global i18next if it gets an instance', async function() {
+    await i18next.init({ lng: 'en' });
+    const instance = i18next.createInstance();
+
+    const formElement = document.createElement('div');
+    const translateForm = new Webform(formElement, {
+      template: 'bootstrap3',
+      language: 'es',
+      i18next: instance,
+      i18n: {
+        es: {
+          'Default Label': 'Spanish Label'
+        }
+      }
+    });
+
+    return translateForm.setForm({
+      title: 'Translate Form',
+      components: [
+        {
+          type: 'textfield',
+          label: 'Default Label',
+          key: 'myfield',
+          input: true,
+          inputType: 'text',
+          validate: {}
+        }
+      ]
+    }).then(() => {
+      assert.equal(i18next.language, 'en');
+      assert.equal(translateForm.i18next.language, 'es');
+      assert.equal(translateForm.i18next, instance);
+
+      const label = formElement.querySelector('.control-label');
+      assert.equal(label.innerHTML.trim(), 'Spanish Label');
     });
   });
 


### PR DESCRIPTION
We've been trying to render multiple instances of the same form in different languages, but after digging around I discovered that Webform mutates the imported `i18next` module in a bunch of places rather than using its own instance (`this.i18next`), which can be passed in via `options.i18next`.

This adds a test for mutation of the imported `i18next` when Webform gets `options.i18next`, and updates the Webform class to always refer to its own instance.