### PR TITLE
FIO-1501: Fixes an issue where Preview component and Default Value component in Builder have the same ids

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1045,7 +1045,7 @@ export default class WebformBuilder extends Component {
     // Update the preview.
     if (this.preview) {
       this.preview.form = {
-        components: [_.omit(component, [
+        components: [_.omit({ ...component }, [
           'hidden',
           'conditional',
           'calculateValue',
@@ -1071,7 +1071,7 @@ export default class WebformBuilder extends Component {
       );
 
       if (!defaultChanged) {
-        _.assign(defaultValueComponent.component, _.omit(component, [
+        _.assign(defaultValueComponent.component, _.omit({ ...component }, [
           'key',
           'label',
           'placeholder',
@@ -1328,6 +1328,7 @@ export default class WebformBuilder extends Component {
 
     // This is the attach step.
     this.editForm.attach(this.componentEdit.querySelector('[ref="editForm"]'));
+    delete componentCopy.id;
     this.updateComponent(componentCopy);
 
     this.editForm.on('change', (event) => {


### PR DESCRIPTION
This leads to the next issues:
1) When you have Select Boxes with Max Checked validation and select the max amount in Form Builder component's Preview, the rest of the select boxes are disabled, but if you click on the label of the option, you can select the value.
2) Sometimes when you change the value inside preview (Select Boxes, Checkbox, Radio), the Default Value is also changed. 