### PR TITLE
FIO-2694: Fixes an issue where eachComponent considers nested components as layout components

### DIFF
--- a/src/components/editgrid/fixtures/comp9.js
+++ b/src/components/editgrid/fixtures/comp9.js
@@ -29,7 +29,7 @@ export default {
 				},
 				{
 					label: 'Container',
-					tableView: true,
+					tableView: false,
 					key: 'container',
 					conditional: { show: true, when: 'editGrid.textField', eq: 'show' },
 					type: 'container',

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -69,7 +69,7 @@ export function eachComponent(components, fn, includeAll, path, parent) {
 
     // there's no need to add other layout components here because we expect that those would either have columns, rows or components
     const layoutTypes = ['htmlelement', 'content'];
-    const isLayoutComponent = hasColumns || hasRows || hasComps || layoutTypes.indexOf(component.type) > -1;
+    const isLayoutComponent = hasColumns || hasRows || (hasComps && !component.input) || layoutTypes.indexOf(component.type) > -1;
     if (includeAll || component.tree || !isLayoutComponent) {
       noRecurse = fn(component, newPath, components);
     }


### PR DESCRIPTION
Probably, a long time ago only **Layout** components included **components** property. But now there are a lot of components which are **input components** and include **components** property as well (EditGrid, DataGrid, Address, Container, DynamicWizard, Tagpad, etc.). And eachComponent does **not call a callback** function with such components if there is not 'includeAll' flag, because it considers them **as layout components** which is not true.