### PR TITLE
Asking for components removal (React FormIO #334)

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -959,15 +959,16 @@ export default class WebformBuilder extends Component {
       return;
     }
     let remove = true;
-    if (
-      !component.skipRemoveConfirm &&
+    const removingComponentsGroup = !component.skipRemoveConfirm &&
       (
         (Array.isArray(component.components) && component.components.length) ||
         (Array.isArray(component.rows) && component.rows.length) ||
         (Array.isArray(component.columns) && component.columns.length)
-      )
-    ) {
-      const message = 'Removing this component will also remove all of its children. Are you sure you want to do this?';
+      );
+
+    if (this.options.askForComponentsRemoval || removingComponentsGroup) {
+      const message = removingComponentsGroup ? 'Removing this component will also remove all of its children. Are you sure you want to do this?'
+        : 'Are you sure you want to remove this component?';
       remove = window.confirm(this.t(message));
     }
     if (!original) {

--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -966,7 +966,7 @@ export default class WebformBuilder extends Component {
         (Array.isArray(component.columns) && component.columns.length)
       );
 
-    if (this.options.askForComponentsRemoval || removingComponentsGroup) {
+    if (this.options.alwaysConfirmComponentRemoval || removingComponentsGroup) {
       const message = removingComponentsGroup ? 'Removing this component will also remove all of its children. Are you sure you want to do this?'
         : 'Are you sure you want to remove this component?';
       remove = window.confirm(this.t(message));


### PR DESCRIPTION
Fixing FormIO React [item #334](https://github.com/formio/react-formio/issues/334)

Added 'askForComponentsRemoval' parameter to FormBuilder options. When set, there's always a question asked before removing any component from the FormBuilder.
Otherwise, it behaves like previously, so only asking when removing "grouping" containers (columns etc.).
