### PR TITLE
Localize selectboxes validation messages

### DIFF
--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -176,8 +176,8 @@ export default class SelectBoxesComponent extends RadioComponent {
         }
         if (maxCount && count > maxCount) {
           const message = this.component.maxSelectedCountMessage
-            ? this.component.maxSelectedCountMessage
-            : `You can only select up to ${maxCount} items.`;
+            ? this.t(this.component.maxSelectedCountMessage)
+            : this.t('You can only select up to {{maxCount}} items.', { maxCount });
           this.setCustomValidity(message, dirty);
           return false;
         }
@@ -189,8 +189,8 @@ export default class SelectBoxesComponent extends RadioComponent {
           });
         }
         const message = this.component.minSelectedCountMessage
-          ? this.component.minSelectedCountMessage
-          : `You must select at least ${minCount} items.`;
+          ? this.t(this.component.minSelectedCountMessage)
+          : this.t('You must select at least {{minCount}} items.', { minCount });
         this.setCustomValidity(message, dirty);
         return false;
       }

--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -175,9 +175,10 @@ export default class SelectBoxesComponent extends RadioComponent {
           });
         }
         if (maxCount && count > maxCount) {
-          const message = this.component.maxSelectedCountMessage
-            ? this.t(this.component.maxSelectedCountMessage)
-            : this.t('You can only select up to {{maxCount}} items.', { maxCount });
+          const message = this.t(
+            this.component.maxSelectedCountMessage || 'You can only select up to {{maxCount}} items.',
+            { maxCount }
+          );
           this.setCustomValidity(message, dirty);
           return false;
         }
@@ -188,9 +189,10 @@ export default class SelectBoxesComponent extends RadioComponent {
             item.disabled = false;
           });
         }
-        const message = this.component.minSelectedCountMessage
-          ? this.t(this.component.minSelectedCountMessage)
-          : this.t('You must select at least {{minCount}} items.', { minCount });
+        const message = this.t(
+          this.component.minSelectedCountMessage || 'You must select at least {{minCount}} items.',
+          { minCount }
+        );
         this.setCustomValidity(message, dirty);
         return false;
       }

--- a/src/components/selectboxes/SelectBoxes.unit.js
+++ b/src/components/selectboxes/SelectBoxes.unit.js
@@ -1,14 +1,168 @@
+import assert from 'power-assert';
 import Harness from '../../../test/harness';
 import SelectBoxesComponent from './SelectBoxes';
