### PR TITLE
FIO-7074: Fixes an issue where setting submission to the Wizard from the form controller will not set values for all the pages

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -895,26 +895,26 @@ export default class Wizard extends Webform {
   }
 
   setValue(submission, flags = {}, ignoreEstablishment) {
-    this._submission = submission;
-    if (
-      (flags && flags.fromSubmission && (this.options.readOnly || this.editMode) && !this.isHtmlRenderMode()) ||
-      (flags && flags.fromSubmission && (this.prefixComps.length || this.suffixComps.length) && submission._id) ||
-      (this.options.server && (this.prefixComps.length || this.suffixComps.length))
-    ) {
-      this._data = submission.data;
-    }
-
-    if (!ignoreEstablishment) {
-      this.establishPages(submission.data);
-    }
     const changed = this.getPages({ all: true }).reduce((changed, page) => {
       return this.setNestedValue(page, submission.data, flags, changed) || changed;
     }, false);
 
+    if (!flags.sanitize) {
+      this.mergeData(this.data, submission.data);
+    }
+
     if (changed) {
       this.pageFieldLogic(this.page);
     }
+
     this.setEditMode(submission);
+
+    submission.data = this.data;
+    this._submission = submission;
+
+    if (!ignoreEstablishment) {
+      this.establishPages(submission.data);
+    }
 
     return changed;
   }

--- a/src/Wizard.unit.js
+++ b/src/Wizard.unit.js
@@ -161,7 +161,7 @@ describe('Wizard tests', () => {
                   }, 'Should contain correct submission data');
 
                   done();
-                }, 200);
+                }, 500);
               }, 200);
             }, 200);
           }, 200);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7074

## Description
The issue: wizardInstace.submission = {...} will set data only for the first Wizard page, because Wizard's setValue method assigns submission.data to the _data property conditionally only when it is in readOnly or edit mode or if there is a submission id and it has suffix/prefix components.The parent's Webform's method almost always assigns submission.data to the _data property, but using _.mergeWith.
I beleive that this is done conditionally in Wizard because without those conditions hide/show logic won't work properly in Use mode, cause we calle setNestedValue for all the pages after merging/not merging data. Ans setNestedValue returns changed variable which value is determined based on the values passed to the method and the value is the _data property. That's why in the Webform we are mergin data after calling super.setValue. 

I removed redundant conditions and reordered some function calls in the Wizard's setValue method to make it work as it was designed originally in the Webform class. 

All the automated tests are passing and I haven't found new issues duting manual testing. 


## How has this PR been tested?

All the automated tests are passing and I haven't found new issues duting manual testing. 


## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
