### PR TITLE
Add aria-invalid attribute, improve test ergonomics

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,9 @@
     "node": true,
     "mocha": true
   },
+  "ignorePatterns": [
+    "!.*rc.js"
+  ],
   "rules": {
     "max-len": [
       "off",

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,10 @@
+process.env.TZ = 'UTC';
+
+module.exports = {
+  bail: true,
+  timeout: 20000,
+  require: [
+    '@babel/register',
+    'jsdom-global/register'
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "gulp eslint",
     "serve": "jekyll serve --config _config.yml,_config.dev.yml",
     "test": "npm run transpile && npm run templates && npm run test:unit",
-    "test:unit": "TZ=UTC mocha --require @babel/register --require jsdom-global/register 'lib/**/*.unit.js' -b -t 20000 --exit",
+    "test:unit": "mocha 'lib/**/*.unit.js'",
     "test:updateRenders": "TZ=UTC node --require @babel/register --require jsdom-global/register test/updateRenders.js",
     "test:e2e": "NODE_OPTIONS=\"--max-old-space-size=4096\" karma start --verbose --single-run"
   },

--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -1620,7 +1620,7 @@ describe('Webform tests', function() {
     }).catch(done);
   });
 
-  it('Should render Nested Modal Wizard Form correclty', (done) => {
+  it('Should render Nested Modal Wizard Form correctly', (done) => {
     formElement.innerHTML = '';
     const form = new Webform(formElement);
     form.setForm(nestedModalWizard).then(() => {
@@ -2348,7 +2348,7 @@ describe('Webform tests', function() {
     }).catch(done);
   });
 
-  it('Should add and clear input error classes correclty', (done) => {
+  it('Should add and clear input error classes correctly', (done) => {
     const formElement = document.createElement('div');
     const form = new Webform(formElement, { language: 'en', template: 'bootstrap3' });
 
@@ -2366,8 +2366,8 @@ describe('Webform tests', function() {
           const dateVisibleInput = dateComponentElement.querySelector('.input');
           const flatpickerInput = dateComponentElement.querySelector('.flatpickr-input');
 
-          assert(dateVisibleInput.className.includes('is-invalid'), 'Visible field should has invalid class');
-          assert(flatpickerInput.className.includes('is-invalid'), 'Flatpickr field should has invalid class as well');
+          assert(dateVisibleInput.className.includes('is-invalid'), 'Visible field should have invalid class');
+          assert(flatpickerInput.className.includes('is-invalid'), 'Flatpickr field should have invalid class as well');
 
           dateTimeComponent.setValue('2020-12-09T00:00:00');
 

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1979,12 +1979,16 @@ export default class Component extends Element {
 
   setErrorClasses(elements, dirty, hasErrors, hasMessages, element = this.element) {
     this.clearErrorClasses();
-    elements.forEach((element) => this.removeClass(this.performInputMapping(element), 'is-invalid'));
+    elements.forEach((element) => {
+      this.setElementInvalid(this.performInputMapping(element), false);
+    });
     this.setInputWidgetErrorClasses(elements, hasErrors);
 
     if (hasErrors) {
       // Add error classes
-      elements.forEach((input) => this.addClass(this.performInputMapping(input), 'is-invalid'));
+      elements.forEach((input) => {
+        this.setElementInvalid(this.performInputMapping(input), true);
+      });
 
       if (dirty && this.options.highlightErrors) {
         this.addClass(element, this.options.componentErrorClass);
@@ -1996,6 +2000,18 @@ export default class Component extends Element {
     if (hasMessages) {
       this.addClass(element, 'has-message');
     }
+  }
+
+  setElementInvalid(element, invalid) {
+    if (!element) return;
+
+    if (invalid) {
+      this.addClass(element, 'is-invalid');
+    }
+    else {
+      this.removeClass(element, 'is-invalid');
+    }
+    element.setAttribute('aria-invalid', invalid ? 'true' : 'false');
   }
 
   clearOnHide() {

--- a/src/widgets/CalendarWidget.js
+++ b/src/widgets/CalendarWidget.js
@@ -374,10 +374,12 @@ export default class CalendarWidget extends InputWidget {
     }
 
     if (hasErrors) {
-      this.input.className = `${this.input.className} is-invalid`;
+      this.addClass(this.input, 'is-invalid');
+      this.input.setAttribute('aria-invalid', 'true');
     }
     else {
-      this.input.className = this.input.className.replace('is-invalid', '');
+      this.removeClass(this.input, 'is-invalid');
+      this.input.setAttribute('aria-invalid', 'false');
     }
   }
 


### PR DESCRIPTION
This PR improves the accessibility of _most_ form inputs by updating the `aria-invalid` attribute to `true` or `false` whenever the `is-invalid` class is added or removed. This called for a new Component method, `setElementInvalid()`, which adds or removes the `is-invalid` class and sets `aria-invalid` in one go.

The only mention of the `is-invalid` class I could find in the tests was for the calendar widget, so I've updated those tests to also assert the correct value of `aria-invalid`. Ideally there would be invalid state tests for every component, but I think it's safe to say that if `is-invalid` is working as a style hook for invalid elements (and I've fixed this in all of the right places) all of the cases should be covered.

I've also introduced a Mocha config file in `.mocharc.js` and moved the CLI options from `package.json` into it so that it's easier to run one-off tests with `npx mocha lib/some/file.unit.js`. Eslint ignores files that begin with `.`, so I've negated it from the eslint config's `ignorePatterns` with `!.*rc.js`. I'm happy to break this out into a separate PR if you'd rather review something smaller. 🍻 