### PR TITLE
#1662 Additional fix "The input element's type ('email') does not support selectionStart"

### DIFF
--- a/src/components/_classes/multivalue/Multivalue.js
+++ b/src/components/_classes/multivalue/Multivalue.js
@@ -204,7 +204,14 @@ export default class Multivalue extends Field {
   // Saves current caret position to restore it after the component is redrawn
   saveCaretPosition(element, index) {
     if (this.root?.focusedComponent?.path === this.path) {
-      this.root.currentSelection = { selection: [element.selectionStart, element.selectionEnd], index };
+      try {
+        this.root.currentSelection = { selection: [element.selectionStart, element.selectionEnd], index };
+      }
+      catch (e) {
+        if (!(e instanceof DOMException)) {
+          console.debug(e);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
#1662 Additional fix for the error "The input element's type ('email') does not support selectionStart"
Fix for Chrome 49.