### PR TITLE
Fix and cleanup form submission api error handling

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1634,10 +1634,10 @@ export default class Webform extends NestedDataComponent {
           this.emit('requestDone');
           this.setAlert('success', '<p> Success </p>');
         }).catch((e) => {
-          this.showErrors(`${e.statusText ? e.statusText : ''} ${e.status ? e.status : e}`);
-          this.emit('error',`${e.statusText ? e.statusText : ''} ${e.status ? e.status : e}`);
-          console.error(`${e.statusText ? e.statusText : ''} ${e.status ? e.status : e}`);
-          this.setAlert('danger', `<p> ${e.statusText ? e.statusText : ''} ${e.status ? e.status : e} </p>`);
+          const message = `${e.statusText ? e.statusText : ''} ${e.status ? e.status : e}`;
+          this.emit('error', message);
+          console.error(message);
+          this.setAlert('danger', `<p> ${message} </p>`);
         });
     }
     else {


### PR DESCRIPTION
When the form submission request results in a 4xx or 5xx response, showErrors() is invoked with a message string. This is no longer supported and results in an exception, causing script abortion without any feedback to the user.

This PR removes the showErrors() call as it seems to be a leftover from a previous implementation that supported string arguments. The message is still displayed via setAlert().

I also cleaned up the error handling code by deduplicating the message composition code.