### PR TITLE
Override instead of overwrite modules setting for Quill.

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2162,7 +2162,8 @@ export default class Component extends Element {
     settings = {
       ...settings,
       modules: {
-        table: true
+        table: true,
+        ...settings.modules
       }
     };
     // Lazy load the quill css.


### PR DESCRIPTION
It's impossible to define custom "modules" settings if it's always overwritten by `{table: true}`.