### PR TITLE
Fix: EditGrid Default Column Headers Translatable

### DIFF
--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -66,7 +66,7 @@ export default class EditGridComponent extends NestedArrayComponent {
       <tr>
         {% util.eachComponent(components, function(component) { %}
           {% if (!component.hasOwnProperty('tableView') || component.tableView) { %}
-            <td class="editgrid-table-column">{{ component.label }}</td>
+            <td class="editgrid-table-column">{{ t(component.label) }}</td>
           {% } %}
         {% }) %}
         {% if (!instance.options.readOnly && !instance.disabled) { %}


### PR DESCRIPTION
Added the `t` wrapper to the template for the column headers, as they were not being translated.