### PR TITLE
Fix/4.13.0 regression datagrid columns width

### DIFF
--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -236,7 +236,7 @@ export default class DataGridComponent extends NestedArrayComponent {
 
   render() {
     const columns = this.getColumns();
-    const colWidth = Math.floor(12 / (columns.length + 1)).toString();
+    const layoutFixed = columns.some(col => col.type === 'select') || this.component.layoutFixed;
     return super.render(this.renderTemplate('datagrid', {
       rows: this.getRows(),
       columns: columns,
@@ -259,7 +259,7 @@ export default class DataGridComponent extends NestedArrayComponent {
       placeholder: this.renderTemplate('builderPlaceholder', {
         position: this.componentComponents.length,
       }),
-      colWidth
+      layoutFixed
     }));
   }
 

--- a/src/templates/bootstrap/datagrid/form.ejs
+++ b/src/templates/bootstrap/datagrid/form.ejs
@@ -2,7 +2,7 @@
     {{ ctx.component.striped ? 'table-striped' : ''}}
     {{ ctx.component.hover ? 'table-hover' : ''}}
     {{ ctx.component.condensed ? 'table-sm' : ''}}
-    " {% if (ctx.component.layoutFixed) { %}style="table-layout: fixed;"{% } %}>
+    " {% if (ctx.layoutFixed) { %}style="table-layout: fixed;"{% } %}>
   {% if (ctx.hasHeader) { %}
   <thead>
     <tr>
@@ -42,7 +42,7 @@
         </td>
       {% } %}
       {% ctx.columns.forEach(function(col) { %}
-        <td ref="{{ctx.datagridKey}}" class="col-md-{{ctx.colWidth}}">
+        <td ref="{{ctx.datagridKey}}">
           {{row[col.key]}}
         </td>
       {% }) %}

--- a/src/templates/bootstrap/table/form.ejs
+++ b/src/templates/bootstrap/table/form.ejs
@@ -6,16 +6,16 @@
   ">
   {% if (ctx.component.header && ctx.component.header.length > 0) { %}
   <thead>
-    <tr>
+    <tr class="row">
       {% ctx.component.header.forEach(function(header) { %}
-      <th>{{ctx.t(header)}}</th>
+      <th class="col-md-{{ctx.colWidth}}">{{ctx.t(header)}}</th>
       {% }) %}
     </tr>
   </thead>
   {% } %}
   <tbody>
     {% ctx.tableComponents.forEach(function(row, rowIndex) { %}
-    <tr ref="row-{{ctx.id}}">
+    <tr class="row" ref="row-{{ctx.id}}">
       {% row.forEach(function(column, colIndex) { %}
       <td ref="{{ctx.tableKey}}-{{rowIndex}}"{% if (ctx.cellClassName) { %} class="{{ctx.cellClassName}} col-md-{{ctx.colWidth}}"{% } %}>{{column}}</td>
       {% }) %}

--- a/test/renders/component-bootstrap-table-multiple.html
+++ b/test/renders/component-bootstrap-table-multiple.html
@@ -2,7 +2,7 @@
   <table class="table
   ">
     <tbody>
-      <tr ref="row-table">
+      <tr class="row" ref="row-table">
         <td ref="table-table-0">
         </td>
         <td ref="table-table-0">
@@ -10,7 +10,7 @@
         <td ref="table-table-0">
         </td>
       </tr>
-      <tr ref="row-table">
+      <tr class="row" ref="row-table">
         <td ref="table-table-1">
         </td>
         <td ref="table-table-1">
@@ -18,7 +18,7 @@
         <td ref="table-table-1">
         </td>
       </tr>
-      <tr ref="row-table">
+      <tr class="row" ref="row-table">
         <td ref="table-table-2">
         </td>
         <td ref="table-table-2">

--- a/test/renders/component-bootstrap-table-required.html
+++ b/test/renders/component-bootstrap-table-required.html
@@ -2,7 +2,7 @@
   <table class="table
   ">
     <tbody>
-      <tr ref="row-table">
+      <tr class="row" ref="row-table">
         <td ref="table-table-0">
         </td>
         <td ref="table-table-0">
@@ -10,7 +10,7 @@
         <td ref="table-table-0">
         </td>
       </tr>
-      <tr ref="row-table">
+      <tr class="row" ref="row-table">
         <td ref="table-table-1">
         </td>
         <td ref="table-table-1">
@@ -18,7 +18,7 @@
         <td ref="table-table-1">
         </td>
       </tr>
-      <tr ref="row-table">
+      <tr class="row" ref="row-table">
         <td ref="table-table-2">
         </td>
         <td ref="table-table-2">

--- a/test/renders/component-bootstrap-table.html
+++ b/test/renders/component-bootstrap-table.html
@@ -2,7 +2,7 @@
   <table class="table
   ">
     <tbody>
-      <tr ref="row-table">
+      <tr class="row" ref="row-table">
         <td ref="table-table-0">
         </td>
         <td ref="table-table-0">
@@ -10,7 +10,7 @@
         <td ref="table-table-0">
         </td>
       </tr>
-      <tr ref="row-table">
+      <tr class="row" ref="row-table">
         <td ref="table-table-1">
         </td>
         <td ref="table-table-1">
@@ -18,7 +18,7 @@
         <td ref="table-table-1">
         </td>
       </tr>
-      <tr ref="row-table">
+      <tr class="row" ref="row-table">
         <td ref="table-table-2">
         </td>
         <td ref="table-table-2">

--- a/test/renders/form-bootstrap-calculateValueWithManualOverride.html
+++ b/test/renders/form-bootstrap-calculateValueWithManualOverride.html
@@ -45,7 +45,7 @@
               </thead>
               <tbody ref="datagrid-dataGrid-tbody">
                 <tr ref="datagrid-dataGrid-row">
-                  <td ref="datagrid-dataGrid" class="col-md-4">
+                  <td ref="datagrid-dataGrid">
                     <div id="label" class="form-group has-feedback formio-component formio-component-textfield formio-component-label  formio-component-label-hidden" ref="component">
                       <div ref="element">
                         <input ref="input" name="data[dataGrid][0][label]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="label-label"></input>
@@ -53,7 +53,7 @@
                       <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
                     </div>
                   </td>
-                  <td ref="datagrid-dataGrid" class="col-md-4">
+                  <td ref="datagrid-dataGrid">
                     <div id="value" class="form-group has-feedback formio-component formio-component-textfield formio-component-value  formio-component-label-hidden" ref="component">
                       <div ref="element">
                         <input ref="input" name="data[dataGrid][0][value]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="value-value"></input>

--- a/test/renders/form-bootstrap-data.html
+++ b/test/renders/form-bootstrap-data.html
@@ -43,7 +43,7 @@
         </thead>
         <tbody ref="datagrid-dataGrid-tbody">
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][0][dataGridText]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText-dataGridText"></input>
@@ -51,7 +51,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText3" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText3  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][0][dataGridText3]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText3-dataGridText3"></input>
@@ -59,7 +59,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText2" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText2 " ref="component">
                 <label class="col-form-label " for="dataGridText2-dataGridText2">
                   Show Row
@@ -70,7 +70,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText4" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText4 " ref="component">
                 <label class="col-form-label " for="dataGridText4-dataGridText4">
                   Show Both
@@ -83,7 +83,7 @@
             </td>
           </tr>
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][1][dataGridText]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText-dataGridText"></input>
@@ -91,7 +91,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText3" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText3  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][1][dataGridText3]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText3-dataGridText3"></input>
@@ -99,7 +99,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText2" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText2 " ref="component">
                 <label class="col-form-label " for="dataGridText2-dataGridText2">
                   Show Row
@@ -110,7 +110,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText4" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText4 " ref="component">
                 <label class="col-form-label " for="dataGridText4-dataGridText4">
                   Show Both
@@ -123,7 +123,7 @@
             </td>
           </tr>
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][2][dataGridText]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText-dataGridText"></input>
@@ -131,7 +131,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText3" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText3  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][2][dataGridText3]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText3-dataGridText3"></input>
@@ -139,7 +139,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText2" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText2 " ref="component">
                 <label class="col-form-label " for="dataGridText2-dataGridText2">
                   Show Row
@@ -150,7 +150,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid">
               <div id="dataGridText4" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText4 " ref="component">
                 <label class="col-form-label " for="dataGridText4-dataGridText4">
                   Show Both
@@ -183,7 +183,7 @@
     ">
         <tbody ref="datagrid-dataGrid2-tbody">
           <tr ref="datagrid-dataGrid2-row">
-            <td ref="datagrid-dataGrid2" class="col-md-4">
+            <td ref="datagrid-dataGrid2">
               <div id="dataGrid2Text" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGrid2Text  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid2][0][dataGrid2Text]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGrid2Text-dataGrid2Text"></input>
