### PR TITLE
FJS-1272: Fixes errors when add a placeholder char to a text mask 

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -50,7 +50,6 @@ export default class Element {
     });
 
     this.defaultMask = null;
-    this.placeholderChar = '\u02cd';
     /**
      * Conditional to show or hide helplinks in editForm
      *
@@ -350,6 +349,20 @@ export default class Element {
     return mask.map((char) => (char instanceof RegExp) ? this.placeholderChar : char).join('');
   }
 
+  get placeholderChar() {
+    if (!this.component.inputMaskPlaceholderChar) {
+      if (!this.component?.inputMask?.includes('\u02cd')) {
+        return '\u02cd';
+      }
+      // If some fields already use \u02cd in the mask, use an underscore as a placeholderChar
+      else {
+        return '_';
+      }
+    }
+
+    return this.component?.inputMaskPlaceholderChar;
+  }
+
   /**
    * Sets the input mask for an input.
    *
@@ -361,6 +374,7 @@ export default class Element {
     if (input && inputMask) {
       const mask = FormioUtils.getInputMask(inputMask, this.placeholderChar);
       this.defaultMask = mask;
+
       try {
         //destroy previous mask
         if (input.mask) {

--- a/src/Element.js
+++ b/src/Element.js
@@ -50,7 +50,7 @@ export default class Element {
     });
 
     this.defaultMask = null;
-
+    this.placeholderChar = '\u02cd';
     /**
      * Conditional to show or hide helplinks in editForm
      *
@@ -347,7 +347,7 @@ export default class Element {
    * @returns {string} - The placeholder that will exist within the input as they type.
    */
   maskPlaceholder(mask) {
-    return mask.map((char) => (char instanceof RegExp) ? '_' : char).join('');
+    return mask.map((char) => (char instanceof RegExp) ? this.placeholderChar : char).join('');
   }
 
   /**
@@ -355,11 +355,11 @@ export default class Element {
    *
    * @param {HTMLElement} input - The html input to apply the mask to.
    * @param {String} inputMask - The input mask to add to this input.
-   * @param {Boolean} placeholder - Set the mask placeholder on the input.
+   * @param {Boolean} usePlaceholder - Set the mask placeholder on the input.
    */
-  setInputMask(input, inputMask, placeholder) {
+  setInputMask(input, inputMask, usePlaceholder) {
     if (input && inputMask) {
-      const mask = FormioUtils.getInputMask(inputMask);
+      const mask = FormioUtils.getInputMask(inputMask, this.placeholderChar);
       this.defaultMask = mask;
       try {
         //destroy previous mask
@@ -368,7 +368,8 @@ export default class Element {
         }
         input.mask = maskInput({
           inputElement: input,
-          mask
+          mask,
+          placeholderChar: this.placeholderChar
         });
       }
       catch (e) {
@@ -379,7 +380,7 @@ export default class Element {
       if (mask.numeric) {
         input.setAttribute('pattern', '\\d*');
       }
-      if (placeholder) {
+      if (usePlaceholder) {
         input.setAttribute('placeholder', this.maskPlaceholder(mask));
       }
     }

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2220,7 +2220,9 @@ export default class Component extends Element {
 
     const checkMask = (value) => {
       if (typeof value === 'string') {
-        value = conformToMask(value, this.defaultMask).conformedValue;
+        const placeholderChar = this.placeholderChar;
+
+        value = conformToMask(value, this.defaultMask, { placeholderChar }).conformedValue;
         if (!FormioUtils.matchInputMask(value, this.defaultMask)) {
           value = '';
         }
@@ -2776,7 +2778,7 @@ export default class Component extends Element {
     }
 
     inputRefs.forEach((input) => {
-      if (input.widget && input.widget.setErrorClasses) {
+      if (input?.widget && input.widget.setErrorClasses) {
         input.widget.setErrorClasses(hasErrors);
       }
     });

--- a/src/components/textfield/TextField.js
+++ b/src/components/textfield/TextField.js
@@ -118,7 +118,8 @@ export default class TextFieldComponent extends Input {
     const maskInput = this.refs.select ? this.refs.select[index]: null;
     const mask = this.getMaskPattern(value.maskName);
     if (textInput && maskInput && mask) {
-      textInput.value = conformToMask(textValue, FormioUtils.getInputMask(mask)).conformedValue;
+      const placeholderChar = this.placeholderChar;
+      textInput.value = conformToMask(textValue, FormioUtils.getInputMask(mask), { placeholderChar }).conformedValue;
       maskInput.value = value.maskName;
     }
     else {

--- a/src/components/textfield/editForm/TextField.edit.display.js
+++ b/src/components/textfield/editForm/TextField.edit.display.js
@@ -74,6 +74,20 @@ export default [
     }
   },
   {
+    weight: 411,
+    type: 'textfield',
+    input: true,
+    key: 'inputMaskPlaceholderChar',
+    label: 'Input Mask Placeholder Char',
+    tooltip: 'You can specify a char which will be used as a placeholder in the field. <br/> E.g., "\u02cd" <br/> Make note that placeholder char will be replaced by a space if it is used inside the mask',
+    validation: {
+      maxLength: 1
+    },
+    customConditional(context) {
+      return context.data.inputMask;
+    }
+  },
+  {
     weight: 413,
     type: 'checkbox',
     input: true,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -756,9 +756,10 @@ export function convertFormatToMask(format) {
 /**
  * Returns an input mask that is compatible with the input mask library.
  * @param {string} mask - The Form.io input mask.
+ * @param {string} placeholderChar - Char which is used as a placeholder.
  * @returns {Array} - The input mask for the mask library.
  */
-export function getInputMask(mask) {
+export function getInputMask(mask, placeholderChar) {
   if (mask instanceof Array) {
     return mask;
   }
@@ -780,6 +781,11 @@ export function getInputMask(mask) {
       case '*':
         maskArray.numeric = false;
         maskArray.push(/[a-zA-Z0-9]/);
+        break;
+      // If char which is used inside mask placeholder was used in the mask, replace it with space to prevent errors
+      case placeholderChar:
+        maskArray.numeric = false;
+        maskArray.push(' ');
         break;
       default:
         maskArray.numeric = false;


### PR DESCRIPTION
Since it is a vanilla-text-mask restriction not to use placeholder char in the mask, the only possible solution is to not use it. But in some customers' cases it is useful to have ability to add an underscore to the mask. So, what this fix does:
- Adds an ability to specify placeholder char for input mask
- Prevents errors when placeholder char is used inside an input mask (when creating a mask, it replaces placeholder chars by spaces)
- Changes a default placeholder char from _ to ˍ which is used more rarely (but only in cases when ˍ is not already used inside an input mask to make changes backward compatible)