### PR TITLE
FIO-7043: Fixes an issue where {{}} values in DataSource headers are resolved in the form builder

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1404,7 +1404,9 @@ export default class WebformBuilder extends Component {
         }
       ]
     } : ComponentClass.editForm(_.cloneDeep(overrides));
-    const instanceOptions = {};
+    const instanceOptions = {
+      inFormBuilder: true,
+    };
 
     this.hook('instanceOptionsPreview', instanceOptions);
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7043

## Description

This is a dependency PR for https://github.com/formio/premium/pull/259

When user clicks Edit on the component in Form Builder, it creates an instance of that component to get all of it properties and their default values which are not contained in the minified JSON schema. When this component is created, its init() method is called, the same happens to the DataSource component and inside it it calls refresh() method causing to try to fetch data and resolve the headers. We don't want that and don't need that because that instance is created only for grabbing the full component's schema. I added new option called inFormBuilder (previously, those components were created without passign any additional options, so there were no way to figure out that this is inside FormBuilder) which is always passed to the component instance created inside Form Builder for getting the full JSON schema and made. I decided to add a new option instead of passing attachhMode = 'builder', cause this one is used by many components including init method and could cause some unexpected issues.

## Dependencies

[*This PR depends on the following PRs from other Form.io modules: ...*](https://github.com/formio/premium/pull/259)

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
