### PR TITLE
Fix formio.js file not loading in IE

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -195,8 +195,7 @@ export default class SelectComponent extends Field {
 
     if (data.data) {
       // checking additional fields in the template for the selected Entire Object option
-      const matchResult = this.component.template.match(/(?<=item\.data.)\w*/g);
-      const hasNestedFields = matchResult && matchResult[0];
+      const hasNestedFields = /item\.data\.\w*/g.test(this.component.template);
       data.data = this.isEntireObjectDisplay() && _.isObject(data.data) && !hasNestedFields
         ? JSON.stringify(data.data)
         : data.data;


### PR DESCRIPTION
Fix check for nested fields regex (positive lookbehind is not supported and throws a syntax error in IE)