### PR TITLE
FIO-4232: fixed an issue where form controller does not work for wizard forms in builder

### DIFF
--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -74,6 +74,7 @@ import formWithCheckboxRadioaType from '../test/forms/formWithCheckboxRadioType'
 import formsWithNewSimpleConditions from '../test/forms/formsWithNewSimpleConditions';
 import formWithRadioInsideDataGrid from '../test/forms/formWithRadioInsideDataGrid';
 import formWithCheckboxRadioType from '../test/forms/formWithCheckboxRadioType';
+import formWithFormController from '../test/forms/formWithFormController';
 
 global.requestAnimationFrame = (cb) => cb();
 global.cancelAnimationFrame = () => {};
@@ -81,6 +82,20 @@ global.cancelAnimationFrame = () => {};
 /* eslint-disable max-statements */
 describe('Webform tests', function() {
   this.retries(3);
+
+  it('Should execute form controller', function(done) {
+    Formio.createForm(formWithFormController).then((form) => {
+      setTimeout(() => {
+        const textField = form.getComponent('textField');
+
+        assert.equal(textField.getValue(), 'Hello World');
+        assert.equal(textField.disabled, true);
+        assert.equal(form.components[0].disabled, true);
+
+        done();
+      }, 300);
+    }).catch((err) => done(err));
+  });
 
   it('Should set radio components value inside data grid correctly', function(done) {
     Formio.createForm(formWithRadioInsideDataGrid).then((form) => {

--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1046,7 +1046,7 @@ export default class WebformBuilder extends Component {
 
   populateRecaptchaSettings(form) {
     //populate isEnabled for recaptcha form settings
-    var isRecaptchaEnabled = false;
+    let isRecaptchaEnabled = false;
     if (this.form.components) {
       eachComponent(form.components, component => {
         if (isRecaptchaEnabled) {

--- a/src/WebformBuilder.unit.js
+++ b/src/WebformBuilder.unit.js
@@ -6,6 +6,7 @@ import Builders from '../lib/builders';
 import { uniqueApiKeys, uniqueApiKeysLayout, uniqueApiKeysSameLevel, columnsForm, resourceKeyCamelCase } from '../test/formtest';
 import sameApiKeysLayoutComps from '../test/forms/sameApiKeysLayoutComps';
 import testApiKeysUniquifying from '../test/forms/testApiKeysUniquifying';
+import formWithFormController from '../test/forms/formWithFormController';
 
 describe('WebformBuilder tests', function() {
   this.retries(3);
@@ -16,6 +17,19 @@ describe('WebformBuilder tests', function() {
     const builder = Harness.getBuilder();
     assert(builder instanceof WebformBuilder, 'Builder must be an instance of FormioFormBuilder');
     done();
+  });
+
+  it('Should execute form controller', (done) => {
+    const builder = Harness.getBuilder();
+    builder.webform.form = formWithFormController;
+
+    setTimeout(() => {
+      const textF = builder.webform.getComponent('textField');
+      assert.equal(textF.getValue(), 'Hello World');
+      assert.equal(textF.disabled, true);
+      assert.equal(builder.webform.components[0].disabled, true);
+      done();
+    }, 500);
   });
 
   it('Should not show unique API error when components with same keys are inside and outside of the Data component', (done) => {

--- a/src/Wizard.unit.js
+++ b/src/Wizard.unit.js
@@ -38,11 +38,30 @@ import wizardWithFieldsValidationParent from '../test/forms/wizardWithFieldsVali
 import nestedConditionalWizard from '../test/forms/nestedConditionalWizard';
 import wizardWithPrefixComps from '../test/forms/wizardWithPrefixComps';
 import wizardPermission from '../test/forms/wizardPermission';
+import formWithFormController from '../test/forms/formWithFormController';
+import { fastCloneDeep } from './utils/utils';
 
 global.requestAnimationFrame = (cb) => cb();
 global.cancelAnimationFrame = () => {};
 
+// eslint-disable-next-line max-statements
 describe('Wizard tests', () => {
+  it('Should execute form controller', function(done) {
+    const form = fastCloneDeep(formWithFormController);
+    form.display = 'wizard';
+    Formio.createForm(form).then((form) => {
+      setTimeout(() => {
+        const textField = form.getComponent('textField');
+
+        assert.equal(textField.getValue(), 'Hello World');
+        assert.equal(textField.disabled, true);
+        assert.equal(form.components[0].disabled, true);
+
+        done();
+      }, 300);
+    }).catch((err) => done(err));
+  });
+
   it('Should check correctly Permissions and disabled sumbit button', (done) => {
     const formElement = document.createElement('div');
     const wizard = new Wizard(formElement);

--- a/src/WizardBuilder.js
+++ b/src/WizardBuilder.js
@@ -197,6 +197,7 @@ export default class WizardBuilder extends WebformBuilder {
       display: 'form',
       type: 'form',
       components: page ? [page] : [],
+      controller: this._form?.controller || ''
     }, { keepAsReference: true });
     return this.redraw();
   }

--- a/src/WizardBuilder.unit.js
+++ b/src/WizardBuilder.unit.js
@@ -2,6 +2,8 @@ import FormBuilder from './FormBuilder';
 import assert from 'power-assert';
 import Harness from '../test/harness';
 import simpleWizard from '../test/forms/simpleWizard';
+import formWithFormController from '../test/forms/formWithFormController';
+import { fastCloneDeep } from './utils/utils';
 
 global.requestAnimationFrame = (cb) => cb();
 global.cancelAnimationFrame = () => {};
@@ -75,7 +77,7 @@ describe('WizardBuilder tests', function() {
       window.confirm = () => {
         return true;
       };
-     
+
       Harness.clickElement(panel, editComponentRef);
       setTimeout(() => {
         assert(builder.instance.editForm, 'Should create the settings form on component edit');
@@ -88,6 +90,21 @@ describe('WizardBuilder tests', function() {
           done();
         }, 300);
       }, 300);
+    }, 500);
+  });
+
+  it('Should execute form controller', (done) => {
+    const form = fastCloneDeep(formWithFormController);
+    form.display = 'wizard';
+    const builder = createWizardBuilder(form).instance;
+
+    setTimeout(() => {
+      const textF = builder.webform.getComponent('textField');
+      assert.equal(textF.getValue(), 'Hello World');
+      assert.equal(textF.disabled, true);
+      assert.equal(builder.webform.components[0].disabled, true);
+
+      done();
     }, 500);
   });
 });

--- a/test/forms/formWithFormController.js
+++ b/test/forms/formWithFormController.js
@@ -1,0 +1,32 @@
+export default {
+    _id: '636e1e0848707efbd322ea71',
+    title: 'test controller',
+    name: 'testcontroller',
+    path: 'testcontroller',
+    type: 'form',
+    display: 'form',
+    components: [
+      {
+        title: 'Page 1',
+        label: 'Page 1',
+        type: 'panel',
+        key: 'page1',
+        components: [
+          {
+            label: 'Text Field',
+            tableView: true,
+            key: 'textField',
+            type: 'textfield',
+            input: true,
+          },
+        ],
+        input: false,
+        tableView: false,
+      },
+    ],
+    controller:
+      "data.textField = 'Hello World';\r\ncomponents[0].disabled = true;\r\ninstance.redraw()",
+    created: '2022-11-11T10:03:52.187Z',
+    modified: '2022-11-11T11:21:15.386Z',
+    machineName: 'ienrmkptejwkozk:gggggg',
+};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-4232

## Description

**What changed?**

Before we did not pass form controller when creating the wizard form in builder mode. I have added it.

## How has this PR been tested?

Manually + unit tests are added.
No new tests fail, except those that fail on the master branch.

## Related PR

https://github.com/formio/formio-app/pull/1434

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
