### PR TITLE
FIO-6661 Fixed DateTime widget throwing an error and not switching la…

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -303,7 +303,7 @@ export default class Webform extends NestedDataComponent {
         if (err) {
           return;
         }
-        this.redraw();
+        this.rebuild();
         this.emit('languageChanged');
       });
     }

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -19,7 +19,7 @@ import {
 } from './utils/utils';
 import { eachComponent } from './utils/formUtils';
 
-// Initialize the available forms.
+// Initialize the available forms.//
 Formio.forms = {};
 
 // Allow people to register components.


### PR DESCRIPTION
…nguages after changing the language of the form

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6661

## Description

Previously, changing the language of the form triggered 'redraw' function, which was working fine, but when we had a widget on the form, widget settings wouldn't be updated because the components were not reinitialized. Changing 'redraw' to 'rebuild' solves that issue, because it reattaches components with the latest settings of the form, i.e. language in this case.

## How has this PR been tested?

All tests are passing locally

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
