### PR TITLE
FIO-6468-Custom_validation_on_Day_component_confusing_Day_and_Year

### DIFF
--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -345,21 +345,23 @@ export default class DayComponent extends Field {
     }
     const dateParts = [];
     const valueParts = value.split('/');
+    const [DAY, MONTH, YEAR] = this.component.dayFirst ? [0, 1, 2] : [1, 0, 2];
+    const defaultValue = this.component.defaultValue ? this.component.defaultValue.split('/') : '';
 
     const getNextPart = (shouldTake, defaultValue) =>
       dateParts.push(shouldTake ? valueParts.shift() : defaultValue);
 
     if (this.dayFirst) {
-      getNextPart(this.showDay, '00');
+      getNextPart(this.showDay, defaultValue ? defaultValue[DAY] : '00');
     }
 
-    getNextPart(this.showMonth, '00');
+    getNextPart(this.showMonth, defaultValue ? defaultValue[MONTH] : '00');
 
     if (!this.dayFirst) {
-      getNextPart(this.showDay, '00');
+      getNextPart(this.showDay, defaultValue ? defaultValue[DAY] : '00');
     }
 
-    getNextPart(this.showYear, '0000');
+    getNextPart(this.showYear, defaultValue ? defaultValue[YEAR] : '0000');
 
     return dateParts.join('/');
   }

--- a/src/components/day/Day.unit.js
+++ b/src/components/day/Day.unit.js
@@ -174,4 +174,38 @@ describe('Day Component', () => {
       done();
     });
   });
+
+  it('Should use the default day value if the day field is hidden', (done) => {
+    comp1.dayFirst = false;
+    comp1.defaultValue = '00/01/0000';
+    comp1.fields.day.hide = true;
+    Harness.testCreate(DayComponent, comp1).then((component) => {
+      component.setValue('12/2023');
+      assert.equal(component.data.date, '12/01/2023');
+      done();
+    });
+    comp1.fields.day.hide = false;
+  });
+
+  it('Should use the default month value if the month field is hidden', (done) => {
+    comp1.defaultValue = '03/00/0000';
+    comp1.fields.month.hide = true;
+    Harness.testCreate(DayComponent, comp1).then((component) => {
+      component.setValue('12/2023');
+      assert.equal(component.data.date, '03/12/2023');
+      done();
+    });
+    comp1.fields.month.hide = false;
+  });
+
+  it('Should use the default year value if the year field is hidden', (done) => {
+    comp1.defaultValue = '00/00/2023';
+    comp1.fields.year.hide = true;
+    Harness.testCreate(DayComponent, comp1).then((component) => {
+      component.setValue('12/21');
+      assert.equal(component.data.date, '12/21/2023');
+      done();
+    });
+    comp1.fields.year.hide = false;
+  });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/jira/software/c/projects/FIO/issues/FIO-6468

## Description

**What changed?**
Fixed issue with default value in the day component

## Dependencies

## How has this PR been tested?

I added automated tests to cover all cases

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
