### PR TITLE
FIO-1068: Fixes an issue where revision of the Nested Form loaded on the front-end side differs from the one which loaded on the server-side

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -96,7 +96,9 @@ export default class FormComponent extends Component {
     }
 
     // Add revision version if set.
-    if (this.component.revision || this.component.revision === 0) {
+    if (this.component.revision || this.component.revision === 0 ||
+      this.component.formRevision || this.component.formRevision === 0
+    ) {
       this.setFormRevision(this.component.revision || this.component.formRevision);
     }
 

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -90,6 +90,11 @@ export default class FormComponent extends Component {
       }
     }
 
+    if (this.builderMode && this.component.hasOwnProperty('formRevision')) {
+      this.component.revision = this.component.formRevision;
+      delete this.component.formRevision;
+    }
+
     // Add revision version if set.
     if (
       this.component.revision || this.component.revision === 0 ||

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -96,10 +96,7 @@ export default class FormComponent extends Component {
     }
 
     // Add revision version if set.
-    if (
-      this.component.revision || this.component.revision === 0 ||
-      this.component.formRevision || this.component.formRevision === 0
-    ) {
+    if (this.component.revision || this.component.revision === 0) {
       this.setFormRevision(this.component.revision || this.component.formRevision);
     }
 

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -91,8 +91,11 @@ export default class FormComponent extends Component {
     }
 
     // Add revision version if set.
-    if (this.component.revision || this.component.revision === 0) {
-      this.setFormRevision(this.component.revision);
+    if (
+      this.component.revision || this.component.revision === 0 ||
+      this.component.formRevision || this.component.formRevision === 0
+    ) {
+      this.setFormRevision(this.component.revision || this.component.formRevision);
     }
 
     return this.createSubForm();

--- a/src/components/form/editForm/Form.edit.form.js
+++ b/src/components/form/editForm/Form.edit.form.js
@@ -46,6 +46,22 @@ export default [
     weight: 11,
   },
   {
+    type: 'textfield',
+    input: true,
+    label: 'Form Revision (Deprecated)',
+    description: `
+      <div class="alert alert-danger">
+        Having 'formRevision' property means that you form was configured in the older version of builder.
+        Please, remove it and use 'revision' property instead.
+      </div>
+    `,
+    customConditional({ data }) {
+      return !!data.formRevision;
+    },
+    key: 'formRevision',
+    weight: 11,
+  },
+  {
     type: 'checkbox',
     input: true,
     weight: 19,

--- a/src/components/form/editForm/Form.edit.form.js
+++ b/src/components/form/editForm/Form.edit.form.js
@@ -46,22 +46,6 @@ export default [
     weight: 11,
   },
   {
-    type: 'textfield',
-    input: true,
-    label: 'Form Revision (Deprecated)',
-    description: `
-      <div class="alert alert-danger">
-        Having 'formRevision' property means that you form was configured in the older version of builder.
-        Please, remove it and use 'revision' property (Form Revision) instead.
-      </div>
-    `,
-    customConditional({ data }) {
-      return !!data.formRevision;
-    },
-    key: 'formRevision',
-    weight: 11,
-  },
-  {
     type: 'checkbox',
     input: true,
     weight: 19,

--- a/src/components/form/editForm/Form.edit.form.js
+++ b/src/components/form/editForm/Form.edit.form.js
@@ -52,7 +52,7 @@ export default [
     description: `
       <div class="alert alert-danger">
         Having 'formRevision' property means that you form was configured in the older version of builder.
-        Please, remove it and use 'revision' property instead.
+        Please, remove it and use 'revision' property (Form Revision) instead.
       </div>
     `,
     customConditional({ data }) {


### PR DESCRIPTION
That issue appears in cases when form was imported or deployed from the older version of builder where revision of the Nested Form was specified using 'formRevision' property. 
Forms that has 'formRevision' property set to any number and 'revision' set to '' (which is default and means to load the current revision), the current version of the form is loaded on the front-end side and the one which 'formRevision' property refers to is loaded on the server-side (eg, for validation)
 