### PR TITLE
check for promise exist before we focus

### DIFF
--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -583,34 +583,37 @@ export default class TextAreaComponent extends TextFieldComponent {
     switch (this.component.editor) {
       case 'ckeditor': {
         // Wait for the editor to be ready.
-        // TODO: I'm defaulting to the first element of the editorsReady array because we are defaulting to the first element
-        // of the editors array when we focus, but is there a scenario in which the editorsReady array would have more than
-        // one element?
-        this.editorsReady[0].then(() => {
-          if (this.editors[0].editing?.view?.focus) {
-            this.editors[0].editing.view.focus();
-          }
-          this.element.scrollIntoView();
-        }).catch((err) => {
-          console.warn('An editor did not initialize properly when trying to focus:', err);
-        });
+        if (this.editorsReady[0]) {
+          this.editorsReady[0].then(() => {
+            if (this.editors[0].editing?.view?.focus) {
+              this.editors[0].editing.view.focus();
+            }
+            this.element.scrollIntoView();
+           }).catch((err) => {
+              console.warn('An editor did not initialize properly when trying to focus:', err);
+           });
+        }
         break;
       }
       case 'ace': {
-        this.editorsReady[0].then(() => {
-          this.editors[0].focus();
-          this.element.scrollIntoView();
-        }).catch((err) => {
-          console.warn('An editor did not initialize properly when trying to focus:', err);
-        });
+        if (this.editorsReady[0]) {
+          this.editorsReady[0].then(() => {
+            this.editors[0].focus();
+            this.element.scrollIntoView();
+          }).catch((err) => {
+            console.warn('An editor did not initialize properly when trying to focus:', err);
+          });
+        }
         break;
       }
       case 'quill': {
-        this.editorsReady[0].then(() => {
-          this.editors[0].focus();
-        }).catch((err) => {
-          console.warn('An editor did not initialize properly when trying to focus:', err);
-        });
+        if (this.editorsReady[0]) {
+          this.editorsReady[0].then(() => {
+            this.editors[0].focus();
+          }).catch((err) => {
+            console.warn('An editor did not initialize properly when trying to focus:', err);
+          });
+        }
         break;
       }
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6582

## Description

My previous PR didn't check for the editorsReady promise, but we need to due to read-only forms not instantiating a editorsReady promise on `attach()`. 

## Dependencies

n/a

## How has this PR been tested?

The previous automated tests should suffice, this was dumb of me 

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
