### PR TITLE
FIO-6964: Fixes server crashing if useSessionToken option passed

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -30,7 +30,7 @@ export default class Form extends Element {
 
     super(options);
 
-    if (this.options.useSessionToken) {
+    if (this.options.useSessionToken && !this.options.server) {
       Formio.useSessionToken(this.options);
     }
 

--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -3001,6 +3001,15 @@ describe('Webform tests', function() {
     });
   });
 
+  it('Should not setup session token on server environment', done => {
+    Formio.createForm({ components: [] }, { useSessionToken: true, server: true })
+      .then(() => {
+        expect(localStorage.getItem('useSessionToken')).to.be.null;
+        done();
+      })
+      .catch((err) => done(err));
+  });
+
   it('Should set different ids for components inside different Table rows', (done) => {
     const formElement = document.createElement('div');
     const form = new Webform(formElement, { language: 'en', pdf: true });


### PR DESCRIPTION
## Link to Jira Ticket

Investigation on @brendanbond reported issue with one of my forms
https://formio.atlassian.net/browse/FIO-6964

## Description

**What changed?**

Previously, there was no check that `useSessionToken` method is executed on server side and as the function relates to `localStorage` and `sessionStorage` and they're not available in server environment, the app crashed.

**Why have you chosen this solution?**

The flow was triggered from Validator on server and it passes the `server` option to `formio.js`, so I've used it to check if we're executing BE code.

## Dependencies

None

## How has this PR been tested?

Manually

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
