### PR TITLE
Localize alert messages, simplify t() methods

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -367,17 +367,11 @@ export default class Element {
   /**
    * Translate a text using the i18n system.
    *
-   * @param {string} text - The i18n identifier.
+   * @param {string|Array<string>} text - The i18n identifier.
    * @param {Object} params - The i18n parameters to use for translation.
    */
-  t(text, params) {
-    params = params || {};
-    params.nsSeparator = '::';
-    params.keySeparator = '.|.';
-    params.pluralSeparator = '._.';
-    params.contextSeparator = '._.';
-    const translated = this.i18next.t(text, params);
-    return translated || text;
+  t(text, ...args) {
+    return this.i18next.t(text, ...args);
   }
 
   /**

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 import compareVersions from 'compare-versions';
 import EventEmitter from './EventEmitter';
 import i18next from 'i18next';
+import i18nDefaults from './i18n';
 import Formio from './Formio';
 import NativePromise from 'native-promise-only';
 import Components from './components/Components';
@@ -85,7 +86,7 @@ export default class Webform extends NestedDataComponent {
     /**
      * The i18n configuration for this component.
      */
-    let i18n = require('./i18n').default;
+    let i18n = i18nDefaults;
     if (options && options.i18n && !options.i18nReady) {
       // Support legacy way of doing translations.
       if (options.i18n.resources) {

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1180,8 +1180,11 @@ export default class Webform extends NestedDataComponent {
         };
 
         if (err.messages && err.messages.length) {
-          const errLabel = this.t(err.component.label);
-          err.messages.forEach(({ message }, index) => createListItem(`${errLabel}. ${message}`, index));
+          const { component } = err;
+          err.messages.forEach(({ message }, index) => {
+            const text = this.t('alertMessage', { label: component.label, message });
+            createListItem(text, index);
+          });
         }
         else if (err) {
           const message = _.isObject(err) ? err.message || '' : err;

--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -33,7 +33,7 @@ describe('Webform tests', () => {
       assert.equal(formWithPattern.element.querySelector('.formio-component-textField').querySelectorAll('.error').length, 1);
       assert.equal(formWithPattern.errors[0].messages.length, 1);
       assert.equal(formWithPattern.errors[0].messages[0].message, 'Text Field is required');
-      assert.equal(formWithPattern.element.querySelector('[ref="errorRef"]').textContent, 'Text Field. Text Field is required');
+      assert.equal(formWithPattern.element.querySelector('[ref="errorRef"]').textContent, 'Text Field: Text Field is required');
       done();
     }, 500);
     })

--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -187,6 +187,42 @@ describe('Webform tests', () => {
     }).catch(done);
   });
 
+  it('Should translate form errors in alerts', () => {
+    const formElement = document.createElement('div');
+    const form = new Webform(formElement, {
+      language: 'es',
+      i18n: {
+        es: {
+          alertMessage: '{{message}}',
+          required: '{{field}} es obligatorio'
+        }
+      }
+    });
+
+    return form.setForm({
+      components: [
+        {
+          type: 'textfield',
+          label: 'Field Label',
+          key: 'myfield',
+          input: true,
+          inputType: 'text',
+          validate: {
+            required: true
+          }
+        }
+      ]
+    })
+      .then(() => form.submit())
+      .catch(() => {
+        // console.warn('nooo:', error)
+      })
+      .then(() => {
+        const ref = formElement.querySelector('[ref="errorRef"]');
+        assert.equal(ref.textContent, 'Field Label es obligatorio');
+      });
+  });
+
   it('Should translate a form after instantiate', done => {
     const formElement = document.createElement('div');
     const translateForm = new Webform(formElement, {

--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -187,6 +187,15 @@ describe('Webform tests', () => {
     }).catch(done);
   });
 
+  it('Should treat double colons as i18next namespace separators', () => {
+    const formElement = document.createElement('div');
+    const form = new Webform(formElement);
+
+    const str = 'Test: this is only a test';
+    assert.equal(form.t(str), str);
+    assert.equal(form.t(`Namespace::${str}`), str);
+  });
+
   it('Should translate form errors in alerts', () => {
     const formElement = document.createElement('div');
     const form = new Webform(formElement, {

--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -33,6 +33,7 @@ describe('Webform tests', () => {
       assert.equal(formWithPattern.element.querySelector('.formio-component-textField').querySelectorAll('.error').length, 1);
       assert.equal(formWithPattern.errors[0].messages.length, 1);
       assert.equal(formWithPattern.errors[0].messages[0].message, 'Text Field is required');
+      assert.equal(formWithPattern.element.querySelector('[ref="errorRef"]').textContent, 'Text Field. Text Field is required');
       done();
     }, 500);
     })

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -695,20 +695,14 @@ export default class Component extends Element {
    * @param {string} text - The i18n identifier.
    * @param {Object} params - The i18n parameters to use for translation.
    */
-  t(text, params) {
+  t(text, params = {}, ...args) {
     if (!text) {
       return '';
     }
-    params = params || {};
     params.data = this.rootValue;
     params.row = this.data;
     params.component = this.component;
-    params.nsSeparator = '::';
-    params.keySeparator = '.|.';
-    params.pluralSeparator = '._.';
-    params.contextSeparator = '._.';
-    const translated = this.i18next.t(text, params);
-    return translated || text;
+    return super.t(text, params, ...args);
   }
 
   labelIsHidden() {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,6 +7,7 @@ export default {
   resources: {
     en: {
       translation: {
+        alertMessage: '{{label}}. {{message}}',
         complete: 'Submission Complete',
         error: 'Please fix the following errors before submitting.',
         submitError: 'Please check the form and correct all errors before submitting.',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,7 @@ export default {
   resources: {
     en: {
       translation: {
-        alertMessage: '{{label}}. {{message}}',
+        alertMessage: '{{label}}: {{message}}',
         complete: 'Submission Complete',
         error: 'Please fix the following errors before submitting.',
         submitError: 'Please check the form and correct all errors before submitting.',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,5 +1,9 @@
 export default {
   lng: 'en',
+  nsSeparator: '::',
+  keySeparator: '.|.',
+  pluralSeparator: '._.',
+  contextSeparator: '._.',
   resources: {
     en: {
       translation: {


### PR DESCRIPTION
This adds a new `alertMessage` localization string for the messages listed in the alert element displayed when validations fail:

![image](https://user-images.githubusercontent.com/113896/85341624-7b511d00-b49d-11ea-8d1b-55214e45efac.png)

The default value was `{{label}}. {{message}}`, but I've swapped out the period for a colon (`{{label}}: {{message}}`) since it sounds like [the period was a typo](https://github.com/formio/formio.js/issues/2627#issuecomment-630862768) anyway. The string gets `label` and `message` placeholder values (which can easily be added to [here](https://github.com/shawnbot/formio.js/blob/4574491b6eab9ef2d112ac667686447fb4570c3b/src/Webform.js#L1185)). I've included a test that localizes it as just `{{message}}` so that the text is just the validation message without the redundant component label, which I believe addresses @darabi's suggestion in https://github.com/formio/formio.js/issues/2627#issuecomment-631239557. (I would suggest simply using `{{message}}` as the default, but that feels like a breaking change to me.)

### Simpler, better `t()` methods
In this PR I've also simplified the Element and Component classes' `t()` methods so that they don't set i18next options each time, and I've moved those options to the `i18n.js` option defaults object. It doesn't look there actually are any tests for these options, but I think that #2972 solves the bug that repeatedly passing these options was meant to work around. However, tests to make sure that both 1) the default options (particularly `nsSeparator`) are respected and 2) they can be overridden via `i18n: { ...options }` would probably be good to round this out.

The big (but not, AFAIK, breaking) change this introduces is that you can now call `t()` with an array of strings, each of which [i18next tries to localize and falls back on the next value](https://www.i18next.com/principles/fallback#calling-with-fallback-keys) if none is found. This makes it much easier to localize form labels and descriptions in custom templates like so:

```diff
- ctx.t(ctx.component.label)
+ ctx.t([`components.${ctx.component.key}.label`, ctx.component.label])
```

which you could localize more explicitly in your `i18n` option object like this:

```js
i18n: {
  es: {
    components: {
      firstName: { label: 'Nombre' },
      lastName: { label: 'Apellido' }
    }
  }
}
```