### PR TITLE
Please set placement by default to "right-start"

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1116,7 +1116,7 @@ export default class Component extends Element {
         this.tooltips[index] = tippy(tooltip, {
           allowHTML: true,
           trigger: 'mouseenter click focus',
-          placement: 'right',
+          placement: 'right-start',
           zIndex: 10000,
           interactive: true,
           content: this.t(tooltipText, { _userInput: true }),


### PR DESCRIPTION
We're having trouble with tooltips when it reaches the edges of the page, esp with mobile. `right-start` will make this work