### PR TITLE
FIO-7030: Fixes an issue where Wizard pages are displayed in one line in the for builder

### DIFF
--- a/src/WizardBuilder.js
+++ b/src/WizardBuilder.js
@@ -170,7 +170,12 @@ export default class WizardBuilder extends WebformBuilder {
     });
 
     if (dragula) {
-      dragula([this.element.querySelector('.wizard-pages')])
+      dragula([this.element.querySelector('.wizard-pages')], {
+        // Don't move Add Page button
+        moves: (el) => (!el.classList.contains('wizard-add-page')),
+        // Don't allow dragging components after Add Page button
+        accepts: (el, target, source, sibling) => (sibling ? true : false),
+      })
         .on('drop', this.onReorder.bind(this));
     }
 
@@ -242,13 +247,15 @@ export default class WizardBuilder extends WebformBuilder {
   }
 
   onReorder(element, _target, _source, sibling) {
-    if (!element.dragInfo || (sibling && !sibling.dragInfo)) {
+    const isSiblingAnAddPageButton = sibling?.classList.contains('wizard-add-page');
+    // We still can paste before Add Page button
+    if (!element.dragInfo || (sibling && !sibling.dragInfo && !isSiblingAnAddPageButton)) {
       console.warn('There is no Drag Info available for either dragged or sibling element');
       return;
     }
     const oldPosition = element.dragInfo.index;
     //should drop at next sibling position; no next sibling means drop to last position
-    const newPosition = (sibling ? sibling.dragInfo.index : this.pages.length);
+    const newPosition = (sibling && sibling.dragInfo ? sibling.dragInfo.index : this.pages.length);
     const movedBelow = newPosition > oldPosition;
     const formComponents = fastCloneDeep(this._form.components);
     const draggedRowData = this._form.components[oldPosition];

--- a/src/sass/formio.form.builder.scss
+++ b/src/sass/formio.form.builder.scss
@@ -172,24 +172,6 @@
   position: relative;
 }
 
-.wizard-page-container {
-  display: flex;
-}
-
-.wizard-pages{
-  display: flex;
-  list-style-type: none;
-  margin-bottom: 0;
-  padding-left: 0;
-  li:not(:first-child) {
-    margin-left: 20px;
-  }
-}
-
-.wizard-add-page{
-  margin-left: 20px;
-}
-
 .gu-mirror {
   list-style-type: none;
 }

--- a/src/templates/bootstrap/builderWizard/form.ejs
+++ b/src/templates/bootstrap/builderWizard/form.ejs
@@ -3,20 +3,18 @@
     {{ctx.sidebar}}
   </div>
   <div class="col-xs-8 col-sm-9 col-md-10 formarea">
-    <div class="breadcrumb wizard-page-container">
-      <ol class="wizard-pages">
+    <ol class="breadcrumb wizard-pages">
         {% ctx.pages.forEach(function(page, pageIndex) { %}
           <li id="{{page.key}}">
             <span title="{{page.title}}" class="mr-2 badge {% if (pageIndex === ctx.self.page) { %}badge-primary{% } else { %}badge-info{% } %} wizard-page-label" ref="gotoPage">{{page.title}}</span>
           </li>
         {% }) %}
+          <li class="wizard-add-page">
+            <span title="{{ctx.t('Create Page')}}" class="mr-2 badge badge-success wizard-page-label" ref="addPage">
+              <i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t('Page')}}
+            </span>
+          </li>
       </ol>
-      <div class="wizard-add-page">
-        <span title="{{ctx.t('Create Page')}}" class="mr-2 badge badge-success wizard-page-label" ref="addPage">
-          <i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t('Page')}}
-        </span>
-      </div>
-    </div>
     <div ref="form">
       {{ctx.form}}
     </div>

--- a/src/templates/bootstrap5/builderWizard/form.ejs
+++ b/src/templates/bootstrap5/builderWizard/form.ejs
@@ -3,13 +3,13 @@
     {{ctx.sidebar}}
   </div>
   <div class="col-xs-8 col-sm-9 col-md-10 formarea">
-    <ol class="breadcrumb">
+    <ol class="breadcrumb wizard-pages">
       {% ctx.pages.forEach(function(page, pageIndex) { %}
       <li>
         <span title="{{page.title}}" class="me-2 badge {% if (pageIndex === ctx.self.page) { %}bg-primary{% } else { %}bg-info{% } %} wizard-page-label" ref="gotoPage">{{page.title}}</span>
       </li>
       {% }) %}
-      <li>
+      <li class="wizard-add-page">
         <span title="{{ctx.t('Create Page')}}" class="me-2 badge bg-success wizard-page-label" ref="addPage">
           <i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t('Page')}}
         </span>


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7030

## Description

When we added an ability to change pages order by dragging them, we put Add Page button to a separate flex container to prevent it from being drugged/prevent dropping other pages after Add Page button, but that caused visial issues. I returned the layout back and prevented Add Page from being dragged/other pages from being dropped after it by moves/accepts functions passed to the dragula options.

## How has this PR been tested?

For now only manually, cuase this feature does not have any tests yet and I need to figure out how to write tests with dragula. 

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
