### PR TITLE
FIO-6632: formiojs-to-run-npm-run-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint"
   ],
   "scripts": {
-    "build": "esdoc && gulp build",
+    "build": "esdoc && gulp build && npm run release",
     "create-app-yml": "node -e 'var fs=require(`fs`);fs.writeFileSync(`./_config.app.yml`, `baseurl: https://formiojs.test-form.io/` + require(`./package.json`).version);'",
     "rm-app-yml": "rm ./_config.app.yml",
     "build-app": "npm run create-app-yml && jekyll build --config _config.yml,_config.app.yml && npm run rm-app-yml",


### PR DESCRIPTION
…build is called

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6632

## Description

**What changed?**

Added npm run release to the npm run build script.

**Why have you chosen this solution?**

This should be the easiest way to have the command run with needing changes to the build script to accomodate.

## How has this PR been tested?

It has not been tested against a build yet but will be tried on this next one.

