### PR TITLE
Allow customization of edit grid error messages

### DIFF
--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -1157,7 +1157,7 @@ export default class EditGridComponent extends NestedArrayComponent {
 
           if (!rowValid && errorContainer && (!this.component.rowDrafts || this.shouldValidateDraft(editRow))) {
             this.addClass(errorContainer,  'help-block' );
-            errorContainer.textContent = this.t('invalidRowError');
+            errorContainer.textContent = this.t(this.errorMessage('invalidRowError'));
           }
           else if (errorContainer) {
             errorContainer.textContent = '';
@@ -1170,14 +1170,14 @@ export default class EditGridComponent extends NestedArrayComponent {
 
     if (!rowsValid) {
       if (!silentCheck && (!this.component.rowDrafts || this.root?.submitted)) {
-        this.setCustomValidity(this.t('invalidRowsError'), dirty);
+        this.setCustomValidity(this.t(this.errorMessage('invalidRowsError')), dirty);
         // Delete this class, because otherwise all the components inside EditGrid will has red border even if they are valid
         this.removeClass(this.element, 'has-error');
       }
       return false;
     }
     else if (rowsEditing && this.saveEditMode) {
-      this.setCustomValidity(this.t('unsavedRowsError'), dirty);
+      this.setCustomValidity(this.t(this.errorMessage('unsavedRowsError')), dirty);
       return false;
     }
 


### PR DESCRIPTION
In #3580 `invalidRowError`, `invalidRowsError` and `unsavedRowsError` have been made translatable, but it should also be possible to customize them on a per component basis.