### PR TITLE
FIO-5565: add logout redirect for SAML

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -1389,6 +1389,9 @@ class Formio {
     return Formio.makeRequest(formio, 'logout', `${projectUrl}/logout`)
       .then(function(result) {
         logout();
+        if (result.shouldRedirect && result.url) {
+          window.location.href = result.url;
+        }
         return result;
       })
       .catch(function(err) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-5565

## Description

**What changed?**

On logout, the client previously would clear the cache and remove the user token from local storage. This PR will allow the client to receive a redirect request from the API server (for now in the case of SAML logout) to redirect to an IdP logout URL after clearing the Form.io token(s) and cache.

## Dependencies


## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
