### PR TITLE
Revert "Element: convert lodash to object in evalContext"

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -5,9 +5,7 @@ import i18next from 'i18next';
 import _ from 'lodash';
 import moment from 'moment';
 import maskInput from 'vanilla-text-mask';
-import { lodashOperators } from './utils/jsonlogic/operators';
 
-const lodash = lodashOperators.reduce((obj, operator) => _.set(obj, operator, _[operator]), {});
 /**
  * The root component for all elements within the Form.io renderer.
  */
@@ -512,7 +510,7 @@ export default class Element {
    */
   evalContext(additional) {
     return Object.assign({
-      _: lodash,
+      _,
       utils: FormioUtils,
       util: FormioUtils,
       user: Formio.getUser(),


### PR DESCRIPTION
Reverts formio/formio.js#3577

This one is about converting lodash to object with only methods listed in jsonlogic/operators in order to be supported with protected-eval plugin.
Moving this functionality from formio.js to protected-eval itself.