### PR TITLE
Revert "Fix (Wizard): page title in navigation is not updated"

### DIFF
--- a/src/WizardBuilder.js
+++ b/src/WizardBuilder.js
@@ -60,9 +60,8 @@ export default class WizardBuilder extends WebformBuilder {
     // Wizard pages don't replace themselves in the right array. Do that here.
     this.on('saveComponent', (component, originalComponent) => {
       const webformComponents = this.webform.components.map(({ component }) => component);
-      const formComponentIndex = this._form.components.findIndex((comp) => originalComponent.key === comp.key);
-      if (formComponentIndex !== -1) {
-        this._form.components[formComponentIndex] = component;
+      if (this._form.components.includes(originalComponent)) {
+        this._form.components[this._form.components.indexOf(originalComponent)] = component;
         this.rebuild();
       }
       else if (webformComponents.includes(originalComponent)) {


### PR DESCRIPTION
Reverts formio/formio.js#2776

This caused an issue where wizard pages would override the first page if the panels have the same key (legacy wizards such as https://humanresources.form.io/benefits)