### PR TITLE
FIO-3884 Improved column comparison by excluding the id.

### DIFF
--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -622,7 +622,14 @@ export default class DataGridComponent extends NestedArrayComponent {
 
           if (col.component.logic && firstRowCheck) {
             const compIndex = _.findIndex(this.columns, ['key', key]);
-            if (!_.isEqual(this.columns[compIndex], col.component)) {
+            const equalColumns = _.isEqualWith(this.columns[compIndex], col.component, (col1, col2, key) => {
+              // Don't compare columns by their auto-generated ids.
+              if (key === 'id') {
+                return true;
+              }
+            });
+
+            if (!equalColumns) {
               logicRebuild = true;
               this.columns[compIndex] = col.component;
             }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-3884
https://github.com/formio/formio.js/pull/4497

## Description

**What changed?**

I have updated how we compare columns to determine if the datagrid needs to be updated.
The previous comparison would compare every field including the auto-generated "id" field.
Through debugging, I've found that the datagrid was being re-drawn unnecessarily because the only field in the columns that were different were the "id"s.
I've updated the logic to ignore the id field when comparing.

**Why have you chosen this solution?**

I kept the majority of the previous solution, simply skipping the comparison of the id to avoid unnecessary rebuilding of the datagrids.

## How has this PR been tested?

I tested it locally with my use case and this reduced the re-drawing of the grid.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
