### PR TITLE
FIO-5511: ensure contextual row data is validated correctly for nested components

### DIFF
--- a/src/Wizard.unit.js
+++ b/src/Wizard.unit.js
@@ -20,6 +20,7 @@ import formWithSignature from '../test/forms/formWithSignature';
 import wizardWithTooltip from '../test/forms/wizardWithTooltip';
 import wizardForHtmlModeTest from '../test/forms/wizardForHtmlRenderModeTest';
 import wizardTestForm from '../test/forms/wizardTestForm';
+import wizardTestFormWithNestedComponents from '../test/forms/wizardTestFormWithNestedComponents';
 import formWithNestedWizard from '../test/forms/formWIthNestedWizard';
 import wizardWithDataGridAndEditGrid from '../test/forms/wizardWithDataGridAndEditGrid';
 import customWizard from '../test/forms/customWizard';
@@ -564,6 +565,36 @@ describe('Wizard tests', () => {
             done();
           }, 200);
         }, 200);
+      }, 200);
+    })
+    .catch((err) => done(err));
+  });
+
+  it('Should NOT navigate to next page if it contains invalid nested component', function(done) {
+    const formElement = document.createElement('div');
+    const wizard = new Wizard(formElement);
+    const form = _.cloneDeep(wizardTestFormWithNestedComponents.form);
+
+    wizard.setForm(form).then(() => {
+      const checkPage = (pageNumber) => {
+        assert.equal(wizard.page, pageNumber, `Should open wizard page ${pageNumber + 1}`);
+      };
+      checkPage(0);
+      wizard.submission = {
+        data: {
+          outerContainer: {
+            firstComponent: 'c',
+            secondComponent: 'q',
+          }
+        }
+      };
+      wizard.nextPage();
+      setTimeout(() => {
+        const errors = wizard.errors;
+        checkPage(0);
+        assert(errors.length > 0, 'Must err before next page');
+        assert.equal(errors[0].message, 'Required Component is required');
+        done();
       }, 200);
     })
     .catch((err) => done(err));

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -643,6 +643,7 @@ export default class NestedComponent extends Field {
   }
 
   checkValidity(data, dirty, row, silentCheck) {
+    row = this.dataValue || row;
     if (!this.checkCondition(row, data)) {
       this.setCustomValidity('');
       return true;

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -642,17 +642,20 @@ export default class NestedComponent extends Field {
     );
   }
 
+  checkChildComponentsValidity(data, dirty, row, silentCheck, isParentValid) {
+    return this.getComponents().reduce(
+      (check, comp) => comp.checkValidity(data, dirty, row, silentCheck) && check,
+      isParentValid
+    );
+  }
+
   checkValidity(data, dirty, row, silentCheck) {
-    row = this.dataValue || row;
     if (!this.checkCondition(row, data)) {
       this.setCustomValidity('');
       return true;
     }
 
-    const isValid = this.getComponents().reduce(
-      (check, comp) => comp.checkValidity(data, dirty, row, silentCheck) && check,
-      super.checkValidity(data, dirty, row, silentCheck)
-    );
+    const isValid = this.checkChildComponentsValidity(data, dirty, row, silentCheck, super.checkValidity(data, dirty, row, silentCheck));
     this.checkModal(isValid, dirty);
     return isValid;
   }

--- a/src/components/container/Container.js
+++ b/src/components/container/Container.js
@@ -66,6 +66,10 @@ export default class ContainerComponent extends NestedDataComponent {
     }, Component.prototype.checkData.call(this, data, flags, row));
   }
 
+  checkChildComponentsValidity(data, dirty, row, silentCheck, isParentValid) {
+    return super.checkChildComponentsValidity(data, dirty, this.dataValue, silentCheck, isParentValid);
+  }
+
   focus() {
     const focusableElements = getFocusableElements(this.element);
       if (focusableElements && focusableElements[0]) {

--- a/test/forms/wizardTestFormWithNestedComponents.js
+++ b/test/forms/wizardTestFormWithNestedComponents.js
@@ -1,0 +1,235 @@
+const form = {
+  title: 'Test Form With Nested Components',
+  name: 'testFormWithNestedComponents',
+  path: 'testFormWithNestedComponents',
+  type: 'form',
+  display: 'wizard',
+  tags: [],
+  components: [
+    {
+      title: 'Page 1',
+      breadcrumbClickable: true,
+      buttonSettings: {
+        previous: true,
+        cancel: true,
+        next: true,
+      },
+      navigateOnEnter: false,
+      saveOnEnter: false,
+      scrollToTop: true,
+      collapsible: false,
+      key: 'page1',
+      type: 'panel',
+      label: 'Page 1',
+      input: false,
+      tableView: false,
+      components: [
+        {
+          label: 'Outer Container',
+          tableView: false,
+          calculateValue: '',
+          key: 'outerContainer',
+          type: 'container',
+          input: true,
+          components: [
+            {
+              legend: 'Inner Field Set',
+              customClass: 'form-page',
+              key: 'innerFieldSet',
+              type: 'fieldset',
+              label: 'Inner Field Set',
+              input: false,
+              tableView: false,
+              components: [
+                {
+                  legend: 'Innermost Field Set A',
+                  key: 'innermostFieldSetA',
+                  type: 'fieldset',
+                  label: 'Innermost Field Set A',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'First Component',
+                      optionsLabelPosition: 'right',
+                      inline: false,
+                      tableView: false,
+                      values: [
+                        {
+                          label: 'a',
+                          value: 'a',
+                          shortcut: '',
+                        },
+                        {
+                          label: 'b',
+                          value: 'b',
+                          shortcut: '',
+                        },
+                        {
+                          label: 'c',
+                          value: 'c',
+                          shortcut: '',
+                        },
+                      ],
+                      validate: {
+                        required: true,
+                      },
+                      key: 'firstComponent',
+                      type: 'radio',
+                      input: true,
+                    },
+                  ],
+                },
+                {
+                  legend: 'Innermost Field Set B',
+                  key: 'innermostFieldSetB',
+                  customConditional:
+                    "show=!!_.get(data,'outerContainer.firstComponent');",
+                  type: 'fieldset',
+                  label: 'Field Set',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Second Component',
+                      optionsLabelPosition: 'right',
+                      inline: false,
+                      tableView: false,
+                      values: [
+                        {
+                          label: 'q',
+                          value: 'q',
+                          shortcut: '',
+                        },
+                        {
+                          label: 'w',
+                          value: 'w',
+                          shortcut: '',
+                        },
+                        {
+                          label: 'e',
+                          value: 'e',
+                          shortcut: '',
+                        },
+                      ],
+                      validate: {
+                        required: true,
+                      },
+                      key: 'secondComponent',
+                      type: 'radio',
+                      input: true,
+                    },
+                  ],
+                },
+                {
+                  legend: 'Innermost Field Set C',
+                  key: 'innermostFieldSetC',
+                  customConditional: "let firstComponent=row.firstComponent;\nlet secondComponent=row.secondComponent;\nshow=false;\nif (!!firstComponent && !!secondComponent) {\n  let selected=_.find(_.find(_.get(form,'config.containerDataSource',[]),item=>item.firstComponent===firstComponent).types,item=>item.secondComponent===secondComponent);\n  show=_.isEmpty(_.get(selected,'requiredComponent'))===false;\n}\n",
+                  type: 'fieldset',
+                  label: 'Innermost Field Set C',
+                  input: false,
+                  tableView: false,
+                  components: [
+                    {
+                      label: 'Required Component',
+                      tableView: false,
+                      defaultValue: false,
+                      validate: {
+                        required: true,
+                      },
+                      key: 'requiredComponent',
+                      type: 'checkbox',
+                      input: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Page 2',
+      breadcrumbClickable: true,
+      buttonSettings: {
+        previous: true,
+        cancel: true,
+        next: true,
+      },
+      navigateOnEnter: false,
+      saveOnEnter: false,
+      scrollToTop: false,
+      collapsible: false,
+      key: 'page3',
+      type: 'panel',
+      label: 'Page 3',
+      input: false,
+      tableView: false,
+      components: [],
+    },
+  ],
+  settings: {},
+  properties: {},
+  controller: '',
+  revisions: '',
+  submissionRevisions: '',
+  _vid: 0,
+  config: {
+    containerDataSource: [
+      {
+        firstComponent: 'a',
+        types: [
+          {
+            secondComponent: 'q',
+            requiredComponent: {},
+          },
+          {
+            secondComponent: 'w',
+            requiredComponent: {},
+          },
+          {
+            secondComponent: 'e',
+            requiredComponent: {},
+          },
+        ],
+      },
+      {
+        firstComponent: 'b',
+        types: [
+          {
+            secondComponent: 'q',
+            requiredComponent: {},
+          },
+          {
+            secondComponent: 'w',
+            requiredComponent: {},
+          },
+          {
+            secondComponent: 'e',
+            requiredComponent: {},
+          },
+        ],
+      },
+      {
+        firstComponent: 'c',
+        types: [
+          {
+            secondComponent: 'q',
+            requiredComponent: 'Hello, world!',
+          },
+          {
+            secondComponent: 'w',
+            requiredComponent: {},
+          },
+          {
+            secondComponent: 'e',
+            requiredComponent: {},
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export default { form };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-5511

## Description

**What changed?**

Previously, forms with nested components (in particular, a container component) would conditionally show correctly based on a contextual `row` property but would not validate. This was due to the `row` property not being properly tied to a container component's context. This PR attempts to alleviate this problem by setting `row` to the component's `dataValue` property (or, in other words, keys into the submission data by its own property key) so it can be validated correctly if it has custom conditionals.

**Why have you chosen this solution?**

Although I'm fairly certain this is a minor change, this is my first renderer ticket, so I'm nervous about "unknown unknowns" here - I've requested a review from @TanyaGashtold to make sure I'm not barking up the wrong tree.

## Dependencies

n/a

## How has this PR been tested?

I added an automated test that covers the case of a wizard with numerous nested components, one of which is conditionally visible and is required. Previously, nextPage() would not validate the required component even if it was visible and unchecked. This test ensures that validation occurs correctly. 

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
