### PR TITLE
Update formio.form.scss

### DIFF
--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -989,10 +989,6 @@ body.formio-dialog-open {
   }
 }
 
-.table-responsive[ref=component] {
-  overflow-x: visible;
-}
-
 .formio-component-textarea {
   .alert .ck-editor__editable {
     color: inherit;


### PR DESCRIPTION
@mikekotikov 
Please review this commit. Your last change made the view a little broken on mobile devices, impossible to scroll to the right when component overflows.