### PR TITLE
FIO-4809: Fixes an issue where value of Wizard suffix/prefix components will be deleted during validation on server

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -899,8 +899,9 @@ export default class Wizard extends Webform {
     this._submission = submission;
     if (
       (flags && flags.fromSubmission && (this.options.readOnly || this.editMode) && !this.isHtmlRenderMode()) ||
-      (flags && flags.fromSubmission && (this.prefixComps.length || this.suffixComps.length) && submission._id)
-      ) {
+      (flags && flags.fromSubmission && (this.prefixComps.length || this.suffixComps.length) && submission._id) ||
+      (this.options.server && (this.prefixComps.length || this.suffixComps.length))
+    ) {
       this._data = submission.data;
     }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-4809

## Description

Since we started using native formiojs validation on the server side, the values of suffix/prefix components were cleared during it because we don't use fromSubmission flag when set value to the form for validation on the server side. 

## How has this PR been tested?

I created a separate PR with tests to the formio library, since it is related to the server-side  https://github.com/formio/formio/pull/1571

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
