### PR TITLE
FIO-6659 added warnings for Tree and Resource

### DIFF
--- a/src/components/resource/Resource.js
+++ b/src/components/resource/Resource.js
@@ -16,7 +16,6 @@ export default class ResourceComponent extends SelectComponent {
   static get builderInfo() {
     return {
       title: 'Resource',
-      group: 'premium',
       icon: 'files-o',
       weight: 90,
       documentation: '/userguide/form-building/form-components#resource',

--- a/src/components/resource/editForm/Resource.edit.display.js
+++ b/src/components/resource/editForm/Resource.edit.display.js
@@ -5,7 +5,7 @@ export default [
     type: 'htmlelement',
     tag: 'div',
     className: 'alert alert-danger',
-    content: 'The Resource component is deprecated. Use the Select component with data source of "Resource" instead.',
+    content: 'This component has been deprecated and will be removed in a future version of Formio.js.',
   },
   {
     type: 'select',

--- a/src/components/tree/Tree.form.js
+++ b/src/components/tree/Tree.form.js
@@ -1,7 +1,12 @@
 import componentEditForm from '../_classes/component/Component.form';
 import TreeEditData from './editForm/Tree.edit.data';
+import TreeDisplayData from './editForm/Tree.edit.display';
 export default function(...extend) {
   return componentEditForm([
+    {
+      key: 'display',
+      components: TreeDisplayData,
+    },
     {
       key: 'data',
       components: TreeEditData,

--- a/src/components/tree/Tree.js
+++ b/src/components/tree/Tree.js
@@ -23,7 +23,6 @@ export default class TreeComponent extends NestedDataComponent {
     return {
       title: 'Tree',
       icon: 'indent',
-      group: 'data',
       weight: 40,
       documentation: '/userguide/form-building/data-components#tree',
       schema: TreeComponent.schema(),

--- a/src/components/tree/editForm/Tree.edit.display.js
+++ b/src/components/tree/editForm/Tree.edit.display.js
@@ -1,0 +1,10 @@
+export default [
+    {
+      key: 'treeInfo',
+      weight: -10,
+      type: 'htmlelement',
+      tag: 'div',
+      className: 'alert alert-danger',
+      content: 'This component has been deprecated and will be removed in a future version of Formio.js.',
+    }
+];


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6659

## Description

*Tree and Resource components are hidden from builder. Added deprecation warning- If a user clicks edit on an existing Tree or Resource component*

## Dependencies

*no*

## How has this PR been tested?

*manually*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
