### PR TITLE
FJS-837: Fixes an issue where 0 and false are considered as empty values for Select 

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -398,15 +398,15 @@ export default class SelectComponent extends Field {
     this.loading = false;
 
     // If a value is provided, then select it.
-    if (this.dataValue) {
+    if (!this.isEmpty()) {
       this.setValue(this.dataValue, {
         noUpdateEvent: true
       });
     }
     else {
       // If a default value is provided then select it.
-      const defaultValue = this.multiple ? this.defaultValue || [] : this.defaultValue;
-      if (defaultValue) {
+      const defaultValue = this.defaultValue;
+      if (!this.isEmpty(defaultValue)) {
         this.setValue(defaultValue);
       }
     }
@@ -415,6 +415,14 @@ export default class SelectComponent extends Field {
     this.itemsLoadedResolve();
   }
   /* eslint-enable max-statements */
+
+  get defaultValue() {
+    let defaultValue = super.defaultValue;
+    if (!defaultValue && (this.component.defaultValue === false || this.component.defaultValue === 0)) {
+      defaultValue = this.component.defaultValue;
+    }
+    return defaultValue;
+  }
 
   loadItems(url, search, headers, options, method, body) {
     options = options || {};
@@ -543,6 +551,10 @@ export default class SelectComponent extends Field {
 
   updateCustomItems() {
     this.setItems(this.getCustomItems() || []);
+  }
+
+  isEmpty(value = this.dataValue) {
+    return super.isEmpty(value) || value === undefined;
   }
 
   refresh(value, { instance }) {
@@ -1097,7 +1109,7 @@ export default class SelectComponent extends Field {
     }
     const notFoundValuesToAdd = [];
     const added = values.reduce((defaultAdded, value) => {
-      if (!value || _.isEmpty(value)) {
+      if (this.isEmpty(value)) {
         return defaultAdded;
       }
       let found = false;
@@ -1290,8 +1302,8 @@ export default class SelectComponent extends Field {
     const previousValue = this.dataValue;
     const changed = this.updateValue(value, flags);
     value = this.dataValue;
-    const hasPreviousValue = Array.isArray(previousValue) ? previousValue.length : previousValue;
-    const hasValue = Array.isArray(value) ? value.length : value;
+    const hasPreviousValue = !this.isEmpty(previousValue);
+    const hasValue = !this.isEmpty(value);
 
     // Undo typing when searching to set the value.
     if (this.component.multiple && Array.isArray(value)) {
@@ -1341,7 +1353,7 @@ export default class SelectComponent extends Field {
   }
 
   setChoicesValue(value, hasPreviousValue, flags = {}) {
-    const hasValue = Array.isArray(value) ? value.length : value;
+    const hasValue = !this.isEmpty(value);
     hasPreviousValue = (hasPreviousValue === undefined) ? true : hasPreviousValue;
     if (this.choices) {
       // Now set the value.


### PR DESCRIPTION
Fixes 2 issues: 
1. When add Advanced logic and in Actions select Type = Property, Set State = False, then save Actions row and Logic row, reopen both rows and see that Set State is empty 
2. When create a Select component with values like {label: False, value: false} and set 'false' as a default value, the default value is not shown.