### PR TITLE
Add .offOne method to remove one listener for a certain event

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -151,6 +151,28 @@ export default class Element {
   }
 
   /**
+   * Remove one listener for a certain event. This is the exact opposite to `.on()`
+   * 
+   * @param {string} event - The event you wish to register the handler for.
+   * @param {function} cb - The callback handler to handle this event.
+   */
+  offOne(event, cb) {
+    if (!this.events) {
+      return;
+    }
+    const type = `${this.options.namespace}.${event}`;
+
+    const listener = this.events
+      .listeners(type)
+      .find(item => item && item === cb && item.id === this.id);
+    if (!listener) {
+      return;
+    }
+
+    this.events.off(type, listener);
+  }
+
+  /**
    * Emit a new event.
    *
    * @param {string} event - The event to emit.

--- a/src/Element.js
+++ b/src/Element.js
@@ -130,46 +130,37 @@ export default class Element {
   }
 
   /**
-   * Removes all listeners for a certain event.
+   * Removes a listener for a certain event. Not passing the 2nd arg will remove all listeners for that event.
    *
-   * @param event
-   */
-  off(event) {
-    if (!this.events) {
-      return;
-    }
-    const type = `${this.options.namespace}.${event}`;
-
-    // Iterate through all the internal events.
-    _.each(this.events.listeners(type), (listener) => {
-      // Ensure this event is for this component.
-      if (listener && (listener.id === this.id)) {
-        // Turn off this event handler.
-        this.events.off(type, listener);
-      }
-    });
-  }
-
-  /**
-   * Remove one listener for a certain event. This is the exact opposite to `.on()`
-   * 
    * @param {string} event - The event you wish to register the handler for.
-   * @param {function} cb - The callback handler to handle this event.
+   * @param {function|undefined} cb - The callback handler to handle this event.
    */
-  offOne(event, cb) {
+  off(event, cb) {
     if (!this.events) {
       return;
     }
     const type = `${this.options.namespace}.${event}`;
 
-    const listener = this.events
+    const listeners = this.events
       .listeners(type)
-      .find(item => item && item === cb && item.id === this.id);
-    if (!listener) {
-      return;
-    }
+      .filter((listener) => {
+        // Ensure the listener is for this element
+        return listener && listener.id === this.id;
+      })
+      .filter((listener) => {
+        // Bypass this filter if no target listener is given
+        if (!cb) {
+          return true;
+        }
 
-    this.events.off(type, listener);
+        // If target listener is given, find that one and filter out others
+        return cb && cb === listener;
+      });
+
+    // Remove all filtered listeners
+    listeners.forEach((listener) => {
+      this.events.off(type, listener);
+    });
   }
 
   /**

--- a/src/Element.js
+++ b/src/Element.js
@@ -139,26 +139,20 @@ export default class Element {
     if (!this.events) {
       return;
     }
+
     const type = `${this.options.namespace}.${event}`;
 
-    const listeners = this.events
-      .listeners(type)
-      .filter((listener) => {
-        // Ensure the listener is for this element
-        return listener && listener.id === this.id;
-      })
-      .filter((listener) => {
-        // Bypass this filter if no target listener is given
-        if (!cb) {
-          return true;
-        }
+    this.events.listeners(type).forEach((listener) => {
+      // Ensure the listener is for this element
+      if (!listener || listener.id !== this.id) {
+        return;
+      }
 
-        // If target listener is given, find that one and filter out others
-        return cb && cb === listener;
-      });
+      // If there is a given callback, only deal with the match
+      if (cb && cb !== listener) {
+        return;
+      }
 
-    // Remove all filtered listeners
-    listeners.forEach((listener) => {
       this.events.off(type, listener);
     });
   }


### PR DESCRIPTION
Method`.off()` of `Element` is removing all listeners for a single event, and we need a way to remove a single listener for a single event as the exact opposite to `.on()`, so that we added `.offOne()`.

The reason behind it is that we want to attach a listener to a single event, and remove it when cleanup of one part without removing all other listeners.

This is particularly important when using `form.io` with `React` -- we want to attach and detach event listeners in `useEffect()` according to the changes of the dependency array.

The example code looks like below:

```jsx
const MyComponent = ({ form, prop }) => {
  useEffect(() => {
    const doOnChange = () => {
        // Do something according to prop
    };

    form.on("change", doOnChange);

    // Clean up
    return () => {
      form.offOne("change", doOnChange);
    };
  }, [form, prop]);
};
```

If we don't remove the listener attached using `.on()`, we have memory leak;
If we remove the listener using `.off()`, it will affect all other listeners for the same event.

In this case, `.offOne()` is the answer:

```js
  /**
   * Remove one listener for a certain event. This is the exact opposite to `.on()`
   * 
   * @param {string} event - The event you wish to register the handler for.
   * @param {function} cb - The callback handler to handle this event.
   */
  offOne(event, cb) {
    if (!this.events) {
      return;
    }
    const type = `${this.options.namespace}.${event}`;

    const listener = this.events
      .listeners(type)
      .find(item => item && item === cb && item.id === this.id);
    if (!listener) {
      return;
    }

    this.events.off(type, listener);
  }
```