### PR TITLE
FIO-6933 Fixes for the formbuilder with keyboard actions

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -362,6 +362,10 @@ export default class WebformBuilder extends Component {
   }
 
   attachComponent(element, component) {
+    if (component instanceof WebformBuilder) {
+      return;
+    }
+
     // Add component to element for later reference.
     element.formioComponent = component;
 
@@ -1573,29 +1577,39 @@ export default class WebformBuilder extends Component {
   }
 
   moveComponent(component) {
+    if (this.selectedComponent) {
+      const prevSelected = this.selectedComponent;
+      prevSelected.element?.classList.remove('builder-component-selected');
+      this.removeEventListener(document, 'keydown');
+    }
+
     component.element.focus();
-    component.element.classList.add('builder-selected');
-    this.selectedElement = component;
-    this.removeEventListener(component.element, 'keydown');
-    this.addEventListener(component.element, 'keydown', this.moveHandler.bind(this));
+    component.element.classList.add('builder-component-selected');
+    this.selectedComponent = component;
+    this.addEventListener(document, 'keydown', this.moveHandler.bind(this));
   }
 
   moveHandler = (e) => {
-    e.stopPropagation();
-    e.preventDefault();
+    if (e.keyCode === 38 || e.keyCode === 40 || e.keyCode === 13) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+
     if (e.keyCode === 38) {
       this.updateComponentPlacement(true);
     }
+
     if (e.keyCode === 40) {
       this.updateComponentPlacement(false);
     }
+
     if (e.keyCode === 13) {
-      this.stopMoving(this.selectedElement);
+      this.stopMoving(this.selectedComponent);
     }
   };
 
   updateComponentPlacement(direction) {
-    const component = this.selectedElement;
+    const component = this.selectedComponent;
     let index, info;
     const step = direction ? -1 : 1;
     if (component) {
@@ -1647,7 +1661,9 @@ export default class WebformBuilder extends Component {
 
   stopMoving(comp) {
     const parent = comp.element.parentNode;
+    this.removeEventListener(document, 'keydown');
     parent.formioComponent.rebuild();
+    this.selectedComponent = null;
   }
 
   addNewComponent(element) {

--- a/src/sass/formio.form.builder.scss
+++ b/src/sass/formio.form.builder.scss
@@ -243,6 +243,6 @@
 }
 
 .builder-component-selected {
-  border: 2px dashed #e8e8e8;
+  border: 2px dashed #919191;
   outline: none !important;
 }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6933

## Description

Fixed the following issues:

1) Double call of attachComponent when WebformBuilder was initialized
2) Fixed focus trap when a component was selected to move
3) Changed the way the component is presented when selected to move, also made the outline to not disappear when the component lost focus
4) Fixed event listeners piling up when using the Move many times
5) Fixed a crash when trying to move a component, when another one was selected previously.

## How has this PR been tested?

Tested on the local environment

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
