### PR TITLE
Pass "locale" (not "language") Flatpickr setting

### DIFF
--- a/src/components/datetime/DateTime.js
+++ b/src/components/datetime/DateTime.js
@@ -90,7 +90,7 @@ export default class DateTimeComponent extends Input {
       timezone,
       displayInTimezone: _.get(this.component, 'displayInTimezone', 'viewer'),
       submissionTimezone: this.submissionTimezone,
-      language: this.options.language,
+      locale: this.options.language,
       useLocaleSettings: _.get(this.component, 'useLocaleSettings', false),
       allowInput: _.get(this.component, 'allowInput', true),
       mode: 'single',


### PR DESCRIPTION
Flatpickr doesn't do anything with the `language` option passed here:

https://github.com/formio/formio.js/blob/60a9cb2c7a7107c1f2a83ed4f93766e9d95dde91/src/components/datetime/DateTime.js#L93

It does, however, [respect the `locale` option](https://flatpickr.js.org/localization/).

Fixes #3130.