### PR TITLE
FIO-6654 fixed UI issue with Checkbox condition

### DIFF
--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -933,6 +933,9 @@ export default class EditGridComponent extends NestedArrayComponent {
 
     if (this.saveEditMode) {
       const dataValue = this.dataValue;
+      if (this.root?.focusedComponent?.component.typeChangeEnabled) {
+        this.root.focusedComponent = null;
+      }
       switch (editRow.state) {
         case EditRowState.New: {
           const newIndex = dataValue.length;

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -176,7 +176,7 @@ export default class EditGridComponent extends NestedArrayComponent {
 
   /**
    * Returns true if the component has nested components which don't trigger changes on the root level
-   */
+   *///
   get hasScopedChildren() {
     return !this.inlineEditMode;
   }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6654

## Description

*Fixed UI issue related to Tab with Settings for  Simple condition with Checkbox or Select condition. Previously, the value for simple conditions was saved, but the edit row was reopened. Now the value for simple conditions are saved and the window opens only after click the edit button*

## Dependencies

*no*

## How has this PR been tested?

*all tests pass locally*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
