### PR TITLE
Ensure that url requests to relative root should prepend the base url.

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -916,6 +916,10 @@ class Formio {
       return NativePromise.resolve(cloneResponse(_Formio.cache[cacheKey]));
     }
 
+    if (url[0] === '/') {
+      url = Formio.baseUrl() + url;
+    }
+
     // Set up and fetch request
     const headers = header || new Headers(opts.headers || {
       'Accept': 'application/json',

--- a/src/Formio.unit.js
+++ b/src/Formio.unit.js
@@ -637,6 +637,11 @@ describe('Formio.js Tests', () => {
         type: 'form'
       },
       {
+        url: '/project/myproject/form/0123456789ABCDEF01234567',
+        method: 'PUT',
+        type: 'form'
+      },
+      {
         url: 'https://api.localhost:3000/project/myproject/form/0123456789ABCDEF01234567',
         method: 'DELETE',
         type: 'form'


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-XXXX

## Description

**What changed?**

If the url request starts with a '/' it can be assumed that it should go to the base url.

**Why have you chosen this solution?**

If the url request starts with a '/' it can be assumed that it should go to the base url.

## Dependencies

None

## How has this PR been tested?

I added automated tests to cover all cases

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
