### PR TITLE
Allow 0 for labelWidth and labelMargin.

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -615,11 +615,13 @@ export default class Component extends Element {
   }
 
   get labelWidth() {
-    return this.component.labelWidth || 30;
+    const width = this.component.labelWidth;
+    return width >= 0 ? width : 30;
   }
 
   get labelMargin() {
-    return this.component.labelMargin || 3;
+    const margin = this.component.labelMargin;
+    return margin >= 0 ? margin : 3;
   }
 
   get isAdvancedLabel() {


### PR DESCRIPTION
Hi!

I think labelWidth and labelMargin should allow 0 as a value. At least labelMargin should work with 0.
~~My changes also constrain the properties to a number because a string compared to a number ("..." >= 0) will always be false.~~
Edit: actually never mind, because of implicit conversion "2" >= 0 gives true.

What do you think? :)