### PR TITLE
FIO-6229 fixed displaying html value on Data tab for inputFormat plain

### DIFF
--- a/src/components/textfield/TextField.js
+++ b/src/components/textfield/TextField.js
@@ -199,6 +199,13 @@ export default class TextFieldComponent extends Input {
     };
   }
 
+  getValueAsString(value, options) {
+    if (value && this.component.inputFormat === 'plain' && /<[^<>]+>/g.test(value)) {
+      value = value.replaceAll('<','&lt;').replaceAll('>', '&gt;');
+    }
+    return super.getValueAsString(value, options);
+  }
+
   isHtmlRenderMode() {
     return super.isHtmlRenderMode() ||
       ((this.options.readOnly || this.disabled) &&


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6229

## Description

**What changed?**

Previously, if  html string was entered into the TextFIeld Component with Input Type 'plain', then the value for this input was displayed as html in the Data tab . Example below
![6229](https://user-images.githubusercontent.com/96909212/215102154-e38ff992-0d18-420e-93b1-6d6c270d9fe9.png)

After the changes, if the TextField Component has property Input Type = 'plain' , then this component will be displayed as a string in the Data tab. The same as on the View tab. Example below
![6229-1](https://user-images.githubusercontent.com/96909212/215103476-b69ef98f-1b76-48c5-9889-5a87b65bc966.png)


## Dependencies

*no*

## How has this PR been tested?

*manually, all automated tests were passed locally*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