@@ -191,7 +191,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid2" class="col-md-4">
+            <td ref="datagrid-dataGrid2">
               <div id="text" class="form-group has-feedback formio-component formio-component-textfield formio-component-text  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid2][0][text]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="text-text"></input>
@@ -245,7 +245,7 @@
         </thead>
         <tbody ref="datagrid-conditionalDataGrid-tbody">
           <tr ref="datagrid-conditionalDataGrid-row">
-            <td ref="datagrid-conditionalDataGrid" class="col-md-6">
+            <td ref="datagrid-conditionalDataGrid">
               <div id="conditionalDataGridShow2" class="form-group has-feedback formio-component formio-component-checkbox formio-component-conditionalDataGridShow2  formio-component-label-hidden" ref="component">
                 <div class="form-check checkbox">
                   <label class=" form-check-label">

--- a/test/renders/form-bootstrap-defaults.html
+++ b/test/renders/form-bootstrap-defaults.html
@@ -345,7 +345,7 @@
       <table class="table
   ">
         <tbody>
-          <tr ref="row-table">
+          <tr class="row" ref="row-table">
             <td ref="table-table-0">
             </td>
             <td ref="table-table-0">
@@ -362,7 +362,7 @@
             <td ref="table-table-0">
             </td>
           </tr>
