### PR TITLE
FIO-6578: Fixes an issue with losing focus on Year field when Day component has advanced logic

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1763,16 +1763,16 @@ export default class Component extends Element {
       if (this.refs.input?.length) {
         const { selection, index } = this.root.currentSelection;
         let input = this.refs.input[index];
-        const isInputRangeSelectable = /text|search|password|tel|url/i.test(input.type || '');
+        const isInputRangeSelectable = (i) => /text|search|password|tel|url/i.test(i?.type || '');
         if (input) {
-          if (isInputRangeSelectable) {
+          if (isInputRangeSelectable(input)) {
             input.setSelectionRange(...selection);
           }
         }
         else {
           input = this.refs.input[this.refs.input.length];
           const lastCharacter = input.value?.length || 0;
-          if (isInputRangeSelectable) {
+          if (isInputRangeSelectable(input)) {
             input.setSelectionRange(lastCharacter, lastCharacter);
           }
         }

--- a/src/components/_classes/field/Field.js
+++ b/src/components/_classes/field/Field.js
@@ -19,4 +19,18 @@ export default class Field extends Component {
       }));
     }
   }
+
+  // Saves current caret position to restore it after the component is redrawn
+  saveCaretPosition(element, index) {
+    if (this.root?.focusedComponent?.path === this.path) {
+      try {
+        this.root.currentSelection = { selection: [element.selectionStart, element.selectionEnd], index };
+      }
+      catch (e) {
+        if (!(e instanceof DOMException)) {
+          console.debug(e);
+        }
+      }
+    }
+  }
 }

--- a/src/components/_classes/multivalue/Multivalue.js
+++ b/src/components/_classes/multivalue/Multivalue.js
@@ -215,20 +215,6 @@ export default class Multivalue extends Field {
     }
   }
 
-  // Saves current caret position to restore it after the component is redrawn
-  saveCaretPosition(element, index) {
-    if (this.root?.focusedComponent?.path === this.path) {
-      try {
-        this.root.currentSelection = { selection: [element.selectionStart, element.selectionEnd], index };
-      }
-      catch (e) {
-        if (!(e instanceof DOMException)) {
-          console.debug(e);
-        }
-      }
-    }
-  }
-
   onSelectMaskHandler(event) {
     this.updateMask(event.target.maskInput, this.getMaskPattern(event.target.value));
   }

--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import moment from 'moment';
 import Field from '../_classes/field/Field';
