### PR TITLE
FIO-6849: fixed issue where form components cannot be edited because of legacy format of multi select default value multiple values

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -221,7 +221,7 @@ export default class SelectComponent extends ListComponent {
       return this.sanitize(value, this.shouldSanitizeValue);
     }
 
-    if (this.component.multiple ? this.dataValue.find((val) => value === val) : (this.dataValue === value)) {
+    if (this.component.multiple && _.isArray(this.dataValue) ? this.dataValue.find((val) => value === val) : (this.dataValue === value)) {
       const selectData = this.selectData;
       if (selectData) {
         const templateValue = this.component.reference && value?._id ? value._id.toString() : value;
@@ -1289,7 +1289,7 @@ export default class SelectComponent extends ListComponent {
         if (this.component.multiple) {
           templateData = {};
           const dataValue = this.dataValue;
-          if (dataValue && dataValue.length) {
+          if (dataValue && _.isArray(dataValue) && dataValue.length) {
             dataValue.forEach((dataValueItem) => {
               const dataValueItemValue = this.component.reference ? dataValueItem._id.toString() : dataValueItem;
               templateData[dataValueItemValue] = this.templateData[dataValueItemValue];


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/jira/software/c/projects/FIO/issues/FIO-6849

## Description

Added check isArray before using find and forEach methods 
This helped to prevent the error from appearing and everything works correctly

## Dependencies

## How has this PR been tested?

Tested  Locally 
video: https://formio.atlassian.net/browse/FIO-6849?focusedCommentId=46282

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
