### PR TITLE
FIO-6600 fixed opening of the settings window

### DIFF
--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -58,7 +58,7 @@ export default class NestedComponent extends Field {
     const forceHide = this.options.hide && this.options.hide[this.component.key];
     this.components.forEach(component => {
       // Set the parent visibility first since we may have nested components within nested components
-      // and they need to be able to determine their visibility based on the parent visibility.//
+      // and they need to be able to determine their visibility based on the parent visibility.
       component.parentVisible = isVisible;
 
       const conditionallyVisible = component.conditionallyVisible();
@@ -323,7 +323,7 @@ export default class NestedComponent extends Field {
     options.root = options?.root || this.root || this;
     options.localRoot = this.localRoot;
     options.skipInit = true;
-    if (options.display !== 'pdf') {
+    if (options.display !== 'pdf' && this.builderMode) {
       component.id = getRandomComponentId();
     }
     if (!this.isInputComponent && this.component.shouldIncludeSubFormPath) {

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -323,7 +323,7 @@ export default class NestedComponent extends Field {
     options.root = options?.root || this.root || this;
     options.localRoot = this.localRoot;
     options.skipInit = true;
-    if (options.display !== 'pdf' && this.builderMode) {
+    if (options.display !== 'pdf' && !this.builderMode) {
       component.id = getRandomComponentId();
     }
     if (!this.isInputComponent && this.component.shouldIncludeSubFormPath) {

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -323,7 +323,9 @@ export default class NestedComponent extends Field {
     options.root = options?.root || this.root || this;
     options.localRoot = this.localRoot;
     options.skipInit = true;
-    component.id = getRandomComponentId();
+    if (options.display !== 'pdf') {
+      component.id = getRandomComponentId();
+    }
     if (!this.isInputComponent && this.component.shouldIncludeSubFormPath) {
       component.shouldIncludeSubFormPath = true;
     }

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -323,7 +323,7 @@ export default class NestedComponent extends Field {
     options.root = options?.root || this.root || this;
     options.localRoot = this.localRoot;
     options.skipInit = true;
-    if (options.display !== 'pdf' && !this.builderMode) {
+    if (!(options.display === 'pdf' && this.builderMode)) {
       component.id = getRandomComponentId();
     }
     if (!this.isInputComponent && this.component.shouldIncludeSubFormPath) {

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -58,7 +58,7 @@ export default class NestedComponent extends Field {
     const forceHide = this.options.hide && this.options.hide[this.component.key];
     this.components.forEach(component => {
       // Set the parent visibility first since we may have nested components within nested components
-      // and they need to be able to determine their visibility based on the parent visibility.
+      // and they need to be able to determine their visibility based on the parent visibility.//
       component.parentVisible = isVisible;
 
       const conditionallyVisible = component.conditionallyVisible();


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6600

## Description

*Previously, after drop a new component, modal window with component settings for the PDF first form did not open. The issue has been fixed. Now when User adds or clicks on a component, a modal window opens.*

## Dependencies

*no*

## How has this PR been tested?

*All tests pass locally*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