-import Input from '../_classes/input/Input';
 import { boolValue, componentValueTypes, getComponentSavedTypes, getLocaleDateFormatInfo } from '../../utils/utils';
 
 export default class DayComponent extends Field {
@@ -298,9 +297,17 @@ export default class DayComponent extends Field {
       }
     }
     else {
-      this.addEventListener(this.refs.day, 'input', () => this.updateValue(null, {
-        modified: true
-      }));
+      this.addEventListener(this.refs.day, 'input', () => {
+        try {
+          this.saveCaretPosition(this.refs.day, 'day');
+        }
+        catch (err) {
+          console.warn('An error occurred while trying to save caret position', err);
+        }
+        this.updateValue(null, {
+          modified: true,
+        });
+      });
       // TODO: Need to rework this to work with day select as well.
       // Change day max input when month changes.
       this.addEventListener(this.refs.month, 'input', () => {
@@ -313,18 +320,32 @@ export default class DayComponent extends Field {
         if (maxDay && day > maxDay) {
           this.refs.day.value = this.refs.day.max;
         }
+        try {
+          this.saveCaretPosition(this.refs.month, 'month');
+        }
+        catch (err) {
+          console.warn('An error occurred while trying to save caret position', err);
+        }
         this.updateValue(null, {
           modified: true
         });
       });
-      this.addEventListener(this.refs.year, 'input', () => this.updateValue(null, {
-        modified: true
-      }));
+      this.addEventListener(this.refs.year, 'input', () => {
+        try {
+          this.saveCaretPosition(this.refs.year, 'year');
+        }
+        catch (err) {
+          console.warn('An error occurred while trying to save caret position', err);
+        }
+        this.updateValue(null, {
+          modified: true,
+        });
+      });
       this.addEventListener(this.refs.input, this.info.changeEvent, () => this.updateValue(null, {
         modified: true
       }));
-      [this.refs.day, this.refs.month, this.refs.year].forEach((element) => {
-        Input.prototype.addFocusBlurEvents.call(this, element);
+      [this.refs.day, this.refs.month, this.refs.year].filter((element) => !!element).forEach((element) => {
+        super.addFocusBlurEvents(element);
       });
     }
     this.setValue(this.dataValue);
@@ -591,8 +612,11 @@ export default class DayComponent extends Field {
     return this.getDate(value) || '';
   }
 
-  focus() {
-    if (this.dayFirst && this.showDay || !this.dayFirst && !this.showMonth && this.showDay) {
+  focus(field) {
+    if (field && typeof field === 'string' && this.refs[field]) {
+      this.refs[field].focus();
+    }
+    else if (this.dayFirst && this.showDay || !this.dayFirst && !this.showMonth && this.showDay) {
       this.refs.day?.focus();
     }
     else if (this.dayFirst && !this.showDay && this.showMonth || !this.dayFirst && this.showMonth) {
@@ -600,6 +624,19 @@ export default class DayComponent extends Field {
     }
     else if (!this.showDay && !this.showDay && this.showYear) {
       this.refs.year?.focus();
+    }
+  }
+
+  restoreCaretPosition() {
+    if (this.root?.currentSelection) {
+      const { selection, index } = this.root.currentSelection;
+      if (this.refs[index]) {
+        const input = this.refs[index];
+        const isInputRangeSelectable = (i) => /text|search|password|tel|url/i.test(i?.type || '');
+        if (isInputRangeSelectable(input)) {
+          input.setSelectionRange(...selection);
+        }
+      }
     }
   }
 

--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -288,6 +288,19 @@ export default class DayComponent extends Field {
   attach(element) {
     this.loadRefs(element, { day: 'single', month: 'single', year: 'single', input: 'multiple' });
     const superAttach = super.attach(element);
+
+    const updateValueAndSaveFocus = (element, name) => () => {
+      try {
+        this.saveCaretPosition(element, name);
+      }
+      catch (err) {
+        console.warn('An error occurred while trying to save caret position', err);
+      }
+      this.updateValue(null, {
+        modified: true,
+      });
+    };
+
     if (this.shouldDisabled) {
       this.setDisabled(this.refs.day, true);
       this.setDisabled(this.refs.month, true);
@@ -297,21 +310,14 @@ export default class DayComponent extends Field {
       }
     }
     else {
-      this.addEventListener(this.refs.day, 'input', () => {
-        try {
-          this.saveCaretPosition(this.refs.day, 'day');
-        }
-        catch (err) {
-          console.warn('An error occurred while trying to save caret position', err);
-        }
-        this.updateValue(null, {
-          modified: true,
-        });
-      });
+      this.addEventListener(this.refs.day, 'input', updateValueAndSaveFocus(this.refs.day, 'day'));
       // TODO: Need to rework this to work with day select as well.
       // Change day max input when month changes.
       this.addEventListener(this.refs.month, 'input', () => {
-        const maxDay = this.refs.year ? parseInt(new Date(this.refs.year.value, this.refs.month.value, 0).getDate(), 10)
+        const maxDay = this.refs.year ? parseInt(
+            new Date(this.refs.year.value, this.refs.month.value, 0).getDate(),
+            10
+          )
           : '';
         const day = this.getFieldValue('day');
         if (!this.component.fields.day.hide && maxDay) {
@@ -320,27 +326,9 @@ export default class DayComponent extends Field {
         if (maxDay && day > maxDay) {
           this.refs.day.value = this.refs.day.max;
         }
-        try {
-          this.saveCaretPosition(this.refs.month, 'month');
-        }
-        catch (err) {
-          console.warn('An error occurred while trying to save caret position', err);
-        }
-        this.updateValue(null, {
-          modified: true
-        });
+        updateValueAndSaveFocus(this.refs.month, 'month')();
       });
-      this.addEventListener(this.refs.year, 'input', () => {
-        try {
-          this.saveCaretPosition(this.refs.year, 'year');
-        }
-        catch (err) {
-          console.warn('An error occurred while trying to save caret position', err);
-        }
-        this.updateValue(null, {
-          modified: true,
-        });
-      });
+      this.addEventListener(this.refs.year, 'input', updateValueAndSaveFocus(this.refs.year, 'year'));
       this.addEventListener(this.refs.input, this.info.changeEvent, () => this.updateValue(null, {
         modified: true
       }));

--- a/src/components/day/Day.unit.js
+++ b/src/components/day/Day.unit.js
@@ -10,6 +10,7 @@ import {
   comp3,
   comp4,
   comp5,
+  comp6,
 } from './fixtures';
 import PanelComponent from '../panel/Panel';
 
@@ -244,6 +245,28 @@ describe('Day Component', () => {
           }, 200);
         }, 200);
       }, 200);
+    }).catch(done);
+  });
+
+  it('Should restore focus after redraw', (done) => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    Formio.createForm(element, comp6).then(form => {
+      const textField = form.getComponent(['textField']);
+      textField.setValue('test');
+
+      setTimeout(() => {
+        const day = form.getComponent(['day']);
+        document.querySelector('select.form-control').focus();
+          day.refs.month.value = 2;
+          day.refs.month.dispatchEvent(new Event('input'));
+
+          setTimeout(() => {
+            console.log(global.document.activeElement, day.refs.month);
+            assert(global.document.activeElement === day.refs.month, 'Should keep focus on the year select');
+            done();
+          }, 200);
+      }, 500);
     }).catch(done);
   });
 });

