### PR TITLE
Resolves #3178 - Fix addTemplate/extendTemplate behaviour.

### DIFF
--- a/src/templates/Templates.js
+++ b/src/templates/Templates.js
@@ -10,11 +10,11 @@ export default class Templates {
   }
 
   static addTemplate(name, template) {
-    Templates.templates[name] = template;
+    Templates.current[name] = template;
   }
 
   static extendTemplate(name, template) {
-    Templates.templates[name] = _.merge({}, Templates.templates[name], template);
+    Templates.current[name] = _.merge({}, Templates.current[name], template);
   }
 
   static setTemplate(name, template) {

--- a/src/templates/Templates.unit.js
+++ b/src/templates/Templates.unit.js
@@ -1,3 +1,5 @@
+import Templates from './Templates';
+
 const renders = require('../../test/renders');
 const forms = require('../../test/formtest');
 const pretty = require('pretty');
@@ -122,5 +124,29 @@ describe('Rendering Tests', () => {
         });
       });
     });
+  });
+});
+
+describe('Issues', () => {
+  it('has resolved issue #3178', () => {
+    Templates.addTemplate('test', {
+      form: 'test component'
+    });
+
+    Templates.extendTemplate('test', {
+      extend: 'extend',
+    });
+
+    class TestComponent extends Components.components.base {
+      render() {
+        return super.render(this.renderTemplate('test', {}));
+      }
+    }
+
+    const html = new TestComponent().render();
+    const rendered = html.includes('test component');
+
+    assert.equal(Templates.current.test.extend, 'extend');
+    assert.equal(rendered, true);
   });
 });


### PR DESCRIPTION
`Templates.addTemplate`/`Templates.extendTemplate` seemed to incorrectly assign custom template (properties) to an object within the library section of templates. Instead of to the current library (see #3178). This resolves this issue and adds an additional test.