### PR TITLE
FIO-7209 Radio works without ValueProperty set

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/register": "^7.17.7",
     "async-limiter": "^2.0.0",
-    "ace-builds": "^1.4.12",
+    "ace-builds": "1.23.4",
     "babel-loader": "^9.1.0",
     "bootstrap": "^4.6.0",
     "bootswatch": "^4.6.0",

--- a/src/components/_classes/list/ListComponent.js
+++ b/src/components/_classes/list/ListComponent.js
@@ -92,7 +92,7 @@ export default class ListComponent extends Field {
 
   loadItems() {}
 
-  getOptionTemplate(data, value) {
+  getOptionTemplate(data, value, index) {
     if (!this.component.template) {
       return data.label;
     }
@@ -111,15 +111,18 @@ export default class ListComponent extends Field {
       // If the value is not an object, then we need to save the template data off for when it is selected.
       this.templateData[templateValue] = options.data.item;
     }
+    if (_.isNumber(index)) {
+      this.templateData[index] = options.data.item;
+    }
     return template;
   }
 
-  itemTemplate(data, value) {
+  itemTemplate(data, value, index) {
     if (_.isEmpty(data)) {
       return '';
     }
 
-    const template = this.sanitize(this.getOptionTemplate(data, value), this.shouldSanitizeValue);
+    const template = this.sanitize(this.getOptionTemplate(data, value, index), this.shouldSanitizeValue);
     if (template) {
       const label = template.replace(/<\/?[^>]+(>|$)/g, '');
       const hasTranslator = this.i18next?.translator;

--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -238,7 +238,7 @@ export default class RadioComponent extends ListComponent {
       return;
     }
 
-    if (!this.shouldLoad) {
+    if (!this.shouldLoad && this.listData) {
       this.loadItemsFromMetadata();
       return;
     }
@@ -273,7 +273,7 @@ export default class RadioComponent extends ListComponent {
       this.loadedOptions[i] = {
         label: this.itemTemplate(item)
       };
-      if (_.isEqual(item, this.selectData)) {
+      if (_.isEqual(item, this.selectData || _.pick(this.dataValue, _.keys(item)))) {
         this.loadedOptions[i].value = this.dataValue;
       }
     });
@@ -286,9 +286,10 @@ export default class RadioComponent extends ListComponent {
     items?.forEach((item, i) => {
       this.loadedOptions[i] = {
         value: this.component.valueProperty ? item[this.component.valueProperty] : item,
-        label: this.itemTemplate(item, item[this.component.valueProperty])
+        label: this.component.valueProperty ? this.itemTemplate(item, item[this.component.valueProperty]) : this.itemTemplate(item, item, i)
       };
-      listData.push(this.templateData[item[this.component.valueProperty]]);
+      listData.push(this.templateData[this.component.valueProperty ? item[this.component.valueProperty] : i]);
+
       if ((this.component.valueProperty || !this.isRadio) && (
         _.isUndefined(item[this.component.valueProperty]) ||
         (!this.isRadio && _.isObject(item[this.component.valueProperty])) ||


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7209

## Description

*If Value Property doesn't set for Radio Component with DataSrc url, the User will be able to submit the form. The item itself is used as value property.*

## Dependencies

*https://github.com/formio/bootstrap/pull/74*

## How has this PR been tested?

*All tests pass locally*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
