### PR TITLE
FJS-726: Fixes an issue where it is possible to check Save as Reference and set Value Property which cause unexpected behavior, because saving a s reference is only possible when there is an _id

### DIFF
--- a/src/components/select/editForm/Select.edit.data.js
+++ b/src/components/select/editForm/Select.edit.data.js
@@ -203,7 +203,7 @@ export default [
     label: 'Value Property',
     key: 'valueProperty',
     skipMerge: true,
-    clearOnHide: false,
+    clearOnHide: true,
     tooltip: 'The field to use as the value.',
     weight: 11,
     refreshOn: 'data.resource',
@@ -246,6 +246,7 @@ export default [
       json: {
         and: [
           { '===': [{ var: 'data.dataSrc' }, 'resource'] },
+          { '!==': [{ var: 'data.reference' }, true] },
           { var: 'data.data.resource' },
         ],
       },


### PR DESCRIPTION
Set Value Property to be hidden and cleared if Save as Reference is checked for Select component