### PR TITLE
FIO-7040 Enabled selectData for all List Based Components

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -68,6 +68,11 @@ export default class RadioComponent extends ListComponent {
     return 'radio-selected';
   }
 
+  get listData() {
+    const listData = _.get(this.root, 'submission.metadata.listData', {});
+    return _.get(listData, this.path);
+  }
+
   init() {
     super.init();
     this.templateData = {};
@@ -96,8 +101,11 @@ export default class RadioComponent extends ListComponent {
     this.itemsLoaded = new NativePromise((resolve) => {
       this.itemsLoadedResolve = resolve;
     });
-    this.shouldLoad = true;
+    this.optionsLoaded = false;
     this.loadedOptions = [];
+
+    // Get the template keys for this radio component.
+    this.getTemplateKeys();
   }
 
   render() {
@@ -216,6 +224,15 @@ export default class RadioComponent extends ListComponent {
   }
 
   loadItems(url, search, headers, options, method, body) {
+    if (this.optionsLoaded) {
+      return;
+    }
+
+    if (!this.shouldLoad) {
+      this.loadItemsFromMetadata();
+      return;
+    }
+
     // Ensure we have a method and remove any body if method is get
     method = method || 'GET';
     if (method.toUpperCase() === 'GET') {
@@ -226,28 +243,42 @@ export default class RadioComponent extends ListComponent {
     options.ignoreCache = this.component.ignoreCache;
     // Make the request.
     options.header = headers;
-    if (this.shouldLoad) {
-      this.loading = true;
-      Formio.makeRequest(this.options.formio, 'select', url, method, body, options)
-      .then((response) => {
-        this.loading = false;
-        this.error = null;
-        this.setItems(response);
-        this.shouldLoad = false;
-        this.redraw();
-      })
-      .catch((err) => {
-        this.handleLoadingError(err);
+
+    this.loading = true;
+    Formio.makeRequest(this.options.formio, 'select', url, method, body, options)
+    .then((response) => {
+      this.loading = false;
+      this.error = null;
+      this.setItems(response);
+      this.optionsLoaded = true;
+      this.redraw();
+    })
+    .catch((err) => {
+      this.handleLoadingError(err);
       });
-    }
+  }
+
+  loadItemsFromMetadata() {
+    this.listData.forEach((item, i) => {
+      this.loadedOptions[i] = {
+        label: this.itemTemplate(item)
+      };
+      if (_.isEqual(item, this.selectData)) {
+        this.loadedOptions[i].value = this.dataValue;
+      }
+    });
+    this.optionsLoaded = true;
+    this.redraw();
   }
 
   setItems(items) {
+    const listData = [];
     items?.forEach((item, i) => {
       this.loadedOptions[i] = {
         value: item[this.component.valueProperty],
         label: this.itemTemplate(item, item[this.component.valueProperty])
       };
+      listData.push(this.templateData[item[this.component.valueProperty]]);
       if (_.isUndefined(item[this.component.valueProperty]) ||
         _.isObject(item[this.component.valueProperty]) ||
         (!this.isRadio && _.isBoolean(item[this.component.valueProperty]))
@@ -255,6 +286,17 @@ export default class RadioComponent extends ListComponent {
         this.loadedOptions[i].invalid = true;
       }
     });
+
+    if (this.isSelectURL) {
+      const submission = this.root.submission;
+      if (!submission.metadata) {
+        submission.metadata = {};
+      }
+      if (!submission.metadata.listData) {
+        submission.metadata.listData = {};
+      }
+      _.set(submission.metadata.listData, this.path, listData);
+    }
   }
 
   setSelectedClasses() {
@@ -323,6 +365,15 @@ export default class RadioComponent extends ListComponent {
     }
     if (value === 'false') {
       value = false;
+    }
+
+    if (this.isSelectURL && this.templateData && this.templateData[value]) {
+      const submission = this.root.submission;
+      if (!submission.metadata.selectData) {
+        submission.metadata.selectData = {};
+      }
+
+      _.set(submission.metadata.selectData, this.path, this.templateData[value]);
     }
 
     return super.normalizeValue(value);

--- a/src/components/radio/Radio.unit.js
+++ b/src/components/radio/Radio.unit.js
@@ -59,6 +59,45 @@ describe('Radio Component', () => {
     }).catch(done);
   });
 
+  it('Should provide metadata.selectData for radio component with URL DataSrc', (done) => {
+    const form = _.cloneDeep(comp9);
+    const element = document.createElement('div');
+    const originalMakeRequest = Formio.makeRequest;
+
+    Formio.makeRequest = function() {
+      return new Promise(resolve => {
+        const values = [
+          { name : 'Alabama', abbreviation : 'AL' },
+          { name : 'Alaska', abbreviation: 'AK' },
+          { name: 'American Samoa', abbreviation: 'AS' }
+        ];
+        resolve(values);
+      });
+    };
+
+    Formio.createForm(element, form).then(form => {
+      const radio = form.getComponent('radio');
+
+      setTimeout(()=>{
+        const value = 'AK';
+        radio.setValue(value);
+        setTimeout(() => {
+          assert.equal(radio.dataValue, value);
+          const submit = form.getComponent('submit');
+          const clickEvent = new Event('click');
+          const submitBtn = submit.refs.button;
+          submitBtn.dispatchEvent(clickEvent);
+          setTimeout(() => {
+            assert.equal(_.isEqual(form.submission.metadata.selectData.radio, { name : 'Alaska' }), true);
+            assert.equal(form.submission.metadata.listData.radio.length, 3);
+            Formio.makeRequest = originalMakeRequest;
+            done();
+          },200);
+        },200);
+      }, 200);
+    }).catch(done);
+  });
+
   it('Should save checked value after redrawing if storage type is Number', (done) => {
     Harness.testCreate(RadioComponent, comp3).then((component) => {
       component.setValue(22);

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -506,52 +506,8 @@ export default class SelectComponent extends ListComponent {
     return defaultValue;
   }
 
-  getTemplateKeys() {
-    this.templateKeys = [];
-    if (this.options.readOnly && this.component.template) {
-      const keys = this.component.template.match(/({{\s*(.*?)\s*}})/g);
-      if (keys) {
-        keys.forEach((key) => {
-          const propKey = key.match(/{{\s*item\.(.*?)\s*}}/);
-          if (propKey && propKey.length > 1) {
-            this.templateKeys.push(propKey[1]);
-          }
-        });
-      }
-    }
-  }
-
   get loadingError() {
     return !this.component.refreshOn && !this.component.refreshOnBlur && this.networkError;
-  }
-
-  get selectData() {
-    const selectData = _.get(this.root, 'submission.metadata.selectData', {});
-    return _.get(selectData, this.path);
-  }
-
-  get shouldLoad() {
-    if (this.loadingError) {
-      return false;
-    }
-    // Live forms should always load.
-    if (!this.options.readOnly) {
-      return true;
-    }
-
-    // If there are template keys, then we need to see if we have the data.
-    if (this.templateKeys && this.templateKeys.length) {
-      // See if we already have the data we need.
-      const dataValue = this.dataValue;
-      const selectData = this.selectData;
-      return this.templateKeys.reduce((shouldLoad, key) => {
-        const hasValue = _.has(dataValue, key) || _.has(selectData, key);
-        return shouldLoad || !hasValue;
-      }, false);
-    }
-
-    // Return that we should load.
-    return true;
   }
 
   loadItems(url, search, headers, options, method, body) {

--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -123,6 +123,17 @@ export default class SelectBoxesComponent extends RadioComponent {
       });
     }
 
+    const checkedValues = _.keys(_.pickBy(value, (val) => val));
+    if (this.isSelectURL && this.templateData && _.every(checkedValues, (val) => this.templateData[val])) {
+      const submission = this.root.submission;
+      if (!submission.metadata.selectData) {
+        submission.metadata.selectData = {};
+      }
+      const selectData = [];
+      checkedValues.forEach((value) => selectData.push(this.templateData[value]));
+      _.set(submission.metadata.selectData, this.path, selectData);
+    }
+
     return value;
   }
 
@@ -176,7 +187,7 @@ export default class SelectBoxesComponent extends RadioComponent {
           key = valuesKeys.find((k) => input?.value.toString() === k);
         }
         const isChecked = value[key];
-        if (isChecked && key) {
+        if ((isChecked && key) || (this.isSelectURL && !this.shouldLoad && _.findIndex(this.selectData, this.listData[index]) !== -1)) {
           //add class to container when selected
           this.addClass(wrapper, this.optionSelectedClass);
           //change "checked" attribute

--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -187,7 +187,7 @@ export default class SelectBoxesComponent extends RadioComponent {
           key = valuesKeys.find((k) => input?.value.toString() === k);
         }
         const isChecked = value[key];
-        if ((isChecked && key) || (this.isSelectURL && !this.shouldLoad && _.findIndex(this.selectData, this.listData[index]) !== -1)) {
+        if ((isChecked && key) || (this.isSelectURL && !this.shouldLoad && this.listData && _.findIndex(this.selectData, this.listData[index]) !== -1)) {
           //add class to container when selected
           this.addClass(wrapper, this.optionSelectedClass);
           //change "checked" attribute

--- a/src/components/selectboxes/SelectBoxes.unit.js
+++ b/src/components/selectboxes/SelectBoxes.unit.js
@@ -47,6 +47,45 @@ describe('SelectBoxes Component', () => {
     }).catch(done);
   });
 
+  it('Should provide metadata.selectData for SelectBoxes component with URL DataSrc', (done) => {
+    const form = _.cloneDeep(comp5);
+    const element = document.createElement('div');
+    const originalMakeRequest = Formio.makeRequest;
+
+    Formio.makeRequest = function() {
+      return new Promise(resolve => {
+        const values = [
+          { name : 'Alabama', abbreviation : 'AL' },
+          { name : 'Alaska', abbreviation: 'AK' },
+          { name: 'American Samoa', abbreviation: 'AS' }
+        ];
+        resolve(values);
+      });
+    };
+
+    Formio.createForm(element, form).then(form => {
+      const selectBoxes = form.getComponent('selectBoxes');
+
+      setTimeout(()=>{
+        const value = { AL: false, AK: true, AS: true };
+        selectBoxes.setValue(value);
+        setTimeout(() => {
+          assert.equal(selectBoxes.dataValue, value);
+          const submit = form.getComponent('submit');
+          const clickEvent = new Event('click');
+          const submitBtn = submit.refs.button;
+          submitBtn.dispatchEvent(clickEvent);
+          setTimeout(() => {
+            assert.equal(_.isEqual(form.submission.metadata.selectData.selectBoxes, [{ name : 'Alaska' }, { name : 'American Samoa' }]), true);
+            assert.equal(form.submission.metadata.listData.selectBoxes.length, 3);
+            Formio.makeRequest = originalMakeRequest;
+            done();
+          },200);
+        },200);
+      }, 200);
+    }).catch(done);
+  });
+
   describe('error messages', () => {
     it('Should have a minSelectedCount validation message', () => {
       const formJson = {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7040

## Description

*The concept of selectData has been implemented for all List Based components (Radio Component and SelecBoxes Component). After the changes, the templateData for the selected items is provided in the metadata.selectData value, and the templateData for items is provided in metadata.listData. This allows not to make an additional request to the Data Source URL for readOnly mode if the value shouldLoad === false.*

## Dependencies

*no*

## How has this PR been tested?

*Automated tests have been added. All tests passed locally*

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
