### PR TITLE
FIO-7194 Fixed chosen values not being shown when ModalEdit is enabled

### DIFF
--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -157,6 +157,11 @@ export default class SelectBoxesComponent extends RadioComponent {
     if (!value) {
       return '';
     }
+
+    if (this.component.data.url) {
+      return Object.keys(value).filter(v => value[v]).join(', ');
+    }
+
     return _(this.component.values || [])
       .filter((v) => value[v.value])
       .map('label')


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7194

## Description

Previously SelectBoxes modal template function was only supporting manually provided values. A condition for the case of URL data was added.

## How has this PR been tested?

Tested locally

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
