### PR TITLE
Retain key if provided when drag/dropping an element

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -669,6 +669,7 @@ export default class WebformBuilder extends Component {
 
     if (info) {
       info.key = _.camelCase(
+        info.key ||
         info.title ||
         info.label ||
         info.placeholder ||


### PR DESCRIPTION
When you create a [custom builder](https://formio.github.io/formio.js/app/examples/custombuilder.html) with predefined components, you want to preserve their key. When they are dropped in the form, their key is regenerated.
This PR adds a line to retain the key if provided