### PR TITLE
FIO-6919 fixed value for Signature submission in Data Tab

### DIFF
--- a/src/components/signature/Signature.js
+++ b/src/components/signature/Signature.js
@@ -261,6 +261,9 @@ export default class SignatureComponent extends Input {
   }
 
   getValueAsString(value) {
+    if (_.isUndefined(value) && this.inDataTable) {
+      return '';
+    }
     return value ? 'Yes' : 'No';
   }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6919

## Description

*Previously, submissions that are created before adding the Signature Component had the value "no" in the Signature column of the Data table. This PR replaces this behavior and now submissions that are created before adding the Signature Component have a blank value in the Signature column of the Data table*

## Dependencies

1. *https://github.com/formio/grid/pull/43*
2. *https://github.com/formio/premium/pull/255*

## How has this PR been tested?

*All tests pass locally*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
