### PR TITLE
Fix typo in class name in align.ejs.

### DIFF
--- a/src/templates/bootstrap/field/align.ejs
+++ b/src/templates/bootstrap/field/align.ejs
@@ -16,7 +16,7 @@
     </div>
   {% } %}
 
-  <div class="filed-content" style="{{ctx.contentStyles}}">
+  <div class="field-content" style="{{ctx.contentStyles}}">
     {{ctx.element}}
   </div>
 </div>


### PR DESCRIPTION
I think this must be a typo. The class "filed-content" is used nowhere.