### PR TITLE
Allow override of url & method in staticRequest hook

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -773,7 +773,7 @@ class Formio {
       .then(() => getFormio().pluginGet('staticRequest', requestArgs)
         .then((result) => {
           if (isNil(result)) {
-            return getFormio().request(url, method, requestArgs.data, requestArgs.opts.header, requestArgs.opts);
+            return getFormio().request(requestArgs.url, requestArgs.method, requestArgs.data, requestArgs.opts.header, requestArgs.opts);
           }
           return result;
         }));


### PR DESCRIPTION
This PR enables override of URL & Method from the `staticRequest` hook. The very same change could be done to the `request` hook if desired.

See #3565 