--- a/src/components/day/fixtures/comp6.js
+++ b/src/components/day/fixtures/comp6.js
@@ -1,0 +1,74 @@
+export default {
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      label: 'Text Field',
+      applyMaskOn: 'change',
+      tableView: true,
+      key: 'textField',
+      type: 'textfield',
+      input: true,
+    },
+    {
+      label: 'Day',
+      hideInputLabels: false,
+      inputsLabelPosition: 'top',
+      useLocaleSettings: false,
+      tableView: false,
+      fields: {
+        day: {
+          hide: true,
+        },
+        month: {
+          hide: false,
+        },
+        year: {
+          hide: false,
+        },
+      },
+      defaultValue: '00/00/0000',
+      key: 'day',
+      logic: [
+        {
+          name: 'Disable when Test is empty',
+          trigger: {
+            type: 'simple',
+            simple: {
+              show: true,
+              conjunction: 'all',
+              conditions: [
+                {
+                  component: 'textField',
+                  operator: 'isEmpty',
+                },
+              ],
+            },
+          },
+          actions: [
+            {
+              name: 'Disable',
+              type: 'property',
+              property: {
+                label: 'Disabled',
+                value: 'disabled',
+                type: 'boolean',
+              },
+              state: true,
+            },
+          ],
+        },
+      ],
+      type: 'day',
+      input: true,
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+};

--- a/src/components/day/fixtures/index.js
+++ b/src/components/day/fixtures/index.js
@@ -3,4 +3,5 @@ import comp2 from './comp2';
 import comp3 from './comp3';
 import comp4 from './comp4';
 import comp5 from './comp5';
-export { comp1, comp2, comp3, comp4, comp5 };
+import comp6 from './comp6';
+export { comp1, comp2, comp3, comp4, comp5, comp6 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6578

## Description

Because Day component has three inputs (Day, month and year), formiojs was not able to properly restore focus on it after redrawing, so I adjusted saveCaretPosition function and focus funtion, now it saves field name (day, month or year) instead of input index for Day component and Day component accepts it as an argument to focus a specific field instead of the first one. 

This fix is for restoring focus properly on the Day component after redraw, but this issue also was happenning because unneccessary redraws were happenning (Even when nothing has changed after logic ccheck). That was caused by assigning min and maxDate properties to this.component inside get validationValue(). Since it was assigned to the component's schema after constructor has been called, the originalComponent property did not have those properties leading to redrawing component on each logic check. This issue is already fixed on the master branch as part of the other fix. https://github.com/formio/formio.js/pull/5024


## Dependencies 
https://github.com/formio/formio.js/pull/5024

## How has this PR been tested?

Functionality was tested manually and covered with automated tests as well

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
