### PR TITLE
FIO-6345: Add rel=noopener to Portal Application Links to Docs / External Links

### DIFF
--- a/src/components/_classes/component/editForm/Component.edit.conditional.js
+++ b/src/components/_classes/component/editForm/Component.edit.conditional.js
@@ -47,7 +47,7 @@ export default [
     '<p>You must assign the <strong>show</strong> variable a boolean result.</p>' +
     '<p><strong>Note: Advanced Conditional logic will override the results of the Simple Conditional logic.</strong></p>' +
     '<h5>Example</h5><pre>show = !!data.showMe;</pre>',
-    '<p><a href="http://formio.github.io/formio.js/app/examples/conditions.html" target="_blank">Click here for an example</a></p>'
+    '<p><a href="http://formio.github.io/formio.js/app/examples/conditions.html" target="_blank" rel="noopener noreferrer">Click here for an example</a></p>'
   )
 ];
 /* eslint-enable quotes, max-len */

--- a/src/components/_classes/component/editForm/Component.edit.data.js
+++ b/src/components/_classes/component/editForm/Component.edit.data.js
@@ -140,7 +140,7 @@ export default [
   ),
   EditFormUtils.javaScriptValue('Calculated Value', 'calculateValue', 'calculateValue', 1100,
     '<p><h4>Example:</h4><pre>value = data.a + data.b + data.c;</pre></p>',
-    '<p><h4>Example:</h4><pre>{"+": [{"var": "data.a"}, {"var": "data.b"}, {"var": "data.c"}]}</pre><p><a target="_blank" href="http://formio.github.io/formio.js/app/examples/calculated.html">Click here for an example</a></p>',
+    '<p><h4>Example:</h4><pre>{"+": [{"var": "data.a"}, {"var": "data.b"}, {"var": "data.c"}]}</pre><p><a href="http://formio.github.io/formio.js/app/examples/calculated.html" target="_blank" rel="noopener noreferrer">Click here for an example</a></p>',
 '<tr><th>token</th><td>The decoded JWT token for the authenticated user.</td></tr>'
   ),
   {

--- a/src/components/_classes/component/editForm/Component.edit.validation.js
+++ b/src/components/_classes/component/editForm/Component.edit.validation.js
@@ -114,7 +114,7 @@ export default [
         type: 'htmlelement',
         tag: 'div',
         /* eslint-disable prefer-template */
-        content: '<p>Execute custom logic using <a href="http://jsonlogic.com/" target="_blank">JSONLogic</a>.</p>' +
+        content: '<p>Execute custom logic using <a href="http://jsonlogic.com/" target="_blank" rel="noopener noreferrer">JSONLogic</a>.</p>' +
           '<h5>Example:</h5>' +
           '<pre>' + JSON.stringify({
             "if": [

--- a/src/components/_classes/component/editForm/utils.js
+++ b/src/components/_classes/component/editForm/utils.js
@@ -52,8 +52,8 @@ const EditFormUtils = {
       '<tr><th>instance</th><td>The current component instance.</td></tr>' +
       '<tr><th>value</th><td>The current value of the component.</td></tr>' +
       '<tr><th>moment</th><td>The moment.js library for date manipulation.</td></tr>' +
-      '<tr><th>_</th><td>An instance of <a href="https://lodash.com/docs/" target="_blank">Lodash</a>.</td></tr>' +
-      '<tr><th>utils</th><td>An instance of the <a href="http://formio.github.io/formio.js/docs/identifiers.html#utils" target="_blank">FormioUtils</a> object.</td></tr>' +
+      '<tr><th>_</th><td>An instance of <a href="https://lodash.com/docs/" target="_blank" rel="noopener noreferrer">Lodash</a>.</td></tr>' +
+      '<tr><th>utils</th><td>An instance of the <a href="http://formio.github.io/formio.js/docs/identifiers.html#utils" target="_blank" rel="noopener noreferrer">FormioUtils</a> object.</td></tr>' +
       '<tr><th>util</th><td>An alias for "utils".</td></tr>' +
       '</table><br/>'
       /* eslint-enable prefer-template */
@@ -100,8 +100,8 @@ const EditFormUtils = {
             type: 'htmlelement',
             tag: 'div',
             /* eslint-disable prefer-template */
-            content: '<p>Execute custom logic using <a href="http://jsonlogic.com/" target="_blank">JSONLogic</a>.</p>' +
-              '<p>Full <a href="https://lodash.com/docs" target="_blank">Lodash</a> support is provided using an "_" before each operation, such as <code>{"_sum": {var: "data.a"}}</code></p>' +
+            content: '<p>Execute custom logic using <a href="http://jsonlogic.com/" target="_blank" rel="noopener noreferrer">JSONLogic</a>.</p>' +
+              '<p>Full <a href="https://lodash.com/docs" target="_blank" rel="noopener noreferrer">Lodash</a> support is provided using an "_" before each operation, such as <code>{"_sum": {var: "data.a"}}</code></p>' +
                exampleJSON
             /* eslint-enable prefer-template */
           },

--- a/src/components/datetime/editForm/DateTime.edit.date.js
+++ b/src/components/datetime/editForm/DateTime.edit.date.js
@@ -40,7 +40,7 @@ export default [
         editor: 'ace',
         key: 'datePicker.disableFunction',
         label: 'Disabling dates by a function',
-        description: 'For more information check out the <a href="https://flatpickr.js.org/examples/#disabling-dates" target="_blank">Docs</a>',
+        description: 'For more information check out the <a href="https://flatpickr.js.org/examples/#disabling-dates" target="_blank" rel="noopener noreferrer">Docs</a>',
         weight: 22
       },
       {

--- a/src/components/datetime/editForm/DateTime.edit.display.js
+++ b/src/components/datetime/editForm/DateTime.edit.display.js
@@ -58,7 +58,7 @@ export default [
     key: 'format',
     label: 'Format',
     placeholder: 'Format',
-    description: 'Use formats provided by <a href="https://github.com/angular-ui/bootstrap/tree/master/src/dateparser/docs#uibdateparsers-format-codes" target="_blank">DateParser Codes</a>',
+    description: 'Use formats provided by <a href="https://github.com/angular-ui/bootstrap/tree/master/src/dateparser/docs#uibdateparsers-format-codes" target="_blank" rel="noopener noreferrer">DateParser Codes</a>',
     tooltip: 'The date format for displaying the datetime value.',
     weight: 52
   },

--- a/src/components/form/editForm/Form.edit.data.js
+++ b/src/components/form/editForm/Form.edit.data.js
@@ -7,7 +7,7 @@ export default [
   ),
   EditFormUtils.javaScriptValue('Calculated Value', 'calculateValue', 'calculateValue', 130,
     '<p><h4>Example:</h4><pre>value = data.a + data.b + data.c;</pre></p>',
-    '<p><h4>Example:</h4><pre>{"+": [{"var": "data.a"}, {"var": "data.b"}, {"var": "data.c"}]}</pre><p><a target="_blank" href="http://formio.github.io/formio.js/app/examples/calculated.html">Click here for an example</a></p>'
+    '<p><h4>Example:</h4><pre>{"+": [{"var": "data.a"}, {"var": "data.b"}, {"var": "data.c"}]}</pre><p><a href="http://formio.github.io/formio.js/app/examples/calculated.html" target="_blank" rel="noopener noreferrer">Click here for an example</a></p>'
   ),
   {
     weight: 140,

--- a/src/components/unknown/editForm/Unknown.edit.display.js
+++ b/src/components/unknown/editForm/Unknown.edit.display.js
@@ -6,7 +6,7 @@ export default [
     tag: 'p',
     content: 'Custom components can be used to render special fields or widgets inside your app. ' +
       'For information on how to display in an app, see ' +
-      '<a href="http://help.form.io/userguide/#custom" target="_blank">' +
+      '<a href="http://help.form.io/userguide/#custom" target="_blank" rel="noopener noreferrer">' +
       'custom component documentation' +
       '</a>.',
     type: 'htmlelement',

--- a/src/templates/bootstrap/builderEditForm/form.ejs
+++ b/src/templates/bootstrap/builderEditForm/form.ejs
@@ -5,7 +5,7 @@
   {% if (ctx.helplinks) { %}
   <div class="col col-sm-6">
     <div class="float-right" style="margin-right: 20px; margin-top: 10px">
-      <a href="{{ctx.t(ctx.helplinks + ctx.componentInfo.documentation)}}" target="_blank">
+      <a href="{{ctx.t(ctx.helplinks + ctx.componentInfo.documentation)}}" target="_blank" rel="noopener noreferrer">
         <i class="{{ctx.iconClass('new-window')}}"></i> {{ctx.t('Help')}}
       </a>
     </div>

--- a/src/templates/bootstrap5/builderEditForm/form.ejs
+++ b/src/templates/bootstrap5/builderEditForm/form.ejs
@@ -5,7 +5,7 @@
   {% if (ctx.helplinks) { %}
   <div class="col col-sm-6">
     <div class="float-end" style="margin-right: 20px; margin-top: 10px">
-      <a href="{{ctx.t(ctx.helplinks + ctx.componentInfo.documentation)}}" target="_blank">
+      <a href="{{ctx.t(ctx.helplinks + ctx.componentInfo.documentation)}}" target="_blank" rel="noopener noreferrer">
         <i class="{{ctx.iconClass('new-window')}}"></i> {{ctx.t('Help')}}
       </a>
     </div>


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/jira/software/c/projects/FIO/issues/FIO-6345

## Description

Added attribute rel="noopener noreferrer" to docs/external links

The **noopener** is needed to enhance the security of your website and prevent other websites from gaining access to your page (through the browser session). The **noreferrer** is used to protect referral information from being passed to the target website and this also hides referral traffic in Google analytics

## Dependencies

## How has this PR been tested?

Tested locally 

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
