### PR TITLE
Resolve Gatsby SSR build error.

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -7,7 +7,7 @@ import fileProcessor from '../../providers/processor/fileProcessor';
 import BMF from 'browser-md5-file';
 
 let Camera;
-let webViewCamera = navigator.camera || Camera;
+let webViewCamera = 'undefined' !== typeof window ? navigator.camera : Camera;
 
 // canvas.toBlob polyfill.
 


### PR DESCRIPTION
Resolve Gatsby SSR build error.

"navigator" is not available during server side rendering.