### PR TITLE
Add "ace-builds" to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.20.2",
     "@babel/register": "^7.17.7",
+    "ace-builds": "^1.4.12",
     "async-limiter": "^2.0.0",
     "babel-loader": "^9.1.0",
     "bootstrap": "^4.6.0",


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-5527

## Description

When cherry-picking this PR (https://github.com/formio/formio.js/pull/4980) into the 4.15.x branch, our build script reverted the change to the package.json and removed "ace-builds". So I am looking to commit the change directly to avoid this problem while we investigate the build script.

## Dependencies

## How has this PR been tested?

n/a

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