+import Formio from './../../Formio';
 
 import {
-  comp1,
+  comp1
 } from './fixtures';
 
 describe('SelectBoxes Component', () => {
   it('Should build a SelectBoxes component', () => {
     return Harness.testCreate(SelectBoxesComponent, comp1).then((component) => {
       Harness.testElements(component, 'input[type="checkbox"]', 8);
+    });
+  });
+
+  describe('error messages', () => {
+    it('Should have a minSelectedCount validation message', () => {
+      const formJson = {
+        components: [
+          {
+            type: 'selectboxes',
+            key: 'options',
+            values: [
+              { label: 'Option 1', value: '1' },
+              { label: 'Option 2', value: '2' },
+              { label: 'Option 3', value: '3' },
+              { label: 'Option 4', value: '4' }
+            ],
+            validate: {
+              minSelectedCount: 2
+            }
+          }
+        ]
+      };
+      const element = document.createElement('div');
+      return Formio.createForm(element, formJson)
+        .then(async form => {
+          form.submission = {
+            data: {
+              options: { 1: true }
+            }
+          };
+          const comp = form.getComponent('options');
+          setTimeout(() => {
+            const { messageContainer } = comp.refs;
+            assert.equal(
+              messageContainer.textContent.trim(),
+              'You must select at least 2 items.'
+            );
+          }, 300);
+        });
+    });
+
+    it('Should use the minSelectedCountMessage if provided', () => {
+      const formJson = {
+        components: [
+          {
+            type: 'selectboxes',
+            key: 'options',
+            values: [
+              { label: 'Option 1', value: '1' },
+              { label: 'Option 2', value: '2' },
+              { label: 'Option 3', value: '3' },
+              { label: 'Option 4', value: '4' }
+            ],
+            validate: {
+              minSelectedCount: 2,
+            },
+            minSelectedCountMessage: 'Please select at least {{minCount}} items.'
+          }
+        ]
+      };
+      const element = document.createElement('div');
+      return Formio.createForm(element, formJson)
+        .then(async form => {
+          form.submission = {
+            data: {
+              options: { 1: true }
+            }
+          };
+          const comp = form.getComponent('options');
+          setTimeout(() => {
+            const { messageContainer } = comp.refs;
+            assert.equal(
+              messageContainer.textContent.trim(),
+              'Please select at least 2 items.'
+            );
+          }, 300);
+        });
+    });
+
+    it('Should have a maxSelectedCount validation message', () => {
+      const formJson = {
+        components: [
+          {
+            type: 'selectboxes',
+            key: 'options',
+            values: [
+              { label: 'Option 1', value: '1' },
+              { label: 'Option 2', value: '2' },
+              { label: 'Option 3', value: '3' },
+              { label: 'Option 4', value: '4' }
+            ],
+            validate: {
+              maxSelectedCount: 2
+            }
+          }
+        ]
+      };
+      const element = document.createElement('div');
+      return Formio.createForm(element, formJson)
+        .then(async form => {
+          form.submission = {
+            data: {
+              options: { 1: true, 2: true, 3: true }
+            }
+          };
+          const comp = form.getComponent('options');
+          setTimeout(() => {
+            const { messageContainer } = comp.refs;
+            assert.equal(
+              messageContainer.textContent.trim(),
+              'You can only select up to 2 items.'
+            );
+          }, 300);
+        });
+    });
+
+    it('Should use the maxSelectedCountMessage if provided', () => {
+      const formJson = {
+        components: [
+          {
+            type: 'selectboxes',
+            key: 'options',
+            values: [
+              { label: 'Option 1', value: '1' },
+              { label: 'Option 2', value: '2' },
+              { label: 'Option 3', value: '3' },
+              { label: 'Option 4', value: '4' }
+            ],
+            validate: {
+              maxSelectedCount: 2,
+            },
+            maxSelectedCountMessage: 'Please select {{maxCount}} items at most.'
+          }
+        ]
+      };
+      const element = document.createElement('div');
+      return Formio.createForm(element, formJson)
+        .then(async form => {
+          form.submission = {
+            data: {
+              options: { 1: true, 2: true, 3: true }
+            }
+          };
+          const comp = form.getComponent('options');
+          setTimeout(() => {
+            const { messageContainer } = comp.refs;
+            assert.equal(
+              messageContainer.textContent.trim(),
+              'Please select 2 items at most.'
+            );
+          }, 300);
+        });
     });
   });
 });


### PR DESCRIPTION
The selectboxes component has some hard-coded validation messages for `minSelectedCount` and `maxSelectedCount`. This change wraps both the hard-coded messages and the custom validation messages (`minSelectedCountMessage` and `maxSelectedCountMessage`) in `this.t()` so that they're passed through the localization layer. This should make it possible to localize them like so:

```js
Formio.createForm({
  components: [
    {
      type: 'selectboxes',
      values: [
        { label: 'Option 1', value: 1 },
        { label: 'Option 2', value: 2 },
        { label: 'Option 3', value: 3 },
        { label: 'Option 4', value: 4 }
      ],
      validate: { maxItemCount: 2 }
    }
  ]
}, {
  i18n: {
    'You can only select up to {{maxCount}} items.': 'Please select {{maxCount}} items or fewer.'
  }
})
```

I've added tests for both the default messages and the custom ones for both the min and max count scenarios.