### PR TITLE
noNewModal = true to skip new component modal

### DIFF
--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -293,7 +293,7 @@ export default class PDFBuilder extends WebformBuilder {
           width: schema.width
         };
 
-        if (!this.options.noNewEdit && !component.component.noNewModal) {
+        if (!this.options.noNewEdit && !component.component.noNewEdit) {
           this.editComponent(component.component, this.webform.iframeElement);
         }
         this.emit('updateComponent', component.component);
@@ -444,7 +444,7 @@ export default class PDFBuilder extends WebformBuilder {
     this.webform.addComponent(schema, {}, null, true);
     this.webform.postMessage({ name: 'addElement', data: schema });
 
-    this.emit('addComponent', schema, this.webform, schema.key, this.webform.component.components.length, !this.options.noNewEdit && !schema.noNewModal);
+    this.emit('addComponent', schema, this.webform, schema.key, this.webform.component.components.length, !this.options.noNewEdit && !schema.noNewEdit);
 
     // Delete the stored drop event now that it's been handled
     this.dropEvent = null;

--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -128,7 +128,7 @@ export default class PDFBuilder extends WebformBuilder {
         'hiddenFileInputElement': 'single',
         'uploadError': 'single',
       });
-      this.addEventListener(this.refs['pdf-upload-button'], 'click',(event) => {
+      this.addEventListener(this.refs['pdf-upload-button'], 'click', (event) => {
         event.preventDefault();
       });
 
@@ -293,7 +293,7 @@ export default class PDFBuilder extends WebformBuilder {
           width: schema.width
         };
 
-        if (!this.options.noNewEdit) {
+        if (!this.options.noNewEdit && !component.component.noNewModal) {
           this.editComponent(component.component, this.webform.iframeElement);
         }
         this.emit('updateComponent', component.component);
@@ -369,7 +369,7 @@ export default class PDFBuilder extends WebformBuilder {
         this.removeEventListener(el, 'dragstart');
         this.removeEventListener(el, 'dragend');
         this.addEventListener(el, 'dragstart', this.onDragStart.bind(this), true);
-        this.addEventListener(el, 'dragend',   this.onDragEnd  .bind(this), true);
+        this.addEventListener(el, 'dragend', this.onDragEnd.bind(this), true);
         this.addEventListener(el, 'drag', (e) => {
           e.target.style.cursor = 'none';
         });
@@ -384,7 +384,7 @@ export default class PDFBuilder extends WebformBuilder {
 
     const iframeRect = getElementRect(this.webform.refs.iframeContainer);
     this.refs.iframeDropzone.style.height = iframeRect && iframeRect.height ? `${iframeRect.height}px` : '1000px';
-    this.refs.iframeDropzone.style.width  = iframeRect && iframeRect.width  ? `${iframeRect.width }px` : '100%';
+    this.refs.iframeDropzone.style.width = iframeRect && iframeRect.width ? `${iframeRect.width}px` : '100%';
   }
 
   onDragStart(e) {
@@ -444,7 +444,7 @@ export default class PDFBuilder extends WebformBuilder {
     this.webform.addComponent(schema, {}, null, true);
     this.webform.postMessage({ name: 'addElement', data: schema });
 
-    this.emit('addComponent', schema, this.webform, schema.key, this.webform.component.components.length, !this.options.noNewEdit);
+    this.emit('addComponent', schema, this.webform, schema.key, this.webform.component.components.length, !this.options.noNewEdit && !schema.noNewModal);
 
     // Delete the stored drop event now that it's been handled
     this.dropEvent = null;

--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -781,7 +781,7 @@ export default class WebformBuilder extends Component {
       parent.addChildComponent(info, element, target, source, sibling);
     }
 
-    if (isNew && !this.options.noNewEdit && !info.noNewModal) {
+    if (isNew && !this.options.noNewEdit && !info.noNewEdit) {
       this.editComponent(info, target, isNew);
     }
 
@@ -811,8 +811,8 @@ export default class WebformBuilder extends Component {
     }
 
     return rebuild.then(() => {
-      this.emit('addComponent', info, parent, path, index, isNew && !this.options.noNewEdit && !info.noNewModal);
-      if (!isNew || this.options.noNewEdit || info.noNewModal) {
+      this.emit('addComponent', info, parent, path, index, isNew && !this.options.noNewEdit && !info.noNewEdit);
+      if (!isNew || this.options.noNewEdit || info.noNewEdit) {
         this.emit('change', this.form);
       }
     });

--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -14,7 +14,7 @@ import Templates from './templates/Templates';
 require('./components/builder');
 
 export default class WebformBuilder extends Component {
-// eslint-disable-next-line max-statements
+  // eslint-disable-next-line max-statements
   constructor() {
     let element, options;
     if (arguments[0] instanceof HTMLElement || arguments[1]) {
@@ -326,7 +326,7 @@ export default class WebformBuilder extends Component {
             this.groups.resource = {
               title: resourceOptions ? resourceOptions.title : 'Existing Resource Fields',
               key: 'resource',
-              weight: resourceOptions ? resourceOptions.weight :  50,
+              weight: resourceOptions ? resourceOptions.weight : 50,
               subgroups: [],
               components: [],
               componentOrder: []
@@ -581,7 +581,7 @@ export default class WebformBuilder extends Component {
                   groupId === clickedParentId ||
                   groupIndex === index
                 )
-                ? 'inherit' : 'none';
+                  ? 'inherit' : 'none';
             });
           }, true);
         });
@@ -688,8 +688,8 @@ export default class WebformBuilder extends Component {
     let tabIndex = 0;
     switch (parent.type) {
       case 'table':
-        tableRowIndex = _.findIndex(parent.rows, row => row.some(column => column.components.some(comp => comp.key  === component.key)));
-        tableColumnIndex = _.findIndex(parent.rows[tableRowIndex], (column => column.components.some(comp => comp.key  === component.key)));
+        tableRowIndex = _.findIndex(parent.rows, row => row.some(column => column.components.some(comp => comp.key === component.key)));
+        tableColumnIndex = _.findIndex(parent.rows[tableRowIndex], (column => column.components.some(comp => comp.key === component.key)));
         path = `rows[${tableRowIndex}][${tableColumnIndex}].components`;
         break;
       case 'columns':
@@ -697,7 +697,7 @@ export default class WebformBuilder extends Component {
         path = `columns[${columnIndex}].components`;
         break;
       case 'tabs':
-        tabIndex = _.findIndex(parent.components, tab => tab.components.some(comp => comp.key  === component.key));
+        tabIndex = _.findIndex(parent.components, tab => tab.components.some(comp => comp.key === component.key));
         path = `components[${tabIndex}].components`;
         break;
     }
@@ -781,7 +781,7 @@ export default class WebformBuilder extends Component {
       parent.addChildComponent(info, element, target, source, sibling);
     }
 
-    if (isNew && !this.options.noNewEdit) {
+    if (isNew && !this.options.noNewEdit && !info.noNewModal) {
       this.editComponent(info, target, isNew);
     }
 
@@ -811,8 +811,8 @@ export default class WebformBuilder extends Component {
     }
 
     return rebuild.then(() => {
-      this.emit('addComponent', info, parent, path, index, isNew && !this.options.noNewEdit);
-      if (!isNew || this.options.noNewEdit) {
+      this.emit('addComponent', info, parent, path, index, isNew && !this.options.noNewEdit && !info.noNewModal);
+      if (!isNew || this.options.noNewEdit || info.noNewModal) {
         this.emit('change', this.form);
       }
     });
@@ -917,14 +917,16 @@ export default class WebformBuilder extends Component {
   updateComponent(component, changed) {
     // Update the preview.
     if (this.preview) {
-      this.preview.form = { components: [_.omit(component, [
-        'hidden',
-        'conditional',
-        'calculateValue',
-        'logic',
-        'autofocus',
-        'customConditional',
-      ])] };
+      this.preview.form = {
+        components: [_.omit(component, [
+          'hidden',
+          'conditional',
+          'calculateValue',
+          'logic',
+          'autofocus',
+          'customConditional',
+        ])]
+      };
       const previewElement = this.componentEdit.querySelector('[ref="preview"]');
       if (previewElement) {
         this.setContent(previewElement, this.preview.render());
@@ -1061,7 +1063,7 @@ export default class WebformBuilder extends Component {
       }
       const rebuild = parentComponent.rebuild() || NativePromise.resolve();
       return rebuild.then(() => {
-        const schema = parentContainer ? parentContainer[index]: (comp ? comp.schema : []);
+        const schema = parentContainer ? parentContainer[index] : (comp ? comp.schema : []);
         this.emit('saveComponent',
           schema,
           originalComp,
@@ -1136,8 +1138,8 @@ export default class WebformBuilder extends Component {
         componentJson: instance.component
       },
     } : {
-      data: instance.component,
-    };
+        data: instance.component,
+      };
 
     if (this.preview) {
       this.preview.destroy();


### PR DESCRIPTION
Add this flag to the predefined components to skip the modal popup.
Referring to the example:
https://formio.github.io/formio.js/app/examples/custombuilder.html

components: {
        firstName: {
          title: 'First Name',
          key: 'firstName',
          icon: 'terminal',
          schema: {
            label: 'First Name',
            type: 'textfield',
            key: 'firstName',
            input: true,
            **noNewModal: true**
          }
        },...

The components under the custom group can have the property noNewModal = true if you want to skip the modal.
Any other component that doesn't have the flag (ex. basic, data, etc) keep their regular behavior (modal popup when dragged/dropped on the form)
