### PR TITLE
FIO-6901 Fixed custom headers not being passed through custom request…

### DIFF
--- a/src/components/file/editForm/File.edit.file.js
+++ b/src/components/file/editForm/File.edit.file.js
@@ -79,8 +79,11 @@ export default [
     input: true,
     weight: 15,
     placeholder: `{
-  "withCredentials": true
-}`,
+      "withCredentials": true,
+      "headers": {
+        "Authorization": "Basic <key>"
+      }
+    }`,
     conditional: {
       json: {
         '===': [{

--- a/src/providers/storage/url.js
+++ b/src/providers/storage/url.js
@@ -71,7 +71,15 @@ const url = (formio) => {
       if (options) {
         const parsedOptions = typeof options === 'string' ? JSON.parse(options) : options;
         for (const prop in parsedOptions) {
-          xhr[prop] = parsedOptions[prop];
+          if (prop === 'headers') {
+            const headers = parsedOptions['headers'];
+            for (const header in headers) {
+              xhr.setRequestHeader(header, headers[header]);
+            }
+          }
+          else {
+            xhr[prop] = parsedOptions[prop];
+          }
         }
       }
       xhr.send(json ? data : fd);


### PR DESCRIPTION
… options in File component

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6901

## Description

Previously, File component had an option field called "Custom request options" where the user could add custom options, but it was only useful for the request properties like 'withCredentials'. If the user wanted to set up custom request headers, they were added to the XHR request object as property, instead of being set by setRequestHeader method. The fix is to basically use this method if the 'headers' object is present in the custom options.

## How has this PR been tested?

Tested locally with the use of webhook.site to check if the headers were applied when uploading a file

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
