### PR TITLE
FIO-6669 Fixed tooltips cutting off in the component settings modal

### DIFF
--- a/src/sass/formio.form.builder.scss
+++ b/src/sass/formio.form.builder.scss
@@ -212,7 +212,6 @@
 .component-edit-tabs.col-sm-6 {
   min-height: 87vh;
   height: 100%;
-  overflow-y: auto;
 }
 
 .component-edit-tabs.col-sm-12 {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6669

## Description

In default component settings modal window layout, the part of it with the actual settings had overflow-y property set to auto, which was causing content to clip. Other possible solutions are usually overflow 'hacks', but I think that there is no case where we need a scrollbar in the settings section.

## How has this PR been tested?

Tested on the local environment.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
