### PR TITLE
Fixed an error occurred when trying to add Logic row

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -497,12 +497,7 @@ export default class Component extends Element {
 
   init() {
     this.disabled = this.shouldDisabled;
-    const visible = this.conditionallyVisible(null, null);
-
-    if (this._visible !== visible) {
-      this.visible = visible;
-      this._visible = visible;
-    }
+    this._visible = this.conditionallyVisible(null, null);
   }
 
   destroy() {
@@ -1542,6 +1537,7 @@ export default class Component extends Element {
   rebuild() {
     this.destroy();
     this.init();
+    this.visible = this.conditionallyVisible(null, null);
     return this.redraw();
   }
 


### PR DESCRIPTION
Select component throws an error in some cases because it declares its triggerUpdate method which is used in visible setter during init(). 