### PR TITLE
fix: falsy currency defaults to USD

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -883,7 +883,7 @@ export function getNumberDecimalLimit(component, defaultLimit) {
 }
 
 export function getCurrencyAffixes({
-   currency = 'USD',
+   currency,
    decimalLimit,
    decimalSeparator,
    lang,
@@ -896,7 +896,7 @@ export function getCurrencyAffixes({
   regex += '(.*)?';
   const parts = (100).toLocaleString(lang, {
     style: 'currency',
-    currency,
+    currency: currency ? currency : "USD",
     useGrouping: true,
     maximumFractionDigits: decimalLimit || 0,
     minimumFractionDigits: decimalLimit || 0


### PR DESCRIPTION
Currency can be an empty string value as seen in #4494 
Changed to provide a default value when passed falsy value