### PR TITLE
FIO-4236: ClearOnRefresh and RefreshOn for Custom Data Source Select Elements

### DIFF
--- a/src/components/select/editForm/Select.edit.data.js
+++ b/src/components/select/editForm/Select.edit.data.js
@@ -500,7 +500,8 @@ export default [
           [
             'url',
             'resource',
-            'values'
+            'values',
+            'custom'
           ],
         ],
       },
@@ -558,7 +559,8 @@ export default [
           [
             'url',
             'resource',
-            'values'
+            'values',
+            'custom'
           ],
         ],
       },


### PR DESCRIPTION
This PR resolves issue #4236, where the ClearOnRefresh and RefreshOn elements are not present for SelectsCustom Data Source Type.

I added 'custom' data type to the list of allowed data sources in the condition of when these options should be shown. 