### PR TITLE
Add Webform language getter

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -276,6 +276,10 @@ export default class Webform extends NestedDataComponent {
   }
   /* eslint-enable max-statements */
 
+  get language() {
+    return this.options.language;
+  }
+
   /**
    * Sets the language for this form.
    *

--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -867,6 +867,15 @@ describe('Webform tests', function() {
     }).catch(done);
   });
 
+  it('Should get the language passed via options', () => {
+    const formElement = document.createElement('div');
+    const form = new Webform(formElement, {
+      language: 'es'
+    });
+
+    assert.equal(form.language, 'es');
+  });
+
   it('Should translate form errors in alerts', () => {
     const formElement = document.createElement('div');
     const form = new Webform(formElement, {


### PR DESCRIPTION
The Webform class lacks a `language` getter to complement the setter. This adds one!

Because the language setter is asynchronous—which seems [sketchy](https://github.com/tc39/proposal-async-await/issues/82), IMO—I figured it's better to have the getter return `this.options.language` rather than `this.i18next.language`, which may not reflect the value provided until `changeLanguage()` resolves.

One case that this doesn't account for is if you've provided your own `i18next` instance in the form options. In that case, `this.options.language` may not equal `this.i18next.language`. So maybe, if [i18next.changeLanguage()](https://www.i18next.com/overview/api#changelanguage) sets the internal value used in the [language getter](https://www.i18next.com/overview/api#language) immediately, it might be better to always return `this.i18next.language` here? 🤔 