### PR TITLE
Tabs: indicate some of components on tab is invalid

### DIFF
--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -92,6 +92,7 @@ export default class TabsComponent extends NestedComponent {
 
   attach(element) {
     this.loadRefs(element, { [this.tabLinkKey]: 'multiple', [this.tabKey]: 'multiple', [this.tabLikey]: 'multiple' });
+    ['change', 'error'].forEach(event => this.on(event, this.handleTabsValidation.bind(this)));
     const superAttach = super.attach(element);
     this.refs[this.tabLinkKey].forEach((tabLink, index) => {
       this.addEventListener(tabLink, 'click', (event) => {
@@ -160,5 +161,45 @@ export default class TabsComponent extends NestedComponent {
     if (tabIndex !== -1) {
       this.setTab(tabIndex);
     }
+  }
+
+  setErrorClasses(elements) {
+    elements.forEach((element) => {
+      this.addClass(element, 'is-invalid');
+      if (this.options.highlightErrors) {
+        this.addClass(element, 'tab-error');
+      }
+      else {
+        this.addClass(element, 'has-error');
+      }
+    });
+  }
+
+  clearErrorClasses(elements) {
+    elements.forEach((element) => {
+      this.removeClass(element, 'is-invalid');
+      this.removeClass(element, 'tab-error');
+      this.removeClass(element, 'has-error');
+    });
+  }
+
+  handleTabsValidation() {
+    if (!this.refs[this.tabLinkKey] || !this.refs[this.tabLinkKey].length || !this.tabs.length) {
+      return;
+    }
+
+    this.clearErrorClasses(this.refs[this.tabLinkKey]);
+
+    const invalidTabsIndexes = this.tabs.reduce((invalidTabs, tab, tabIndex) => {
+      const hasComponentWithError = tab.some(comp => !!comp.error);
+      return hasComponentWithError ? [...invalidTabs, tabIndex] : invalidTabs;
+    }, []);
+
+    if (!invalidTabsIndexes.length) {
+      return;
+    }
+
+    const invalidTabs = [...this.refs[this.tabLinkKey]].filter((_, tabIndex) => invalidTabsIndexes.includes(tabIndex));
+    this.setErrorClasses(invalidTabs, true, true);
   }
 }

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -200,6 +200,6 @@ export default class TabsComponent extends NestedComponent {
     }
 
     const invalidTabs = [...this.refs[this.tabLinkKey]].filter((_, tabIndex) => invalidTabsIndexes.includes(tabIndex));
-    this.setErrorClasses(invalidTabs, true, true);
+    this.setErrorClasses(invalidTabs);
   }
 }

--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -1249,3 +1249,12 @@ div[read-only="true"] {
 .formio-form > div > nav > ul.pagination {
   flex-flow: wrap row;
 }
+
+.tab-error {
+  color: #222222 !important;
+  background-color: #f8d7da !important;
+
+  &.active {
+    background-color: #ea2f10 !important;
+  }
+}

--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -92,7 +92,7 @@ $autocomplete-in-dialog-z-index: $dialog-z-index + 1000;
   background-color: #fff;
 }
 
-.field-required:after {
+.field-required:after, .tab-error::after {
   content:" *";
   color:red;
 }
@@ -1248,13 +1248,4 @@ div[read-only="true"] {
 
 .formio-form > div > nav > ul.pagination {
   flex-flow: wrap row;
-}
-
-.tab-error {
-  color: #222222 !important;
-  background-color: #f8d7da !important;
-
-  &.active {
-    background-color: #ea2f10 !important;
-  }
 }


### PR DESCRIPTION
@travist for now made this way, it looks more distinguish to me.
When the tab with error gets active, the color becomes more red.
![image](https://user-images.githubusercontent.com/54106407/100614971-ff9aac80-3327-11eb-8a9b-f2c03f276187.png)

But can make it the way you proposed, with an asterisk.
![image](https://user-images.githubusercontent.com/54106407/100615069-1a6d2100-3328-11eb-8cb6-9115bc647ae6.png)