### PR TITLE
FIO-6761 removed Storage Type setting for Radio

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -294,39 +294,20 @@ export default class RadioComponent extends ListComponent {
    * @return {*}
    */
   normalizeValue(value) {
-    const dataType = this.component.dataType || 'auto';
-
     if (value === this.emptyValue) {
       return value;
     }
 
-    switch (dataType) {
-      case 'auto':
-        if (!isNaN(parseFloat(value)) && isFinite(value)) {
-          value = +value;
-        }
-        if (value === 'true') {
-          value = true;
-        }
-        if (value === 'false') {
-          value = false;
-        }
-        break;
-      case 'number':
-        value = +value;
-        break;
-      case 'string':
-        if (typeof value === 'object') {
-          value = JSON.stringify(value);
-        }
-        else {
-          value = String(value);
-        }
-        break;
-      case 'boolean':
-        value = !(!value || value.toString() === 'false');
-        break;
+    if (!isNaN(parseFloat(value)) && isFinite(value)) {
+      value = +value;
     }
+    if (value === 'true') {
+      value = true;
+    }
+    if (value === 'false') {
+      value = false;
+    }
+
     return super.normalizeValue(value);
   }
 }

--- a/src/components/radio/editForm/Radio.edit.data.js
+++ b/src/components/radio/editForm/Radio.edit.data.js
@@ -76,26 +76,6 @@ export default [
     },
   },
   {
-    type: 'select',
-    input: true,
-    label: 'Storage Type',
-    key: 'dataType',
-    clearOnHide: true,
-    tooltip: 'The type to store the data. If you select something other than autotype, it will force it to that type.',
-    weight: 12,
-    template: '<span>{{ item.label }}</span>',
-    dataSrc: 'values',
-    data: {
-      values: [
-        { label: 'Autotype', value: 'auto' },
-        { label: 'String', value: 'string' },
-        { label: 'Number', value: 'number' },
-        { label: 'Boolean', value: 'boolean' },
-        { label: 'Object', value: 'object' },
-      ],
-    },
-  },
-  {
     key: 'template',
     conditional: {
       json: { '===': [{ var: 'data.dataSrc' }, 'url'] },


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6761

## Description

*The 'Storage type' parameter has been removed from the Radio component settings*

## Dependencies

*no*

## How has this PR been tested?

*All automated tests were passed locally*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
