### PR TITLE
Fix edit grid not translated column labels. Bind translation function to any interpolated string context.

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1466,7 +1466,7 @@ export default class Component extends Element {
       // Bind the translate function to the data context of any interpolated string.
       // It is useful to translate strings in different scenarions (eg: custom edit grid templates, custom error messages etc.)
       // and desirable to be publicly available rather than calling the internal {instance.t} function in the template string.
-      translate: this.t.bind(this),
+      t: this.t.bind(this),
       submission: (this.root ? this.root._submission : {
         data: this.rootValue
       }),

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1466,7 +1466,7 @@ export default class Component extends Element {
       // Bind the translate function to the data context of any interpolated string.
       // It is useful to translate strings in different scenarions (eg: custom edit grid templates, custom error messages etc.)
       // and desirable to be publicly available rather than calling the internal {instance.t} function in the template string.
-      translate: this.translate.bind(this),
+      translate: this.t.bind(this),
       submission: (this.root ? this.root._submission : {
         data: this.rootValue
       }),
@@ -1511,15 +1511,6 @@ export default class Component extends Element {
     return Templates.current.hasOwnProperty('iconClass')
       ? Templates.current.iconClass(iconset, name, spinning)
       : this.options.iconset === 'fa' ? Templates.defaultTemplates.iconClass(iconset, name, spinning) : name;
-  }
-
-  /**
-   * Gets the translation of the given label/text for the form current language
-   * @param {string} text
-   * @returns {string} - The translation of the text
-   */
-  translate(text) {
-    return this.t(text);
   }
 
   size(size) {

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1463,6 +1463,10 @@ export default class Component extends Element {
       rowIndex: this.rowIndex,
       data: this.rootValue,
       iconClass: this.iconClass.bind(this),
+      // Bind the translate function to the data context of any interpolated string.
+      // It is useful to translate strings in different scenarions (eg: custom edit grid templates, custom error messages etc.)
+      // and desirable to be publicly available rather than calling the internal {instance.t} function in the template string.
+      translate: this.translate.bind(this),
       submission: (this.root ? this.root._submission : {
         data: this.rootValue
       }),
@@ -1507,6 +1511,15 @@ export default class Component extends Element {
     return Templates.current.hasOwnProperty('iconClass')
       ? Templates.current.iconClass(iconset, name, spinning)
       : this.options.iconset === 'fa' ? Templates.defaultTemplates.iconClass(iconset, name, spinning) : name;
+  }
+
+  /**
+   * Gets the translation of the given label/text for the form current language
+   * @param {string} text
+   * @returns {string} - The translation of the text
+   */
+  translate(text) {
+    return this.t(text);
   }
 
   size(size) {

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -53,7 +53,7 @@ export default class EditGridComponent extends NestedArrayComponent {
     return `<div class="row">
       {% util.eachComponent(components, function(component) { %}
         {% if (displayValue(component)) { %}
-          <div class="col-sm-2">{{ component.label }}</div>
+          <div class="col-sm-2">{{ translate(component.label) }}</div>
         {% } %}
       {% }) %}
     </div>`;

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -53,7 +53,7 @@ export default class EditGridComponent extends NestedArrayComponent {
     return `<div class="row">
       {% util.eachComponent(components, function(component) { %}
         {% if (displayValue(component)) { %}
-          <div class="col-sm-2">{{ translate(component.label) }}</div>
+          <div class="col-sm-2">{{ t(component.label) }}</div>
         {% } %}
       {% }) %}
     </div>`;

--- a/src/components/editgrid/templates/header.ejs
+++ b/src/components/editgrid/templates/header.ejs
@@ -1,7 +1,7 @@
 <div class="row">
   {% ctx.util.eachComponent(ctx.components, function(component) { %}
     {% if (!component.hasOwnProperty('tableView') || component.tableView) { %}
-      <div class="col-sm-2">{{ component.label }}</div>
+      <div class="col-sm-2">{{ ctx.t(component.label) }}</div>
     {% } %}
   {% }) %}
 </div>


### PR DESCRIPTION
Fix edit grid not translated column labels. Bind translation function to any interpolated string.