### PR TITLE
Add capture option to file fields

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -284,9 +284,12 @@ export default class FileComponent extends Field {
     if (this.component.multiple) {
       options.multiple = true;
     }
+    if (this.component.capture) {
+      options.capture = this.component.capture;
+    }
     //use "accept" attribute only for desktop devices because of its limited support by mobile browsers
+    const filePattern = this.component.filePattern.trim() || '';
     if (!this.isMobile.any) {
-      const filePattern = this.component.filePattern.trim() || '';
       const imagesPattern = 'image/*';
 
       if (this.imageUpload && (!filePattern || filePattern === '*')) {
@@ -297,6 +300,18 @@ export default class FileComponent extends Field {
       }
       else {
         options.accept = filePattern;
+      }
+    }
+    // if input capture is set, we need the "accept" attribute to determine which device to launch
+    else if (this.component.capture) {
+      if (filePattern.includes('video')) {
+        options.accept = 'video/*';
+      }
+      else if (filePattern.includes('audio')) {
+        options.accept = 'audio/*';
+      }
+      else {
+        options.accept = 'image/*';
       }
     }
 

--- a/src/components/file/editForm/File.edit.file.js
+++ b/src/components/file/editForm/File.edit.file.js
@@ -206,6 +206,30 @@ export default [
     }
   },
   {
+    type: 'radio',
+    input: true,
+    key: 'capture',
+    label: 'Enable device capture',
+    tooltip: 'This will allow a mobile device to open the camera or microphone directly in capture mode.',
+    optionsLabelPosition: 'right',
+    inline: true,
+    defaultValue: false,
+    values: [
+      {
+        label: 'Disabled',
+        value: 'false'
+      },
+      {
+        label: 'Environment (rear camera)',
+        value: 'environment'
+      },
+      {
+        label: 'User (front camera)',
+        value: 'user'
+      }
+    ]
+  },
+  {
     type: 'datagrid',
     input: true,
     label: 'File Types',

--- a/src/templates/bootstrap/file/form.ejs
+++ b/src/templates/bootstrap/file/form.ejs
@@ -72,13 +72,25 @@
     </div>
   {% } else if (!ctx.self.cameraMode) { %}
     <div class="fileSelector" ref="fileDrop" {{ctx.fileDropHidden ?'hidden' : ''}}>
-      <i class="{{ctx.iconClass('cloud-upload')}}"></i> {{ctx.t('Drop files to attach,')}}
+      {% if (!ctx.self.isMobile.any) { %}
+        <i class="{{ctx.iconClass('cloud-upload')}}"></i> {{ctx.t('Drop files to attach,')}}
+      {% } %}
         {% if (ctx.self.imageUpload && ctx.component.webcam) { %}
-          <a href="#" ref="toggleCameraMode"><i class="fa fa-camera"></i> {{ctx.t('use camera')}}</a>
-        {% } %}
+          <a href="#" ref="toggleCameraMode"><i class="fa fa-camera"></i>{{ctx.t('Use Camera')}}</a>
         {{ctx.t('or')}}
+        {% } %}
         <a href="#" ref="fileBrowse" class="browse">
-          {{ctx.t('browse')}}
+          {% if (ctx.self.isMobile.any && ctx.component.capture) { %}
+            {% if (ctx.component.filePattern && ctx.component.filePattern.includes("video")) { %}
+              <i class="fa fa-video"></i>{{ctx.t('Capture Video')}}
+            {% } else if (ctx.component.filePattern && ctx.component.filePattern.includes("audio")) { %}
+              <i class="fa fa-microphone"></i>{{ctx.t('Capture Audio')}}
+            {% } else { %}
+              <i class="fa fa-camera"></i>{{ctx.t('Capture Image')}}
+            {% } %}    
+          {% } else { %}
+            <i class="fa fa-folder-open"></i>{{ctx.t('Browse Files')}}
+          {% } %}
           <span class="sr-only">
             {{ctx.t('Browse to attach file for ' + ctx.component.label + '. ' + 
             (ctx.component.description ? ctx.component.description + '. ' : '') + 


### PR DESCRIPTION
This adds a new `capture` option to file fields, which allows a mobile device to open the camera or microphone directly in [capture mode](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture). This offers more flexibility over the current `webcam` setting as it lets the user configure which device to launch (camera, video, microphone- based on `filePattern`) and specify front or rear device, on supported platforms (iOS). Capture can be used alongside webcam and is ignored on desktop.

While working on this, I also tried to tidy up the file input a bit, removing the "Drop files to attach" label on mobile and adding some icons to the link buttons.

## Example Configurations

### Launch rear-facing camera
```js
{
  type: "file",
  label: "My Photos",
  key: "photos",
  storage: "base64",
  image: true,
  capture: "environment",
  filePattern: "image/*",
  multiple: true,
  imageSize: "250"
}
```

### Launch front-facing video camera
```js
{
  type: "file",
  label: "My Videos",
  key: "videos",
  storage: "base64",
  capture: "user",
  filePattern: "video/*",
  multiple: true,
  imageSize: "250"
}
```

### Launch microphone
```js
{
  type: "file",
  label: "My Audio",
  key: "audio",
  storage: "base64",
  capture: "environment",
  filePattern: "audio/*",
  multiple: true,
  imageSize: "250"
}
```

![image](https://user-images.githubusercontent.com/753187/137561657-059316ae-8624-4a45-a4ea-6e9f4dbbacc4.png)
