### PR TITLE
FIO-5685 Data in Select with Entire Object is set as an object

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -198,10 +198,10 @@ export default class SelectComponent extends ListComponent {
   }
 
   selectValueAndLabel(data) {
-    const value = this.getOptionValue(this.itemValue(data));
+    const value = this.getOptionValue((this.isEntireObjectDisplay() && !this.itemValue(data)) ? data : this.itemValue(data));
     return {
       value,
-      label: this.itemTemplate(data, value)
+      label: this.itemTemplate((this.isEntireObjectDisplay() && !_.isObject(data.data)) ? { data: data } : data, value)
     };
   }
 
@@ -1286,10 +1286,6 @@ export default class SelectComponent extends ListComponent {
       },
 
       object() {
-        if (_.isObject(this.value) && displayEntireObject && !retainObject) {
-          this.value = JSON.stringify(this.value);
-        }
-
         return this;
       },
 

--- a/src/components/select/Select.unit.js
+++ b/src/components/select/Select.unit.js
@@ -855,31 +855,6 @@ describe('Select Component', () => {
     }).catch(done);
   });
 
-  it('Should provide correct value', (done) => {
-    const form = _.cloneDeep(comp15);
-    const element = document.createElement('div');
-
-    Formio.createForm(element, form).then(form => {
-      const select = form.getComponent('select');
-      const value = '{"textField":"rgd","submit":true,"number":11}';
-      select.setValue(value);
-
-      setTimeout(() => {
-        assert.equal(select.getValue(), value);
-        assert.equal(select.dataValue, value);
-        const submit = form.getComponent('submit');
-        const clickEvent = new Event('click');
-        const submitBtn = submit.refs.button;
-        submitBtn.dispatchEvent(clickEvent);
-
-        setTimeout(() => {
-          assert.equal(select.dataValue, value);
-          done();
-        }, 200);
-      }, 200);
-    }).catch(done);
-  });
-
   it('Should show async custom values and be able to set submission', (done) => {
     const formObj = _.cloneDeep(comp16);
     const element = document.createElement('div');
@@ -919,4 +894,62 @@ describe('Select Component', () => {
   //     assert.equal(component.refs.input[0].value, '');
   //   });
   // });
+});
+
+describe('Select Component with Entire Object Value Property', () => {
+  it('Should provide correct value', (done) => {
+    const form = _.cloneDeep(comp15);
+    const element = document.createElement('div');
+
+    Formio.createForm(element, form).then(form => {
+      const select = form.getComponent('select');
+      const value = { 'textField':'rgd','submit':true,'number':11 };
+      select.setValue(value);
+
+      setTimeout(() => {
+        assert.equal(select.getValue(), value);
+        assert.equal(select.dataValue, value);
+        const submit = form.getComponent('submit');
+        const clickEvent = new Event('click');
+        const submitBtn = submit.refs.button;
+        submitBtn.dispatchEvent(clickEvent);
+
+        setTimeout(() => {
+          assert.equal(select.dataValue, value);
+          done();
+        }, 200);
+      }, 200);
+    }).catch(done);
+  });
+
+  it('Should provide correct items for Resource DataSrc Type and Entire Object Value Property', (done) => {
+    const form = _.cloneDeep(comp15);
+    const testItems = [
+      { textField: 'Jone', number: 1 },
+      { textField: 'Mary', number: 2 },
+      { textField: 'Sally', number: 3 }
+    ];
+    const element = document.createElement('div');
+
+    Formio.createForm(element, form).then(form => {
+      const select = form.getComponent('select');
+      select.setItems(testItems.map(item => ({ data: item })));
+      const value = { textField: 'Jone', number: 1 };
+      select.setValue(value);
+      assert.equal(select.selectOptions.length, 3);
+
+      setTimeout(() => {
+        assert.equal(select.dataValue, value);
+        const submit = form.getComponent('submit');
+        const clickEvent = new Event('click');
+        const submitBtn = submit.refs.button;
+        submitBtn.dispatchEvent(clickEvent);
+
+        setTimeout(() => {
+          assert.equal(typeof select.dataValue, 'object');
+          done();
+        }, 200);
+      }, 200);
+    }).catch(done);
+  });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-5685

## Description

Previously, Data in Select with Value Property as {Entire Object} was set as a string. This PR replaces this behavior by removing JSON.stringify method for value. Added the ability to use data in Select Component   with Value Property as {Entire Object} as an object, for example in Calculated Value.

## How has this PR been tested?

I added automated tests, including tests for Select Component with Value Property as {Entire Object} 

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
* [x] My changes generate no new warnings
* [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
* [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
