### PR TITLE
Should allow quotes in options

### DIFF
--- a/src/components/select/Select.unit.js
+++ b/src/components/select/Select.unit.js
@@ -167,6 +167,29 @@ describe('Select Component', () => {
     });
   });
 
+  it('should allow quotes in options', function(done) {
+    comp5.template = '<span>{{ item.label }}</span>';
+    comp5.uniqueOptions = true;
+    Harness.testCreate(SelectComponent, comp5).then((component) => {
+      component.setItems([{
+        'label': 'Label "1"',
+        'value': 'value1'
+      }, {
+        'label': "Label \"2\"",
+        'value': 'value2'
+      }, {
+        'label': 'Label \"3\"',
+        'value': 'value3'
+      }], false);
+
+      assert.equal(component.selectOptions.length, 3);
+      assert.equal(component.selectOptions[0].label, 'Label "1"');
+      assert.equal(component.selectOptions[1].label, 'Label "2"');
+      assert.equal(component.selectOptions[2].label, 'Label "3"');
+      done();
+    });
+  });
+
   it('should format unlisted values', function(done) {
     comp5.template = '<span>{{ item.label }}</span>';
     Harness.testCreate(SelectComponent, comp5).then((component) => {


### PR DESCRIPTION
Initial draft PR to demonstrate the problem by adding failing tests.

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-XXXX

## Description

**What changed?**

*Previously, formio.js ... This PR replaces this behavior by ...*

**Why have you chosen this solution?**

*Although there were many potential solutions such as ..., [my solution] was best because ...*

## Dependencies

*This PR depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

*I added automated tests to cover [all/the following] cases, including ...*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
