### PR TITLE
FIO-7209 Radio works without ValueProperty set

### DIFF
--- a/src/components/radio/Radio.unit.js
+++ b/src/components/radio/Radio.unit.js
@@ -172,47 +172,47 @@ describe('Radio Component', () => {
     }).catch(done);
   });
 
-  it('Should provide validation for ValueProperty', (done) => {
-    const form = _.cloneDeep(comp9);
-    const element = document.createElement('div');
-    const originalMakeRequest = Formio.makeRequest;
+  // it('Should provide validation for ValueProperty', (done) => {
+  //   const form = _.cloneDeep(comp9);
+  //   const element = document.createElement('div');
+  //   const originalMakeRequest = Formio.makeRequest;
 
-    Formio.makeRequest = function() {
-      return new Promise(resolve => {
-        const values = [
-          { name : 'Alabama', abbreviation : 'AL' },
-          { name : 'Alaska', abbreviation: { a:2, b: 'c' } }
-        ];
-        resolve(values);
-      });
-    };
+  //   Formio.makeRequest = function() {
+  //     return new Promise(resolve => {
+  //       const values = [
+  //         { name : 'Alabama', abbreviation : 'AL' },
+  //         { name : 'Alaska', abbreviation: { a:2, b: 'c' } }
+  //       ];
+  //       resolve(values);
+  //     });
+  //   };
 
-    Formio.createForm(element, form).then(form => {
-      const radio = form.getComponent('radio');
-      radio.setValue({ a:2, b: 'c' });
+  //   Formio.createForm(element, form).then(form => {
+  //     const radio = form.getComponent('radio');
+  //     radio.setValue({ a:2, b: 'c' });
 
-      setTimeout(()=>{
-        const submit = form.getComponent('submit');
-        const clickEvent = new Event('click');
-        const submitBtn = submit.refs.button;
-        submitBtn.dispatchEvent(clickEvent);
+  //     setTimeout(()=>{
+  //       const submit = form.getComponent('submit');
+  //       const clickEvent = new Event('click');
+  //       const submitBtn = submit.refs.button;
+  //       submitBtn.dispatchEvent(clickEvent);
 
-        setTimeout(() => {
-          assert.equal(form.errors.length, 1);
-          assert.equal(radio.error.message, 'Invalid Value Property');
-          radio.setValue('AL');
+  //       setTimeout(() => {
+  //         assert.equal(form.errors.length, 1);
+  //         assert.equal(radio.error.message, 'Invalid Value Property');
+  //         radio.setValue('AL');
 
-          setTimeout(() => {
-            assert.equal(form.errors.length, 0);
-            assert.equal(!!radio.error, false);
-            document.innerHTML = '';
-            Formio.makeRequest = originalMakeRequest;
-            done();
-          }, 300);
-        }, 300);
-      }, 200);
-    }).catch(done);
-  });
+  //         setTimeout(() => {
+  //           assert.equal(form.errors.length, 0);
+  //           assert.equal(!!radio.error, false);
+  //           document.innerHTML = '';
+  //           Formio.makeRequest = originalMakeRequest;
+  //           done();
+  //         }, 300);
+  //       }, 300);
+  //     }, 200);
+  //   }).catch(done);
+  // });
 
   it('Should not have default values in schema', (done) => {
     const form = _.cloneDeep(comp6);

--- a/src/components/radio/Radio.unit.js
+++ b/src/components/radio/Radio.unit.js
@@ -172,47 +172,50 @@ describe('Radio Component', () => {
     }).catch(done);
   });
 
-  // it('Should provide validation for ValueProperty', (done) => {
-  //   const form = _.cloneDeep(comp9);
-  //   const element = document.createElement('div');
-  //   const originalMakeRequest = Formio.makeRequest;
+  it('Should use whole Object as value if URL DataSrc and ValueProperty is not set', (done) => {
+    const form = _.cloneDeep(comp9);
+    delete form.components[0].valueProperty;
+    const element = document.createElement('div');
+    const originalMakeRequest = Formio.makeRequest;
+    const values = [
+      { name : 'Alabama', abbreviation : 'AL' },
+      { name : 'Alaska', abbreviation: 'AK' }
+    ];
 
-  //   Formio.makeRequest = function() {
-  //     return new Promise(resolve => {
-  //       const values = [
-  //         { name : 'Alabama', abbreviation : 'AL' },
-  //         { name : 'Alaska', abbreviation: { a:2, b: 'c' } }
-  //       ];
-  //       resolve(values);
-  //     });
-  //   };
+    Formio.makeRequest = function() {
+      return new Promise(resolve => {
+        resolve(values);
+      });
+    };
 
-  //   Formio.createForm(element, form).then(form => {
-  //     const radio = form.getComponent('radio');
-  //     radio.setValue({ a:2, b: 'c' });
+    Formio.createForm(element, form).then(form => {
+      const radio = form.getComponent('radio');
 
-  //     setTimeout(()=>{
-  //       const submit = form.getComponent('submit');
-  //       const clickEvent = new Event('click');
-  //       const submitBtn = submit.refs.button;
-  //       submitBtn.dispatchEvent(clickEvent);
+      setTimeout(()=>{
+        values.forEach((value, i) => {
+          assert.equal(_.isEqual(value, radio.loadedOptions[i].value), true);
+        });
+        radio.setValue(values[1]);
 
-  //       setTimeout(() => {
-  //         assert.equal(form.errors.length, 1);
-  //         assert.equal(radio.error.message, 'Invalid Value Property');
-  //         radio.setValue('AL');
+        setTimeout(() => {
+          const submit = form.getComponent('submit');
+          const clickEvent = new Event('click');
+          const submitBtn = submit.refs.button;
+          submitBtn.dispatchEvent(clickEvent);
 
-  //         setTimeout(() => {
-  //           assert.equal(form.errors.length, 0);
-  //           assert.equal(!!radio.error, false);
-  //           document.innerHTML = '';
-  //           Formio.makeRequest = originalMakeRequest;
-  //           done();
-  //         }, 300);
-  //       }, 300);
-  //     }, 200);
-  //   }).catch(done);
-  // });
+          setTimeout(() => {
+            assert.equal(form.errors.length, 0);
+            assert.equal(!!radio.error, false);
+            assert.equal(radio.getValue(), values[1]);
+            assert.equal(radio.dataValue, values[1]);
+            document.innerHTML = '';
+            Formio.makeRequest = originalMakeRequest;
+            done();
+          }, 300);
+        }, 300);
+      }, 200);
+    }).catch(done);
+  });
 
   it('Should not have default values in schema', (done) => {
     const form = _.cloneDeep(comp6);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7209

## Description

*If Value Property doesn't set for Radio Component with DataSrc url, the User will be able to submit the form. The item itself is used as value property.*

## Dependencies

*https://github.com/formio/bootstrap/pull/74*

## How has this PR been tested?

*All tests pass locally. Automated tests have been updated*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
