### PR TITLE
FIO-3820: Ability to delete files inside the Storage Services

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -302,7 +302,7 @@ export default class FileComponent extends Field {
   deleteFile(fileInfo) {
     const { options = {} } = this.component;
 
-    if (fileInfo && (['url', 'indexeddb'].includes(this.component.storage))) {
+    if (fileInfo && (['url', 'indexeddb', 's3','googledrive', 'azure'].includes(this.component.storage))) {
       const { fileService } = this;
       if (fileService && typeof fileService.deleteFile === 'function') {
         fileService.deleteFile(fileInfo, options);

--- a/src/providers/storage/azure.js
+++ b/src/providers/storage/azure.js
@@ -6,19 +6,25 @@ const azure = (formio) => ({
       xhr.setRequestHeader('Content-Type', file.type);
       xhr.setRequestHeader('x-ms-blob-type', 'BlockBlob');
       return file;
-    }, file, fileName, dir, progressCallback, groupPermissions, groupId, abortCallback).then(() => {
+    }, file, fileName, dir, progressCallback, groupPermissions, groupId, abortCallback).then((response) => {
       return {
         storage: 'azure',
         name: XHR.path([dir, fileName]),
         size: file.size,
         type: file.type,
         groupPermissions,
-        groupId
+        groupId,
+        key: response.pathFile
       };
     });
   },
   downloadFile(file) {
     return formio.makeRequest('file', `${formio.formUrl}/storage/azure?name=${XHR.trim(file.name)}`, 'GET');
+  },
+
+  deleteFile: function deleteFile(fileInfo) {
+    var url = `${formio.formUrl}/storage/azure?name=${XHR.trim(fileInfo.name)}&key=${XHR.trim(fileInfo.key)}`;
+    return formio.makeRequest('', url, 'delete');
   }
 });
 

--- a/src/providers/storage/googleDrive.js
+++ b/src/providers/storage/googleDrive.js
@@ -58,6 +58,11 @@ const googledrive = (formio) => ({
     file.url =
       `${formio.formUrl}/storage/gdrive?fileId=${file.id}&fileName=${file.originalName}${token ? `&x-jwt-token=${token}` : ''}`;
     return NativePromise.resolve(file);
+  },
+
+  deleteFile: function deleteFile(fileInfo) {
+    var url = ''.concat(formio.formUrl, `/storage/gdrive?id=${fileInfo.id}&name=${fileInfo.originalName}`);
+    return formio.makeRequest('', url, 'delete');
   }
 });
 

--- a/src/providers/storage/s3.js
+++ b/src/providers/storage/s3.js
@@ -39,8 +39,13 @@ const s3 = (formio) => ({
     else {
       return NativePromise.resolve(file);
     }
-  }
-});
+  },
+
+  deleteFile(fileInfo) {
+    const url = `${formio.formUrl}/file/${XHR.trim(fileInfo.name)}?bucket=${XHR.trim(fileInfo.bucket)}&key=${XHR.trim(fileInfo.key)}`;
+    return formio.makeRequest('', url, 'delete');
+   }
+ });
 
 s3.title = 'S3';
 export default s3;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-3820

## Description

**What changed?**

*Ability to delete files that are removed from the form and to delete the files also inside the Storage Services.*

**Why have you chosen this solution?**

*Previously, files were deleted only from the portal, but not from the file storage*

## Dependencies

*This PR depends on the PR for the formio server that I attached in the ticket.*

## How has this PR been tested?

*I have not added automated tests. All tests pass locally with my changes*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
