### PR TITLE
FJS-1167-Fix-textarea-readonly-disable-rendering-behavior

### DIFF
--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -64,13 +64,6 @@ export default class TextAreaComponent extends TextFieldComponent {
     const info = this.inputInfo;
     info.attr = info.attr || {};
     info.content = value;
-    if (this.options.readOnly || this.disabled) {
-      return this.renderTemplate('well', {
-        children: '<div ref="input" class="formio-editor-read-only-content"></div>',
-        nestedKey: this.key,
-        value
-      });
-    }
 
     return this.renderTemplate('input', {
       prefix: this.prefix,


### PR DESCRIPTION
Hello,

Regarding issue FJS-1167: https://github.com/formio/formio.js/issues/3145

I propose this fix (remove specific rendering when textarea is in readOnly or disable). As the component have the disabled property by default when disable or readOnly, there is no need for a custom rendering for the component.

Hope this will help.
Regards,
Grellier Mathieu