### PR TITLE
FIO-6621: added rc version determination for cdn url

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -1670,6 +1670,9 @@ Formio.version = '---VERSION---';
 Formio.pathType = '';
 Formio.events = new EventEmitter();
 Formio.cdn = new CDN();
+if ((Formio.version || '').includes('rc')) {
+  Formio.cdn.setBaseUrl('https://cdn.test-form.io');
+}
 
 if (typeof global !== 'undefined') {
   Formio.addToGlobal(global);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6621

## Description

**What changed?**

*Previously, formio.js had CDN url set to https://cdn.form.io by default and that didn't depend on version. With this PR CDN url will be https://cdn.test-form.io if the version is rc*

## Dependencies

*This PR doesn't depend on any PRs.*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
