### PR TITLE
FIO-6862: Fixes some cases when component value is calculated in loop causing stack overflow

### DIFF
--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -82,7 +82,7 @@ if (_.has(Formio, 'Components.setComponents')) {
   Formio.Components.setComponents(AllComponents);
 }
 
-/* eslint-disable max-statements */
+/* eslint-disable max-statements  */
 describe('Webform tests', function() {
   this.retries(3);
 

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2355,7 +2355,7 @@ export default class Component extends Element {
    *
    */
   hasValue(data) {
-    return _.has(data || this.data, this.key);
+    return !_.isUndefined(_.get(data || this.data, this.key));
   }
 
   /**
@@ -2760,6 +2760,10 @@ export default class Component extends Element {
 
   /* eslint-disable max-statements */
   calculateComponentValue(data, flags, row) {
+    // Skip value calculation for the component if we don't have entire form data set
+    if (_.isUndefined(_.get(this, 'root.data'))) {
+      return false;
+    }
     // If no calculated value or
     // hidden and set to clearOnHide (Don't calculate a value for a hidden field set to clear when hidden)
     const { clearOnHide } = this.component;

--- a/test/forms/calculateValueOnServerForEditGrid.js
+++ b/test/forms/calculateValueOnServerForEditGrid.js
@@ -1,0 +1,49 @@
+export default {
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      key: 'first',
+      type: 'textfield',
+      input: true,
+      label: 'Text Field',
+      tableView: true,
+    },
+    {
+      key: 'editGrid',
+      type: 'editgrid',
+      input: true,
+      label: 'Edit Grid',
+      rowDrafts: false,
+      tableView: false,
+      components: [
+        {
+          key: 'fielda',
+          type: 'textfield',
+          input: true,
+          label: 'Text Field',
+          tableView: true,
+        },
+        {
+          key: 'fieldb',
+          type: 'textfield',
+          input: true,
+          label: 'Text Field',
+          tableView: true,
+        },
+      ],
+      calculateValue:
+        'if (options.server){\n  value = [{ fielda: data.first, fieldb: "test"}];\n}',
+      displayAsTable: false,
+      calculateServer: true,
+    },
+    {
+      key: 'submit',
+      type: 'button',
+      input: true,
+      label: 'Submit',
+      tableView: false,
+      disableOnInvalid: true,
+    },
+  ],
+};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6862

## Description

**What changed?**

There was a problem that for some form configurations `dataValue` would never match `calculatedValue`, so that `calculateComponentValue` would go in loop assuming that component value has changed.
This PR adds changes that make `dataValue` be eventually set to equal `calculatedValue`, preventing loop calls.

**Why have you chosen this solution?**

1) When any component is created, the Component.js constructor checks if it has the value and should either set default value or maintain current `dataValue`. Howewer, the check inside `hasValue` method didn't take into account that we might have `undefined` value set for component. So if this situation happened, not the default value would be set and eventually the whole key-value pair from the form data object was removed. This was fixed in `hasValue` method by making sure the value is not `undefined`

2) When opening component edit modal, there may be a moment when `calculateComponentValue` is called with the `data` object containing only the now editing component value, instead of the whole form data. I've added a check to make sure the form data object is initialized, so that we can make sure the `calculatedValue` won't have `undefined` values for components not present in `data` object.

## Dependencies

None, but the formio.js version with this changes needs to be applied both to formio-app and formio-server. 

**Also notice that this bug is most probably reproducible on our stable builds (seen it on 8.0.0).**

## How has this PR been tested?

I've added automated test for it + manually

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
