### PR TITLE
FIO-6800: fixed issue where select dropdowns go behind the component settings modal

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Upgrade to Bootstrap 5
  - Replace SDK with @formio/core SDK.
  - Remove Semantic template and Bootstrap 3 template from build.  Use import @formio/bootstrap3 or @formio/semantic instead.
-
+ 
 ### Added
  - FIO-5986: added check for identical uploaded file
  - FIO-6453: added sanitization inside error message container

--- a/src/sass/formio.form.builder.scss
+++ b/src/sass/formio.form.builder.scss
@@ -225,6 +225,7 @@
 }
 
 .component-edit-tabs.col-sm-6 {
+  min-height: 87vh;
   height: 100%;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/jira/software/c/projects/FIO/issues/FIO-6800

## Description

Fixed issue where select dropdowns go behind the component settings modal

**Why have you chosen this solution?**
I chose this solution because after investigating the issue I realized that we use the overflow property for parents blocks and this hides our dropdown selector and we cannot refuse to use property overflow

## Dependencies

## How has this PR been tested?

Tested locally 
Attached video https://formio.atlassian.net/browse/FIO-6800?focusedCommentId=46024

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
