### PR TITLE
Use schema instead of component for Builder Edit JSON dialog

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1274,7 +1274,7 @@ export default class WebformBuilder extends Component {
     const instance = new ComponentClass(componentCopy);
     this.editForm.submission = isJsonEdit ? {
       data: {
-        componentJson: instance.component
+        componentJson: component
       },
     } : {
         data: instance.component,


### PR DESCRIPTION
This changes the the “Edit JSON” dialog so it uses the compact `schema` value
without all the default settings.

### Before
![before](https://user-images.githubusercontent.com/1183945/104134951-2ddec380-538d-11eb-8949-a6370190da16.png)
### After
![after](https://user-images.githubusercontent.com/1183945/104134952-30411d80-538d-11eb-9578-de0f3785c0ee.png)