-          <tr ref="row-table">
+          <tr class="row" ref="row-table">
             <td ref="table-table-1">
             </td>
             <td ref="table-table-1">
@@ -370,7 +370,7 @@
             <td ref="table-table-1">
             </td>
           </tr>
-          <tr ref="row-table">
+          <tr class="row" ref="row-table">
             <td ref="table-table-2">
             </td>
             <td ref="table-table-2">
@@ -429,7 +429,7 @@
         </thead>
         <tbody ref="datagrid-dataGrid-tbody">
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-6">
+            <td ref="datagrid-dataGrid">
               <div id="textField7" class="form-group has-feedback formio-component formio-component-textfield formio-component-textField7  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][0][textField7]" type="text" class="form-control" lang="en" spellcheck="true" value="Datagrid Default" id="textField7-textField7"></input>

--- a/test/renders/form-bootstrap-formWithCustomFormatDate.html
+++ b/test/renders/form-bootstrap-formWithCustomFormatDate.html
@@ -23,7 +23,7 @@
         </thead>
         <tbody ref="datagrid-dataGrid-tbody">
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-3">
+            <td ref="datagrid-dataGrid">
               <div id="dateTime" class="form-group has-feedback formio-component formio-component-datetime formio-component-dateTime  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="input-group">
@@ -38,7 +38,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-3">
+            <td ref="datagrid-dataGrid">
               <div id="textField2" class="form-group has-feedback formio-component formio-component-textfield formio-component-textField2  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="input-group">
@@ -53,7 +53,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-3">
+            <td ref="datagrid-dataGrid">
               <div id="textField" class="form-group has-feedback formio-component formio-component-textfield formio-component-textField  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="input-group">

--- a/test/renders/form-bootstrap-layout.html
+++ b/test/renders/form-bootstrap-layout.html
@@ -141,7 +141,7 @@
     table-sm
   ">
         <tbody>
-          <tr ref="row-table">
+          <tr class="row" ref="row-table">
             <td ref="table-table-0">
               <div id="tableText" class="form-group has-feedback formio-component formio-component-textfield formio-component-tableText " ref="component">
                 <label class="col-form-label " for="tableText-tableText">
