### PR TITLE
FIO-6604 fixed padding for Numbers inside Content

### DIFF
--- a/src/sass/formio.form.builder.scss
+++ b/src/sass/formio.form.builder.scss
@@ -129,6 +129,9 @@
 
 .component-settings .formio-dialog-content {
   max-height: 100%;
+  .ck-editor__editable ol {
+    padding-inline-start: 40px;
+  }
 }
 
 .component-btn-group .btn.component-settings-button-paste {

--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -1335,6 +1335,10 @@ div[data-oembed-url] {
   & .text-huge {
     font-size: 1.8em;
   }
+
+  ol {
+    padding-inline-start: 40px;
+  }
 }
 
 .formio-component-address.formio-component-label-hidden {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6604

## Description

*added padding for Numbered List inside Content Component*

## Dependencies

*no*

## How has this PR been tested?

*manually*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
