### PR TITLE
Initialize Column with only 1 element

### DIFF
--- a/src/components/columns/Columns.js
+++ b/src/components/columns/Columns.js
@@ -8,8 +8,7 @@ export default class ColumnsComponent extends NestedComponent {
       key: 'columns',
       type: 'columns',
       columns: [
-        { components: [], width: 6, offset: 0, push: 0, pull: 0, size: 'md' },
-        { components: [], width: 6, offset: 0, push: 0, pull: 0, size: 'md' }
+        { components: [], width: 12, offset: 0, push: 0, pull: 0, size: 'md' }
       ],
       clearOnHide: false,
       input: false,


### PR DESCRIPTION
The column component should be initialized with 1 element instead of two, because otherwise you won't be able to remove and leave it with only 1 column