@@ -158,7 +158,7 @@
             <td ref="table-table-0">
             </td>
           </tr>
-          <tr ref="row-table">
+          <tr class="row" ref="row-table">
             <td ref="table-table-1">
             </td>
             <td ref="table-table-1">
@@ -175,7 +175,7 @@
             <td ref="table-table-1">
             </td>
           </tr>
-          <tr ref="row-table">
+          <tr class="row" ref="row-table">
             <td ref="table-table-2">
             </td>
             <td ref="table-table-2">

--- a/test/renders/form-bootstrap-settingErrors.html
+++ b/test/renders/form-bootstrap-settingErrors.html
@@ -122,7 +122,7 @@
                   <table class="table
   ">
                     <tbody>
-                      <tr ref="row-table">
+                      <tr class="row" ref="row-table">
                         <td ref="table-table-0" class="cell-align-left col-md-6">
                           <div id="dateTime" class="form-group has-feedback formio-component formio-component-datetime formio-component-dateTime  required" ref="component">
                             <label class="col-form-label  field-required" for="dateTime-dateTime">
@@ -210,7 +210,7 @@
                           </div>
                         </td>
                       </tr>
-                      <tr ref="row-table">
+                      <tr class="row" ref="row-table">
                         <td ref="table-table-1" class="cell-align-left col-md-6">
                           <div id="currencyTable" class="form-group has-feedback formio-component formio-component-currency formio-component-currencyTable  required" ref="component">
                             <label class="col-form-label  field-required" for="currencyTable-currencyTable">

--- a/test/renders/form-bootstrap3-calculateValueWithManualOverride.html
+++ b/test/renders/form-bootstrap3-calculateValueWithManualOverride.html
@@ -41,7 +41,7 @@
           </thead>
           <tbody ref="datagrid-dataGrid-tbody">
             <tr ref="datagrid-dataGrid-row">
-              <td ref="datagrid-dataGrid" class="col-md-4">
+              <td ref="datagrid-dataGrid" class="col-md-">
                 <div id="label" class="form-group has-feedback formio-component formio-component-textfield formio-component-label  formio-component-label-hidden" ref="component">
                   <div ref="element">
                     <input ref="input" name="data[dataGrid][0][label]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="label-label"></input>
@@ -49,7 +49,7 @@
                   <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
                 </div>
               </td>
-              <td ref="datagrid-dataGrid" class="col-md-4">
+              <td ref="datagrid-dataGrid" class="col-md-">
                 <div id="value" class="form-group has-feedback formio-component formio-component-textfield formio-component-value  formio-component-label-hidden" ref="component">
                   <div ref="element">
                     <input ref="input" name="data[dataGrid][0][value]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="value-value"></input>

--- a/test/renders/form-bootstrap3-data.html
+++ b/test/renders/form-bootstrap3-data.html
@@ -43,7 +43,7 @@
         </thead>
         <tbody ref="datagrid-dataGrid-tbody">
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][0][dataGridText]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText-dataGridText"></input>
@@ -51,7 +51,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText3" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText3  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][0][dataGridText3]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText3-dataGridText3"></input>
@@ -59,7 +59,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText2" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText2 " ref="component">
                 <label class="control-label " for="dataGridText2-dataGridText2">
                   Show Row
@@ -70,7 +70,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText4" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText4 " ref="component">
                 <label class="control-label " for="dataGridText4-dataGridText4">
                   Show Both
@@ -83,7 +83,7 @@
             </td>
           </tr>
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][1][dataGridText]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText-dataGridText"></input>
@@ -91,7 +91,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText3" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText3  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][1][dataGridText3]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText3-dataGridText3"></input>
@@ -99,7 +99,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText2" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText2 " ref="component">
                 <label class="control-label " for="dataGridText2-dataGridText2">
                   Show Row
@@ -110,7 +110,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText4" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText4 " ref="component">
                 <label class="control-label " for="dataGridText4-dataGridText4">
                   Show Both
