### PR TITLE
init() Submission with Existing Data

### DIFF
--- a/src/displays/webform/Webform.js
+++ b/src/displays/webform/Webform.js
@@ -943,7 +943,7 @@ export class Webform extends NestedDataComponent {
    * Build the form.
    */
   init() {
-    this._submission = this._submission || { data: {} };
+    this._submission = this._submission || { data: this._data || {} };
 
     // Remove any existing components.
     if (this.components && this.components.length) {


### PR DESCRIPTION
With our components that aren't using a debounced onChange when an existing submission is edited we're getting an onChange the sets it to empty values. I found it was because `submission` was defaulting to an empty data.