### PR TITLE
FIO-4595 | 4364: Fixes Select with URL keeping default value on pdf submission

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -521,7 +521,7 @@ export default class SelectComponent extends Field {
       return false;
     }
     // Live forms should always load.
-    if (!this.options.readOnly) {
+    if (!this.options.readOnly || (this.options.display === 'pdf' && this.options.readOnly)) {
       return true;
     }
 


### PR DESCRIPTION
It's another approach to fix 4364, because part of previous fix in formio-pdf broke Signature submission edit on pdf.
Removing that failing part here: https://github.com/formio/formio-pdf/pull/138