### PR TITLE
FIO-6895 fixed interpolation for falsy values

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "fast-deep-equal": "^3.1.3",
     "fast-json-patch": "^3.1.1",
     "fetch-ponyfill": "^7.1.0",
-    "i18next": "^22.4.3",
+    "i18next": "22.4.12",
     "idb": "^7.1.1",
     "ismobilejs": "^1.1.1",
     "json-logic-js": "^2.0.2",

--- a/test/forms/helpers/testBasicComponentSettings/tests.js
+++ b/test/forms/helpers/testBasicComponentSettings/tests.js
@@ -283,13 +283,12 @@ export default {
       const checkboxValue = form.data.checkbox;
 
       assert.deepEqual(checkboxValue, false, 'Should set checkbox value to false');
-      // BUG: false and 0 values are not interpolated in label, uncomment once fix
-      // form.components.forEach(comp => {
-      //   const compKey = comp.component.key;
-      //   const compType = comp.component.type;
+      form.components.forEach(comp => {
+        const compKey = comp.component.key;
+        const compType = comp.component.type;
 
-      //   assert.deepEqual(comp.name.trim().endsWith(checkboxValue.toString()), true, `Should interpolate label using checkbox data for ${compKey} (component ${compType})`);
-      // });
+        assert.deepEqual(comp.name.trim().endsWith(checkboxValue.toString()), true, `Should interpolate label using checkbox data for ${compKey} (component ${compType})`);
+      });
 
       form.getComponent('checkbox').setValue(true);
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6895
https://formio.atlassian.net/browse/FIO-6894

## Description

*Changed the version of i18next. After adding deepFind function (v22.14.13) to the i18next library, there is an issue with incorrect interpolation for falsy values. When using a version of i18next library higher than 22.14.12 (not related to the formio.js version), different results are received for interpolation with the same condition. Example below:*
```
    i18next.init({
        lng: 'en',
        keySeparator: '.|.',
        resources: {
          en: {
            translation: {
              'key': 'Label {{data.number}}'
            }
          }
        }
       })

    const res1 = i18next.t('key', {data: {number: 0}})
    const res2 = i18next.t('key', {data: {number: 5}})
    console.log(res1, ' - res1')
    console.log(res2, ' - res2')
```
![image](https://github.com/formio/formio.js/assets/96909212/791b6948-e496-42f9-a855-d2ca1af39eb6)

*Before version 22.14.12, interpolation works as expected*

## Dependencies

*no*

## How has this PR been tested?

*All tests pass locally. Fixed a test that previously failed.*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
