### PR TITLE
FIO-6220: added some new methods to CDN class

### DIFF
--- a/src/CDN.js
+++ b/src/CDN.js
@@ -5,6 +5,7 @@
 class CDN {
   constructor(baseUrl) {
     this.baseUrl = baseUrl || 'https://cdn.form.io';
+    this.overrides = {};
     this.libs = {
       'ace': '1.4.12',
       'bootstrap': '4.6.2',
@@ -12,8 +13,8 @@ class CDN {
       'flatpickr': '4.6.8',
       'flatpickr-formio': '4.6.13-formio.1',
       'font-awesome': '4.7.0',
-      'grid': '',
-      'moment-timezone': '',
+      'grid': 'latest',
+      'moment-timezone': 'latest',
       'quill': '1.3.7',
       'shortcut-buttons-flatpickr': '0.4.0',
       'uswds': '2.4.8',
@@ -25,18 +26,49 @@ class CDN {
     return this.libs[lib];
   }
 
+  setVersion(lib, version) {
+    this.libs[lib] = version;
+    this.updateUrls();
+  }
+
   setBaseUrl(url) {
     this.baseUrl = url;
     this.updateUrls();
   }
 
+  setOverrideUrl(lib, url) {
+    this.overrides[lib] = url;
+    this.updateUrls();
+  }
+
+  removeOverride(lib) {
+    delete this.overrides[lib];
+    this.updateUrls();
+  }
+
+  removeOverrides() {
+    this.overrides = {};
+    this.updateUrls();
+  }
+
+  buildUrl(cdnUrl, lib, version) {
+    let url;
+    if (version === 'latest' || version === '') {
+      url = `${cdnUrl}/${lib}`;
+    }
+    else {
+      url = `${cdnUrl}/${lib}/${version}`;
+    }
+    return url;
+  }
+
   updateUrls() {
     for (const lib in this.libs) {
-      if (this.libs[lib] === '') {
-        this[lib] = `${this.baseUrl}/${lib}`;
+      if (lib in this.overrides) {
+        this[lib] = this.buildUrl(this.overrides[lib], lib, this.libs[lib]);
       }
       else {
-        this[lib] = `${this.baseUrl}/${lib}/${this.libs[lib]}`;
+        this[lib] = this.buildUrl(this.baseUrl, lib, this.libs[lib]);
       }
     }
   }

--- a/src/CDN.js
+++ b/src/CDN.js
@@ -26,26 +26,31 @@ class CDN {
     return this.libs[lib];
   }
 
+  // Sets a specific library version
   setVersion(lib, version) {
     this.libs[lib] = version;
     this.updateUrls();
   }
 
+  // Sets base CDN url for all libraries
   setBaseUrl(url) {
     this.baseUrl = url;
     this.updateUrls();
   }
 
+  // Allows to override CDN url for a specific library
   setOverrideUrl(lib, url) {
     this.overrides[lib] = url;
     this.updateUrls();
   }
 
+  // Removes override for a specific library
   removeOverride(lib) {
     delete this.overrides[lib];
     this.updateUrls();
   }
 
+  // Removes all overrides
   removeOverrides() {
     this.overrides = {};
     this.updateUrls();

--- a/src/CDN.unit.js
+++ b/src/CDN.unit.js
@@ -2,11 +2,39 @@ import CDN from './CDN';
 import assert from 'power-assert';
 
 describe('Formio.js CDN class Tests', () => {
-  it('Should give correct cdn URLs', () => {
-    const cdn = new CDN('https://cdn.form.io');
+  let cdn;
+  before(() => {
+    cdn = new CDN('https://cdn.form.io');
+  });
+
+  it('Should give correct CDN URLs', () => {
     for (const lib in cdn.libs) {
       let expectedUrl = `${cdn.baseUrl}/${lib}/${cdn.libs[lib]}`;
-      if (cdn.libs[lib] === '') {
+      if (cdn.libs[lib] === '' || cdn.libs[lib] === 'latest') {
+        expectedUrl = `${cdn.baseUrl}/${lib}`;
+      }
+      assert.equal(cdn[lib], expectedUrl);
+    }
+  });
+
+  it('Should update lib versions', () => {
+    cdn.setVersion('grid', '1.1.1');
+    assert.equal(cdn.grid, 'https://cdn.form.io/grid/1.1.1');
+  });
+
+  it('Shoudl override CDN urls', () => {
+    cdn.setOverrideUrl('grid', 'http://cdn.test-form.io');
+    cdn.setVersion('grid', 'latest');
+    assert.equal(cdn.grid, `http://cdn.test-form.io/grid`);
+
+    cdn.setOverrideUrl('ace', 'http://cdn.test-form.io');
+  });
+
+  it('Should remove overrides', () => {
+    cdn.removeOverrides();
+    for (const lib in cdn.libs) {
+      let expectedUrl = `${cdn.baseUrl}/${lib}/${cdn.libs[lib]}`;
+      if (cdn.libs[lib] === '' || cdn.libs[lib] === 'latest') {
         expectedUrl = `${cdn.baseUrl}/${lib}`;
       }
       assert.equal(cdn[lib], expectedUrl);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6220

## Description

**What changed?**

*Previously, CDN class lack some methods to override CDN ursl for a specific library. This PR adds that method as well as methods to set specific library version and remove overrides.*

## Dependencies

*This PR doest not depend on any PRs.*

## How has this PR been tested?

*I added automated tests to cover all cases.*

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
