### PR TITLE
FIO 6582 - fix bug in auto-focused TextArea components

### DIFF
--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -583,10 +583,7 @@ export default class TextAreaComponent extends TextFieldComponent {
     switch (this.component.editor) {
       case 'ckeditor': {
         // Wait for the editor to be ready.
-        // TODO: I'm defaulting to the first element of the editorsReady array because we are defaulting to the first element
-        // of the editors array when we focus, but is there a scenario in which the editorsReady array would have more than
-        // one element?
-        this.editorsReady[0].then(() => {
+        this.editorsReady[0]?.then(() => {
           if (this.editors[0].editing?.view?.focus) {
             this.editors[0].editing.view.focus();
           }
@@ -597,7 +594,7 @@ export default class TextAreaComponent extends TextFieldComponent {
         break;
       }
       case 'ace': {
-        this.editorsReady[0].then(() => {
+        this.editorsReady[0]?.then(() => {
           this.editors[0].focus();
           this.element.scrollIntoView();
         }).catch((err) => {
@@ -606,7 +603,7 @@ export default class TextAreaComponent extends TextFieldComponent {
         break;
       }
       case 'quill': {
-        this.editorsReady[0].then(() => {
+        this.editorsReady[0]?.then(() => {
           this.editors[0].focus();
         }).catch((err) => {
           console.warn('An editor did not initialize properly when trying to focus:', err);

--- a/src/components/textarea/TextArea.unit.js
+++ b/src/components/textarea/TextArea.unit.js
@@ -453,7 +453,7 @@ describe('TextArea Component', () => {
       }).catch(done);
     });
 
-    it('Should not autofocus until if the form is readOnly', (done) => {
+    it('Should not autofocus if the form is readOnly', (done) => {
       const element = document.createElement('div');
       const testComponents = [
         {

--- a/src/components/textarea/TextArea.unit.js
+++ b/src/components/textarea/TextArea.unit.js
@@ -452,5 +452,28 @@ describe('TextArea Component', () => {
           done();
       }).catch(done);
     });
+
+    it('Should not autofocus until if the form is readOnly', (done) => {
+      const element = document.createElement('div');
+      const testComponents = [
+        {
+          type: 'textarea',
+          autofocus: true,
+          editor: 'ckeditor',
+          key: 'textArea',
+          label: 'Text Area',
+          input: true,
+        }
+      ];
+      const testForm = { ...formWithCKEditor, components: testComponents };
+
+      Formio.createForm(element, testForm, { readOnly: true }).then(form => {
+          const textArea = form.getComponent('textArea');
+          // since prior to this fix the focus function will throw if readOnly, we'll make sure it doesn't
+          expect(textArea.focus.bind(textArea)).to.not.throw();
+
+          done();
+      }).catch(done);
+    });
   });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6582

## Description

My previous PR (#5128) didn't take into account that readOnly forms will not bother to instantiate the editors, so we should check for the value to be populated with a promise before execution

## Dependencies

n/a

## How has this PR been tested?

Added a test to cover readOnly forms

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
