### PR TITLE
FIO-6582: 

### DIFF
--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -591,6 +591,8 @@ export default class TextAreaComponent extends TextFieldComponent {
             this.editors[0].editing.view.focus();
           }
           this.element.scrollIntoView();
+        }).catch((err) => {
+          console.warn('An editor did not initialize properly when trying to focus:', err);
         });
         break;
       }
@@ -598,12 +600,16 @@ export default class TextAreaComponent extends TextFieldComponent {
         this.editorsReady[0].then(() => {
           this.editors[0].focus();
           this.element.scrollIntoView();
+        }).catch((err) => {
+          console.warn('An editor did not initialize properly when trying to focus:', err);
         });
         break;
       }
       case 'quill': {
         this.editorsReady[0].then(() => {
           this.editors[0].focus();
+        }).catch((err) => {
+          console.warn('An editor did not initialize properly when trying to focus:', err);
         });
         break;
       }

--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -582,19 +582,29 @@ export default class TextAreaComponent extends TextFieldComponent {
     super.focus();
     switch (this.component.editor) {
       case 'ckeditor': {
-        if (this.editors[0].editing?.view?.focus) {
-          this.editors[0].editing.view.focus();
-        }
-        this.element.scrollIntoView();
+        // Wait for the editor to be ready.
+        // TODO: I'm defaulting to the first element of the editorsReady array because we are defaulting to the first element
+        // of the editors array when we focus, but is there a scenario in which the editorsReady array would have more than
+        // one element?
+        this.editorsReady[0].then(() => {
+          if (this.editors[0].editing?.view?.focus) {
+            this.editors[0].editing.view.focus();
+          }
+          this.element.scrollIntoView();
+        });
         break;
       }
       case 'ace': {
-        this.editors[0].focus();
-        this.element.scrollIntoView();
+        this.editorsReady[0].then(() => {
+          this.editors[0].focus();
+          this.element.scrollIntoView();
+        });
         break;
       }
       case 'quill': {
-        this.editors[0].focus();
+        this.editorsReady[0].then(() => {
+          this.editors[0].focus();
+        });
         break;
       }
     }

--- a/src/components/textarea/TextArea.unit.js
+++ b/src/components/textarea/TextArea.unit.js
@@ -442,7 +442,7 @@ describe('TextArea Component', () => {
           input: true,
         }
       ];
-      const testForm = {...formWithCKEditor, components: testComponents};
+      const testForm = { ...formWithCKEditor, components: testComponents };
 
       Formio.createForm(element, testForm).then(form => {
           const textArea = form.getComponent('textArea');

--- a/src/components/textarea/TextArea.unit.js
+++ b/src/components/textarea/TextArea.unit.js
@@ -429,5 +429,27 @@ describe('TextArea Component', () => {
         }, 300);
       }).catch(done);
     });
+
+    it('Should not autofocus until the editor is ready', (done) => {
+      const element = document.createElement('div');
+      const testComponents = [
+        {
+          type: 'textarea',
+          autofocus: true,
+          editor: 'ckeditor',
+          key: 'textArea',
+          label: 'Text Area',
+          input: true,
+        }
+      ];
+      const testForm = {...formWithCKEditor, components: testComponents};
+
+      Formio.createForm(element, testForm).then(form => {
+          const textArea = form.getComponent('textArea');
+          expect(textArea.focus.bind(textArea)).to.not.throw();
+
+          done();
+      }).catch(done);
+    });
   });
 });

--- a/src/components/textarea/TextArea.unit.js
+++ b/src/components/textarea/TextArea.unit.js
@@ -446,6 +446,7 @@ describe('TextArea Component', () => {
 
       Formio.createForm(element, testForm).then(form => {
           const textArea = form.getComponent('textArea');
+          // since prior to this fix the focus function will throw, we'll make sure it doesn't
           expect(textArea.focus.bind(textArea)).to.not.throw();
 
           done();


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6582

## Description

When `textarea` components have the `autofocus` param enabled, the renderer will wait for the `render` event to emit and focus the element by keying in on `this.component.editors[0]`. However, `textarea` components have an additional asynchronous initialize step, all of which are stored in the `this.editorsReady` array. This PR modifies the `textarea` component to wait for the editor to be ready before it attempts to focus it.

## Dependencies

n/a

## How has this PR been tested?

added an automated test around the focus() instance method and tested manually

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above

__My local tests are not passing, but a look at the last 5-6 PRs for this repo make me think they haven't been passing for a while. I'm going to look into this next and fix them, but IMHO we need to make sure they're passing on every PR__
