### PR TITLE
Select component - debounce option for server side filtering

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -31,6 +31,7 @@ export default class SelectComponent extends Field {
       lazyLoad: true,
       filter: '',
       searchEnabled: true,
+      searchDebounce: 0.3,
       searchField: '',
       minSearch: 0,
       readOnlyValue: false,
@@ -1052,7 +1053,14 @@ export default class SelectComponent extends Field {
         }
         this.isFromSearch = false;
       });
-      this.addEventListener(input, 'search', (event) => this.triggerUpdate(event.detail.value));
+      // avoid spamming the resource/url endpoint when we have server side filtering enabled.
+      const debounceTimeout = this.component.searchField && (this.isSelectResource || this.isSelectURL) ?
+      (this.component.searchDebounce || this.defaultSchema.searchDebounce) * 1000
+      : 0;
+      const updateComponent = (evt) => {
+        this.triggerUpdate(evt.detail.value);
+      };
+      this.addEventListener(input, 'search', _.debounce(updateComponent, debounceTimeout));
       this.addEventListener(input, 'stopSearch', () => this.triggerUpdate());
       this.addEventListener(input, 'hideDropdown', () => {
         if (this.choices && this.choices.input && this.choices.input.element) {

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -1055,7 +1055,7 @@ export default class SelectComponent extends Field {
       });
       // avoid spamming the resource/url endpoint when we have server side filtering enabled.
       const debounceTimeout = this.component.searchField && (this.isSelectResource || this.isSelectURL) ?
-      (this.component.searchDebounce || this.defaultSchema.searchDebounce) * 1000
+      (this.component.searchDebounce === 0 ? 0 : this.component.searchDebounce || this.defaultSchema.searchDebounce) * 1000
       : 0;
       const updateComponent = (evt) => {
         this.triggerUpdate(evt.detail.value);

--- a/src/components/select/Select.unit.js
+++ b/src/components/select/Select.unit.js
@@ -664,6 +664,50 @@ describe('Select Component', () => {
     }).catch(done);
   });
 
+  it('Server side search is debounced with the correct timeout', (done) => {
+    const form = _.cloneDeep(comp9);
+    form.components[1].lazyLoad = false;
+    form.components[1].searchDebounce = 0.7;
+    form.components[1].disableLimit = false;
+    form.components[1].searchField = 'name';
+    const element = document.createElement('div');
+
+    const originalMakeRequest = Formio.makeRequest;
+    Formio.makeRequest = function() {
+      return new Promise(resolve => {
+        resolve([]);
+      });
+    };
+
+    var searchHasBeenDebounced = false;
+    var originalDebounce = _.debounce;
+    _.debounce = (fn, timeout, opts) => {
+      searchHasBeenDebounced = timeout === 700;
+      return originalDebounce(fn, 0, opts);
+    };
+
+    Formio.createForm(element, form).then(form => {
+      const select = form.getComponent('select');
+      const searchField = select.element.querySelector('.choices__input.choices__input--cloned');
+      const focusEvent = new Event('focus');
+      searchField.dispatchEvent(focusEvent);
+
+      setTimeout(() => {
+        const keyupEvent = new Event('keyup');
+        searchField.value = 'the_name';
+        searchField.dispatchEvent(keyupEvent);
+
+        setTimeout(() => {
+          _.debounce = originalDebounce;
+          Formio.makeRequest = originalMakeRequest;
+
+          assert.equal(searchHasBeenDebounced, true);
+          done();
+        }, 50);
+      }, 200);
+    }).catch(done);
+  });
+
   it('Should provide "Allow only available values" validation', (done) => {
     const form = _.cloneDeep(comp10);
     form.components[0].validate.onlyAvailableItems = true;

--- a/src/components/select/editForm/Select.edit.data.js
+++ b/src/components/select/editForm/Select.edit.data.js
@@ -356,6 +356,36 @@ export default [
   {
     type: 'number',
     input: true,
+    key: 'searchDebounce',
+    label: 'Search request delay',
+    weight: 16,
+    description: 'The delay (in seconds) before the search request is sent.',
+    tooltip: 'The delay in seconds before the search request is sent, measured from the last character input in the search field.',
+    validate: {
+      min: 0,
+      customMessage: '',
+      json: '',
+      max: 1,
+    },
+    delimiter: false,
+    requireDecimal: false,
+    encrypted: false,
+    defaultValue: 0.3,
+    conditional: {
+      json: {
+        in: [
+          { var: 'data.dataSrc' },
+          [
+            'url',
+            'resource',
+          ],
+        ],
+      },
+    },
+  },
+  {
+    type: 'number',
+    input: true,
     key: 'minSearch',
     weight: 17,
     label: 'Minimum Search Length',


### PR DESCRIPTION
When querying endpoints for select options and we have server side filtering enabled (searchField is defined), the requests are not debounced which results in spamming the endpoints.

This PR introduces a new builder option to set a debounce timeout value, between 0 and 1s.