### PR TITLE
Fio 6512 cannot drag and drop components on to pdf first forms using mac

### DIFF
--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -441,7 +441,8 @@ export default class PDFBuilder extends WebformBuilder {
       if (getBrowserInfo().chrome && global.navigator.userAgentData.platform === 'macOS' && iframeRect.left < e.clientX && iframeRect.top < e.clientY) {
         this.dropEvent = e;
         this.dropEvent.dataTransfer.effectAllowed = 'all';
-      } else {
+      }
+      else {
         return;
       }
     }

--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -3,7 +3,7 @@ import NativePromise from 'native-promise-only';
 import { GlobalFormio as Formio } from './Formio';
 
 import WebformBuilder from './WebformBuilder';
-import { fastCloneDeep, getElementRect } from './utils/utils';
+import { fastCloneDeep, getElementRect , getBrowserInfo } from './utils/utils';
 import { eachComponent } from './utils/formUtils';
 import BuilderUtils from './utils/builder';
 import PDF from './PDF';
@@ -427,6 +427,7 @@ export default class PDFBuilder extends WebformBuilder {
   onDragEnd(e) {
     // IMPORTANT - must retrieve offsets BEFORE disabling the dropzone - offsets will
     // reflect absolute positioning if accessed after the target element is hidden
+    const iframeRect = this.webform.refs.iframeContainer.getBoundingClientRect();
     const layerX = this.dropEvent ? this.dropEvent.layerX : null;
     const layerY = this.dropEvent ? this.dropEvent.layerY : null;
     const WIDTH = 100;
@@ -436,7 +437,13 @@ export default class PDFBuilder extends WebformBuilder {
 
     // If there hasn't been a drop event on the dropzone, we're done
     if (!this.dropEvent) {
-      return;
+      // a 'drop' event may not be emited in the chrome browser when using a Mac, therefore an additional check has been added
+      if (getBrowserInfo().chrome && global.navigator.userAgentData.platform === 'macOS' && iframeRect.left < e.clientX && iframeRect.top < e.clientY) {
+        this.dropEvent = e;
+        this.dropEvent.dataTransfer.effectAllowed = 'all';
+      } else {
+        return;
+      }
     }
 
     const element = e.target;
@@ -455,8 +462,8 @@ export default class PDFBuilder extends WebformBuilder {
     this.webform._form.components.push(schema);
 
     schema.overlay = {
-      top: layerY - this.itemOffsetY + HEIGHT,
-      left: layerX - this.itemOffsetX,
+      top: layerY ? (layerY - this.itemOffsetY + HEIGHT) : (e.clientY - iframeRect.top - (this.itemOffsetY - HEIGHT )*2),
+      left: layerX ? (layerX - this.itemOffsetX) : (e.clientX - iframeRect.left - this.itemOffsetX*2),
       width: WIDTH,
       height: HEIGHT
     };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6512

## Description

*fixed drag and drop functionality  on PDF first form when using Mac and Chrome browser*

## How has this PR been tested?

*manually*

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
