### PR TITLE
FIO-7054: Fixes an issue where after saving Wizard Panel settings, some of them disappear

### DIFF
--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -321,13 +321,13 @@ export default class TextAreaComponent extends TextFieldComponent {
   }
 
   setValue(value, flags = {}) {
-    if (this.isPlain || this.options.readOnly || this.disabled || (value === '' && !this.options.building)) {
+    if (this.isPlain || this.options.readOnly || this.disabled) {
       value = (this.component.multiple && Array.isArray(value)) ?
         value.map((val, index) => this.setConvertedValue(val, index)) :
         this.setConvertedValue(value);
       return super.setValue(value, flags);
     }
-    flags.skipWysiwyg = _.isEqual(value, this.getValue());
+    flags.skipWysiwyg = value === '' && flags.resetValue ? false : _.isEqual(value, this.getValue());
     return super.setValue(value, flags);
   }
 

--- a/src/components/textarea/TextArea.unit.js
+++ b/src/components/textarea/TextArea.unit.js
@@ -6,7 +6,7 @@ import formWithCKEditor from '../../../test/forms/formWithCKEditor';
 import formWithRichTextAreas from '../../../test/forms/formWithRichTextAreas';
 import Harness from '../../../test/harness';
 import { Formio } from './../../Formio';
-import { comp1, comp2, comp3 } from './fixtures';
+import { comp1, comp2, comp3, comp4 } from './fixtures';
 import TextAreaComponent from './TextArea';
 import 'ace-builds';
 
@@ -470,6 +470,16 @@ describe('TextArea Component', () => {
             done();
           }, 300);
         }, 500);
+      }).catch(done);
+    });
+
+    it('Should set empty value properly when save as JSON', (done) => {
+      const element = document.createElement('div');
+
+      Formio.createForm(element, comp4).then(form => {
+        const aceTextArea = form.getComponent(['jsonTextarea']);
+        assert.equal(aceTextArea.data.jsonTextarea, '', 'The value should be empty');
+        done();
       }).catch(done);
     });
 

--- a/src/components/textarea/fixtures/comp4.js
+++ b/src/components/textarea/fixtures/comp4.js
@@ -1,0 +1,25 @@
+export default {
+  type: 'form',
+  components: [
+    {
+      type: 'textarea',
+      key: 'jsonTextarea',
+      rows: 5,
+      editor: 'ace',
+      hideLabel: true,
+      as: 'json',
+      input: true
+    },
+    {
+      label: 'Submit',
+      showValidations: false,
+      tableView: false,
+      key: 'submit',
+      type: 'button',
+      input: true
+    }
+  ],
+  title: 'text area tests',
+  display: 'form',
+  name: 'textAriaTests',
+};

--- a/src/components/textarea/fixtures/index.js
+++ b/src/components/textarea/fixtures/index.js
@@ -1,3 +1,4 @@
 export comp1 from './comp1';
 export comp2 from './comp2';
 export comp3 from './comp3';
+export comp4 from './comp4';


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7049

Also its a replacement for the https://formio.atlassian.net/browse/FIO-7049 original fix (cause the original fix works only in builder)

## Description

Previouly, we had an issue where on the 'Reset' event, textareas  with rich text editors were not cleared. The dataValue property was empty, but HTML elements of the rich text editors were keeping the value. This issue was fixed by adding a condition _|| (value === '')_ to the setValue method, but this caused another issue where empty value ("") was stringified (which results in "/"/"") inside setConvertedValue method for ACE editor with saveAs JSON setting. That caused some issues like the conditional function of the page panel settings giving the wrong false result and an issue with Data Table. So I replaced the fix for the original issue with resetting text areas values with setting skipWysiwyg flag to false when we need to reset/clear the value, because originally this flag was set to false only when there is the difference between value and dataValue property that both are equla to "" in the scenario with resetting (but the rich text areas still contain values in their input fields). 

**Why have you chosen this solution?**

*Although there were many potential solutions such as ..., [my solution] was best because ...*

## Dependencies

*This PR depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

There is an automated test written for the issue with resetting rich textareas values that is passing successfully, also I added a test for making sure that there won't be "/"/"" value in the ACE text editor with saveAs JSON setting.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
