### PR TITLE
Hide removeItemButton on choicesjs select when the placeholder is selected

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -1240,7 +1240,7 @@ export default class SelectComponent extends Field {
     const items = this.choices._store.activeItems;
     if (!items.length) {
       this.choices._addItem({
-        value: placeholderValue,
+        value: '',
         label: placeholderValue,
         choiceId: 0,
         groupId: -1,

--- a/src/components/select/Select.unit.js
+++ b/src/components/select/Select.unit.js
@@ -744,7 +744,7 @@ describe('Select Component', () => {
 
     Formio.createForm(element, formObj).then(form => {
       const select = form.getComponent('select');
-      assert.equal(select.choices.containerInner.element.children[1].children[0].dataset.value, formObj.components[0].placeholder);
+      assert.equal(select.choices.containerInner.element.children[1].children[0].dataset.value, '');
       select.choices.showDropdown();
 
       setTimeout(() => {


### PR DESCRIPTION
<img width="1095" alt="Screen Shot 2022-08-29 at 12 22 17 PM" src="https://user-images.githubusercontent.com/21179028/187271546-ba4ca94e-2b1d-4cc5-a1a4-1fb6fe7c30a8.png">

Fixing a bug where the choices.js's removeItemButton (the x button in the screen shot) is being shown for the placeholder option.

According to the [choices.js readme](https://github.com/Choices-js/Choices#placeholder). The value of the placeholder option should be set to `''`. When the value is set to `''` the remove button is hidden. 