@@ -123,7 +123,7 @@
             </td>
           </tr>
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][2][dataGridText]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText-dataGridText"></input>
@@ -131,7 +131,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText3" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText3  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][2][dataGridText3]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGridText3-dataGridText3"></input>
@@ -139,7 +139,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText2" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText2 " ref="component">
                 <label class="control-label " for="dataGridText2-dataGridText2">
                   Show Row
@@ -150,7 +150,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText4" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText4 " ref="component">
                 <label class="control-label " for="dataGridText4-dataGridText4">
                   Show Both
@@ -183,7 +183,7 @@
     ">
         <tbody ref="datagrid-dataGrid2-tbody">
           <tr ref="datagrid-dataGrid2-row">
-            <td ref="datagrid-dataGrid2" class="col-md-4">
+            <td ref="datagrid-dataGrid2" class="col-md-">
               <div id="dataGrid2Text" class="form-group has-feedback formio-component formio-component-textfield formio-component-dataGrid2Text  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid2][0][dataGrid2Text]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="dataGrid2Text-dataGrid2Text"></input>
@@ -191,7 +191,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid2" class="col-md-4">
+            <td ref="datagrid-dataGrid2" class="col-md-">
               <div id="text" class="form-group has-feedback formio-component formio-component-textfield formio-component-text  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid2][0][text]" type="text" class="form-control" lang="en" spellcheck="true" value="" id="text-text"></input>
@@ -245,7 +245,7 @@
         </thead>
         <tbody ref="datagrid-conditionalDataGrid-tbody">
           <tr ref="datagrid-conditionalDataGrid-row">
-            <td ref="datagrid-conditionalDataGrid" class="col-md-6">
+            <td ref="datagrid-conditionalDataGrid" class="col-md-">
               <div id="conditionalDataGridShow2" class="form-group has-feedback formio-component formio-component-checkbox formio-component-conditionalDataGridShow2  formio-component-label-hidden" ref="component">
                 <div class="form-check checkbox">
                   <label class=" form-check-label">

--- a/test/renders/form-bootstrap3-defaults.html
+++ b/test/renders/form-bootstrap3-defaults.html
@@ -427,7 +427,7 @@
         </thead>
         <tbody ref="datagrid-dataGrid-tbody">
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-6">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="textField7" class="form-group has-feedback formio-component formio-component-textfield formio-component-textField7  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <input ref="input" name="data[dataGrid][0][textField7]" type="text" class="form-control" lang="en" spellcheck="true" value="Datagrid Default" id="textField7-textField7"></input>

--- a/test/renders/form-bootstrap3-formWithCustomFormatDate.html
+++ b/test/renders/form-bootstrap3-formWithCustomFormatDate.html
@@ -23,7 +23,7 @@
         </thead>
         <tbody ref="datagrid-dataGrid-tbody">
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-3">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dateTime" class="form-group has-feedback formio-component formio-component-datetime formio-component-dateTime  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="input-group">
@@ -36,7 +36,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-3">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="textField2" class="form-group has-feedback formio-component formio-component-textfield formio-component-textField2  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="input-group">
@@ -49,7 +49,7 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-3">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="textField" class="form-group has-feedback formio-component formio-component-textfield formio-component-textField  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="input-group">

--- a/test/renders/form-semantic-calculateValueWithManualOverride.html
+++ b/test/renders/form-semantic-calculateValueWithManualOverride.html
@@ -37,7 +37,7 @@
         </thead>
         <tbody ref="datagrid-dataGrid-tbody">
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-4">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="label" class="field form-group has-feedback formio-component formio-component-textfield formio-component-label  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">
@@ -47,7 +47,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-4">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="value" class="field form-group has-feedback formio-component formio-component-textfield formio-component-value  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">

--- a/test/renders/form-semantic-data.html
+++ b/test/renders/form-semantic-data.html
@@ -51,7 +51,7 @@
         </thead>
         <tbody ref="datagrid-dataGrid-tbody">
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">
@@ -61,7 +61,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText3" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText3  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">
@@ -71,7 +71,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText2" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText2 " ref="component">
                 <label class="" for="dataGridText2-dataGridText2">
                   Show Row
@@ -84,7 +84,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText4" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText4 " ref="component">
                 <label class="" for="dataGridText4-dataGridText4">
                   Show Both
