### PR TITLE
FIO-6431 fixed display of premium components using Quick Inline Embed link

### DIFF
--- a/src/Embed.js
+++ b/src/Embed.js
@@ -28,8 +28,8 @@ export function embed(config = {}) {
       config.formioPath(scriptSrc);
     }
     scriptSrc = scriptSrc.join('/');
-    query.script = query.script || (`${scriptSrc}/formio.form.min.js`);
-    query.styles = query.styles || (`${scriptSrc}/formio.form.min.css`);
+    query.script = query.script || (`${config.updatePath ? config.updatePath() :scriptSrc}/formio.form.min.js`);
+    query.styles = query.styles || (`${config.updatePath ? config.updatePath() :scriptSrc}/formio.form.min.css`);
     const cdn = query.cdn || 'https://cdn.jsdelivr.net/npm';
 
     const resolveLibs = (cdn) => {
@@ -191,7 +191,7 @@ export function embed(config = {}) {
     };
 
     // Create a loader
-    addStyles(`${scriptSrc}/formio.embed.min.css`);
+    addStyles(`${config.updatePath ? config.updatePath() : scriptSrc}/formio.embed.min.css`);
     debug('Creating loader');
     const loader = createElement('div', {
       'class': 'formio-loader'


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6431

## Description

*Changed Quick Inline Embed link for hosted. Now, when using the Quick Inline Embed link, Premium Components are displayed and work as in the portal*

## Dependencies

*https://github.com/formio/formio-app/pull/1399*

## How has this PR been tested?

*manually*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
