### PR TITLE
Fix html render mode for the Day component

### DIFF
--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -226,6 +226,7 @@ export default class DayComponent extends Field {
       showDay: this.showDay,
       showMonth: this.showMonth,
       showYear: this.showYear,
+      parts: this.parts,
       day: this.renderField('day'),
       month: this.renderField('month'),
       year: this.renderField('year'),

--- a/src/templates/bootstrap/day/html.ejs
+++ b/src/templates/bootstrap/day/html.ejs
@@ -1,0 +1,34 @@
+<div class="row">
+  {% if (ctx.dayFirst && ctx.showDay) { %}
+  <div class="col col-xs-3">
+    {% if (!ctx.component.hideInputLabels) { %}
+    <label for="{{ctx.component.key}}-day" class="{% if(ctx.component.fields.day.required) { %}field-required{% } %}">{{ctx.t('Day')}}</label>
+    {% } %}
+    <div>{{ctx.parts.day}}</div>
+  </div>
+  {% } %}
+  {% if (ctx.showMonth) { %}
+  <div class="col col-xs-4">
+    {% if (!ctx.component.hideInputLabels) { %}
+    <label for="{{ctx.component.key}}-month" class="{% if(ctx.component.fields.month.required) { %}field-required{% } %}">{{ctx.t('Month')}}</label>
+    {% } %}
+    <div>{{ctx.parts.month}}</div>
+  </div>
+  {% } %}
+  {% if (!ctx.dayFirst && ctx.showDay) { %}
+  <div class="col col-xs-3">
+    {% if (!ctx.component.hideInputLabels) { %}
+    <label for="{{ctx.component.key}}-day" class="{% if(ctx.component.fields.day.required) { %}field-required{% } %}">{{ctx.t('Day')}}</label>
+    {% } %}
+    <div>{{ctx.parts.day}}</div>
+  </div>
+  {% } %}
+  {% if (ctx.showYear) { %}
+  <div class="col col-xs-5">
+    {% if (!ctx.component.hideInputLabels) { %}
+    <label for="{{ctx.component.key}}-year" class="{% if(ctx.component.fields.year.required) { %}field-required{% } %}">{{ctx.t('Year')}}</label>
+    {% } %}
+    <div>{{ctx.parts.year}}</div>
+  </div>
+  {% } %}
+</div>

--- a/src/templates/bootstrap/day/index.js
+++ b/src/templates/bootstrap/day/index.js
@@ -1,3 +1,4 @@
 import form from './form.ejs';
+import html from './html.ejs';
 
-export default { form };
+export default { form, html };

--- a/test/renders/component-bootstrap-day-html-value0.html
+++ b/test/renders/component-bootstrap-day-html-value0.html
@@ -5,23 +5,16 @@
   <div class="row" role="group" aria-labelledby="l-day-day">
     <div class="col col-xs-4">
       <label for="day-month" class="">Month</label>
-      <div>
-        <div ref="value">00/00/0000</div>
-      </div>
+      <div>0</div>
     </div>
     <div class="col col-xs-3">
       <label for="day-day" class="">Day</label>
-      <div>
-        <div ref="value">00/00/0000</div>
-      </div>
+      <div>0</div>
     </div>
     <div class="col col-xs-5">
       <label for="day-year" class="">Year</label>
-      <div>
-        <div ref="value">00/00/0000</div>
-      </div>
+      <div>0</div>
     </div>
   </div>
-  <input name="ctx.data[day]" type="hidden" class="form-control" lang="en" value="" ref="input">
   <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
 </div>

--- a/test/renders/component-bootstrap-day-html-value1.html
+++ b/test/renders/component-bootstrap-day-html-value1.html
@@ -5,23 +5,16 @@
   <div class="row" role="group" aria-labelledby="l-day-day">
     <div class="col col-xs-4">
       <label for="day-month" class="">Month</label>
-      <div>
-        <div ref="value">01/01/2001</div>
-      </div>
+      <div>1</div>
     </div>
     <div class="col col-xs-3">
       <label for="day-day" class="">Day</label>
-      <div>
-        <div ref="value">01/01/2001</div>
-      </div>
+      <div>1</div>
     </div>
     <div class="col col-xs-5">
       <label for="day-year" class="">Year</label>
-      <div>
-        <div ref="value">01/01/2001</div>
-      </div>
+      <div>2001</div>
     </div>
   </div>
-  <input name="ctx.data[day]" type="hidden" class="form-control" lang="en" value="" ref="input">
   <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
 </div>

--- a/test/renders/component-bootstrap-day-html-value2.html
+++ b/test/renders/component-bootstrap-day-html-value2.html
@@ -5,23 +5,16 @@
   <div class="row" role="group" aria-labelledby="l-day-day">
     <div class="col col-xs-4">
       <label for="day-month" class="">Month</label>
-      <div>
-        <div ref="value">12/31/1999</div>
-      </div>
+      <div>12</div>
     </div>
     <div class="col col-xs-3">
       <label for="day-day" class="">Day</label>
-      <div>
-        <div ref="value">12/31/1999</div>
-      </div>
+      <div>31</div>
     </div>
     <div class="col col-xs-5">
       <label for="day-year" class="">Year</label>
-      <div>
-        <div ref="value">12/31/1999</div>
-      </div>
+      <div>1999</div>
     </div>
   </div>
-  <input name="ctx.data[day]" type="hidden" class="form-control" lang="en" value="" ref="input">
   <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
 </div>


### PR DESCRIPTION
This fix provides an html template so that the Day component shows the individual date part values vs rendering the full date multiple times. I hope I'm not misunderstanding the way the Day component should work, let me know if that is the case.

**Current html rendering**
![image](https://user-images.githubusercontent.com/80373413/124992166-e06fa600-dfff-11eb-88ab-0dc962f29a9f.png)

**Rendering with this fix**
![image](https://user-images.githubusercontent.com/80373413/124992134-d2ba2080-dfff-11eb-9ef1-6fe9452640d5.png)
