### PR TITLE
FIO-6009 When checkboxes set as radio, conditional logic is triggered upon deselect

### DIFF
--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -196,6 +196,7 @@ export default class CheckBoxComponent extends Field {
       this.input.checked = 0;
       this.input.value = 0;
       this.dataValue = '';
+      this.updateOnChange(flags, true);
     }
 
     const changed = super.updateValue(value, flags);

--- a/src/components/checkbox/Checkbox.unit.js
+++ b/src/components/checkbox/Checkbox.unit.js
@@ -1,6 +1,8 @@
 import assert from 'power-assert';
+import _ from 'lodash';
 
 import Harness from '../../../test/harness';
+import Formio from './../../Formio';
 import CheckBoxComponent from './Checkbox';
 
 import {
@@ -8,6 +10,7 @@ import {
   customDefaultComponent,
   comp2,
   comp3,
+  comp4
 } from './fixtures';
 
 describe('Checkbox Component', () => {
@@ -66,5 +69,26 @@ describe('Checkbox Component', () => {
       assert(label.className.includes('field-required'));
       done();
     }).catch(done);
+  });
+
+  it('Should hide component with conditional logic when checkbox component with the radio input type is unchecked', (done) =>  {
+    const form = _.cloneDeep(comp3);
+    const element = document.createElement('div');
+
+    Formio.createForm(element, form).then(form => {
+      const radioCheckbox = form.getComponent('p1');
+      const contentComp = form.getComponent('p1Content');
+      assert.equal(contentComp.visible, false);
+      const radio = Harness.testElements(radioCheckbox, 'input[type="radio"]', 1)[0];
+      Harness.clickElement(radioCheckbox, radio);
+      setTimeout(() => {
+        assert.equal(contentComp.visible, true);
+        Harness.clickElement(radioCheckbox, radio);
+        setTimeout(() => {
+          assert.equal(contentComp.visible, false);
+          done();
+        }, 300);
+      }, 300);
+    }).catch((err) => done(err));
   });
 });

--- a/src/components/checkbox/fixtures/comp4.js
+++ b/src/components/checkbox/fixtures/comp4.js
@@ -1,0 +1,37 @@
+export default {
+    title: '6009test',
+    name: '6009Test',
+    path: '6009test',
+    type: 'form',
+    display: 'form',
+    components:[
+        {
+            label: 'P1',
+            inputType:'radio',
+            tableView:false,
+            key: 'p1',
+            type:'checkbox',
+            name:'priorities',
+            value:'p1',
+            input:true
+        },
+        {
+            html:'<p>Content 1</p>',
+            label:'P1 Content',
+            refreshOnChange:false,
+            key:'p1Content',
+            type:'content',
+            input:false,
+            tableView:false,
+            customConditional:'show = data.priorities == "p1"'
+        },
+        {
+            type:'button',
+            label:'Submit',
+            key:'submit',
+            disableOnInvalid:true,
+            input:true,
+            tableView:false
+        }
+    ]
+};

--- a/src/components/checkbox/fixtures/index.js
+++ b/src/components/checkbox/fixtures/index.js
@@ -2,3 +2,4 @@ export comp1 from './comp1';
 export customDefaultComponent from './customDefaultComponent';
 export comp2 from './comp2';
 export comp3 from './comp3';
+export comp4 from './comp4';


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6009

## Description

*If the checkbox is set as a radio and there is a corresponding content field which should display conditionally, then after clicking on the checkbox,  the conditional content field shows. And this is the correct behavior. But after deselect the same checkbox, the content field was not hidden. This has been fixed and now when checkbox is deselected, the corresponding component is hidden according to Advanced Conditions logic*

## Dependencies

*no*

## How has this PR been tested?

*added automated tests*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
