### PR TITLE
Don't trigger component redraw if id not present

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1674,7 +1674,8 @@ export default class Component extends Element {
     }
 
     const newComponent = fastCloneDeep(this.originalComponent);
-
+    newComponent.id = this.component.id;
+    
     let changed = logics.reduce((changed, logic) => {
       const result = FormioUtils.checkTrigger(
         newComponent,


### PR DESCRIPTION
Currently component redraws are happening even when there is no change in the component.
This can be because of `id` not present on the original component. So, will add to the `newComponent` before comparing with `this.component`.