### PR TITLE
FIO-6970: Fixes an issue where SelectBoxes Only Available Items validation always fails

### DIFF
--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { componentValueTypes, getComponentSavedTypes } from '../../utils/utils';
+import { componentValueTypes, getComponentSavedTypes, boolValue } from '../../utils/utils';
 import RadioComponent from '../radio/Radio';
 
 export default class SelectBoxesComponent extends RadioComponent {
@@ -282,5 +282,17 @@ export default class SelectBoxesComponent extends RadioComponent {
       }
     }
     return super.checkComponentValidity(data, dirty, rowData, options);
+  }
+
+  validateValueAvailability(setting, value) {
+    if (!boolValue(setting) || !value) {
+      return true;
+    }
+
+    const values = this.component.values;
+    const availableValueKeys = (values || []).map(({ value: optionValue }) => optionValue);
+    const valueKeys = Object.keys(value);
+
+    return valueKeys.every((key) => availableValueKeys.includes(key));
   }
 }

--- a/src/components/selectboxes/SelectBoxes.unit.js
+++ b/src/components/selectboxes/SelectBoxes.unit.js
@@ -364,13 +364,13 @@ describe('SelectBoxes Component', () => {
 
   it('Should perform OnlyAvailableItems check properly', (done) => {
     Harness.testCreate(SelectBoxesComponent, comp7).then(component => {
-      assert.equal(comp7.validateValueAvailability(true, { a: true }), true, 'Should be valid');
-      assert.equal(comp7.validateValueAvailability(true, { a: false, b: false, c: false }), true, 'Should be valid');
-      assert.equal(comp7.validateValueAvailability(true, { a: false, newKey: false }), false, 'Should not be valid');
-      assert.equal(comp7.validateValueAvailability(true, { newKey: false }), false, 'Should not be valid');
-      assert.equal(comp7.validateValueAvailability(true, {}), false, 'Should be valid');
-      assert.equal(comp7.validateValueAvailability(false, {}), false, 'Should be valid');
+      assert.equal(component.validateValueAvailability(true, { a: true }), true, 'Should be valid');
+      assert.equal(component.validateValueAvailability(true, { a: false, b: false, c: false }), true, 'Should be valid');
+      assert.equal(component.validateValueAvailability(true, { a: false, newKey: false }), false, 'Should not be valid');
+      assert.equal(component.validateValueAvailability(true, { newKey: false }), false, 'Should not be valid');
+      assert.equal(component.validateValueAvailability(true, {}), true, 'Should be valid');
+      assert.equal(component.validateValueAvailability(false, {}), true, 'Should be valid');
       done();
-    });
+    }).catch(done);
   });
 });

--- a/src/components/selectboxes/SelectBoxes.unit.js
+++ b/src/components/selectboxes/SelectBoxes.unit.js
@@ -9,7 +9,8 @@ import {
   comp3,
   comp4,
   comp5,
-  comp6
+  comp6,
+  comp7,
 } from './fixtures';
 import wizardWithSelectBoxes from '../../../test/forms/wizardWithSelectBoxes';
 
@@ -358,6 +359,18 @@ describe('SelectBoxes Component', () => {
       options.forEach(i => {
         assert.deepEqual(!!getComputedStyle(i, ':before'), true);
       });
+    });
+  });
+
+  it('Should perform OnlyAvailableItems check properly', (done) => {
+    Harness.testCreate(SelectBoxesComponent, comp7).then(component => {
+      assert.equal(comp7.validateValueAvailability(true, { a: true }), true, 'Should be valid');
+      assert.equal(comp7.validateValueAvailability(true, { a: false, b: false, c: false }), true, 'Should be valid');
+      assert.equal(comp7.validateValueAvailability(true, { a: false, newKey: false }), false, 'Should not be valid');
+      assert.equal(comp7.validateValueAvailability(true, { newKey: false }), false, 'Should not be valid');
+      assert.equal(comp7.validateValueAvailability(true, {}), false, 'Should be valid');
+      assert.equal(comp7.validateValueAvailability(false, {}), false, 'Should be valid');
+      done();
     });
   });
 });

--- a/src/components/selectboxes/fixtures/comp7.js
+++ b/src/components/selectboxes/fixtures/comp7.js
@@ -1,0 +1,29 @@
+export default {
+  label: 'Select Boxes',
+  optionsLabelPosition: 'right',
+  tableView: false,
+  values: [
+    {
+      label: 'a',
+      value: 'a',
+      shortcut: '',
+    },
+    {
+      label: 'b',
+      value: 'b',
+      shortcut: '',
+    },
+    {
+      label: 'c',
+      value: 'c',
+      shortcut: '',
+    },
+  ],
+  validate: {
+    onlyAvailableItems: true,
+  },
+  key: 'selectBoxes',
+  type: 'selectboxes',
+  input: true,
+  inputType: 'checkbox',
+};

--- a/src/components/selectboxes/fixtures/index.js
+++ b/src/components/selectboxes/fixtures/index.js
@@ -4,4 +4,5 @@ import comp3 from './comp3';
 import comp4 from './comp4';
 import comp5 from './comp5';
 import comp6 from './comp6';
-export { comp1, comp2, comp3, comp4, comp5, comp6 };
+import comp7 from './comp7';
+export { comp1, comp2, comp3, comp4, comp5, comp6, comp7 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6970

## Description

**What changed?**

Originally, this feature was requested for the Select and Radio component to prevent saving submission with unexisting values by direct request to the server. But since SelectBoxes extend Radio component, it inherited this setting as well and it was not working properly due to the different value structures. I override the method executing the check for this validation for SelectBoxes vomponent, so now it works properly and fails only if component value contains keys that it should not. 

## How has this PR been tested?

Manually and I also added an automated test
## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