@@ -99,7 +99,7 @@
             </td>
           </tr>
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">
@@ -109,7 +109,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText3" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText3  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">
@@ -119,7 +119,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText2" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText2 " ref="component">
                 <label class="" for="dataGridText2-dataGridText2">
                   Show Row
@@ -132,7 +132,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText4" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText4 " ref="component">
                 <label class="" for="dataGridText4-dataGridText4">
                   Show Both
@@ -147,7 +147,7 @@
             </td>
           </tr>
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">
@@ -157,7 +157,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText3" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText3  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">
@@ -167,7 +167,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText2" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText2 " ref="component">
                 <label class="" for="dataGridText2-dataGridText2">
                   Show Row
@@ -180,7 +180,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-2">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dataGridText4" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGridText4 " ref="component">
                 <label class="" for="dataGridText4-dataGridText4">
                   Show Both
@@ -217,7 +217,7 @@
     ">
         <tbody ref="datagrid-dataGrid2-tbody">
           <tr ref="datagrid-dataGrid2-row">
-            <td ref="datagrid-dataGrid2" class="col-md-4">
+            <td ref="datagrid-dataGrid2" class="col-md-">
               <div id="dataGrid2Text" class="field form-group has-feedback formio-component formio-component-textfield formio-component-dataGrid2Text  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">
@@ -227,7 +227,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid2" class="col-md-4">
+            <td ref="datagrid-dataGrid2" class="col-md-">
               <div id="text" class="field form-group has-feedback formio-component formio-component-textfield formio-component-text  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">
@@ -285,7 +285,7 @@
         </thead>
         <tbody ref="datagrid-conditionalDataGrid-tbody">
           <tr ref="datagrid-conditionalDataGrid-row">
-            <td ref="datagrid-conditionalDataGrid" class="col-md-6">
+            <td ref="datagrid-conditionalDataGrid" class="col-md-">
               <div id="conditionalDataGridShow2" class="field form-group has-feedback formio-component formio-component-checkbox formio-component-conditionalDataGridShow2  formio-component-label-hidden" ref="component">
                 <div class="ui checkbox">
                   <input ref="input" id="conditionalDataGridShow2" name="data[conditionalDataGrid][0][conditionalDataGridShow2]" type="checkbox" class="form-check-input" lang="en" value="0">

--- a/test/renders/form-semantic-defaults.html
+++ b/test/renders/form-semantic-defaults.html
@@ -458,7 +458,7 @@
         </thead>
         <tbody ref="datagrid-dataGrid-tbody">
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-6">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="textField7" class="field form-group has-feedback formio-component formio-component-textfield formio-component-textField7  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid ">

--- a/test/renders/form-semantic-formWithCustomFormatDate.html
+++ b/test/renders/form-semantic-formWithCustomFormatDate.html
@@ -24,7 +24,7 @@
         </thead>
         <tbody ref="datagrid-dataGrid-tbody">
           <tr ref="datagrid-dataGrid-row">
-            <td ref="datagrid-dataGrid" class="col-md-3">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="dateTime" class="field form-group has-feedback formio-component formio-component-datetime formio-component-dateTime  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid  right labeled">
@@ -37,7 +37,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-3">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="textField2" class="field form-group has-feedback formio-component formio-component-textfield formio-component-textField2  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid  right labeled">
@@ -50,7 +50,7 @@
                 <div ref="messageContainer"></div>
               </div>
             </td>
-            <td ref="datagrid-dataGrid" class="col-md-3">
+            <td ref="datagrid-dataGrid" class="col-md-">
               <div id="textField" class="field form-group has-feedback formio-component formio-component-textfield formio-component-textField  formio-component-label-hidden" ref="component">
                 <div ref="element">
                   <div class="ui input fluid  right labeled">


### PR DESCRIPTION
@travist tried my best to make it look ok both in formio-app and in angular-demo, but wasn't able to achieve it =(
Whether I applied logic with counting and setting col-md-[number] classes to every column or tried to apply different styles and other related bootstrap classes, nothing worked out well to me to be used with both repos.
So, was forced to stop on making DataGrid table layout fixed when there is at least one Select component.