### PR TITLE
FIO-7173 Fixed issue when initial focus gets triggered in Formbuilder…

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -3539,23 +3539,8 @@ export default class Component extends Element {
     };
   }
 
-  isParentFormPreview(parentForm) {
-    if (parentForm.parent?.options.preview) {
-      return true;
-    }
-
-    if (parentForm.parent) {
-      return this.isParentFormPreview(parentForm.parent);
-    }
-
-    return false;
-  }
-
   autofocus() {
-    let hasAutofocus = this.component.autofocus && !this.builderMode && !this.options.preview;
-    if (hasAutofocus && this.isParentFormPreview(this.parent)) {
-      hasAutofocus = false;
-    }
+    const hasAutofocus = this.component.autofocus && !this.builderMode && !this.options.preview;
 
     if (hasAutofocus) {
       this.on('render', () => this.focus(), true);

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -3539,8 +3539,24 @@ export default class Component extends Element {
     };
   }
 
+  isParentFormPreview(parentForm) {
+    if (parentForm.parent?.options.preview) {
+      return true;
+    }
+
+    if (parentForm.parent) {
+      return this.isParentFormPreview(parentForm.parent);
+    }
+
+    return false;
+  }
+
   autofocus() {
-    const hasAutofocus = this.component.autofocus && !this.builderMode && !this.options.preview;
+    let hasAutofocus = this.component.autofocus && !this.builderMode && !this.options.preview;
+    if (hasAutofocus && this.isParentFormPreview(this.parent)) {
+      hasAutofocus = false;
+    }
+
     if (hasAutofocus) {
       this.on('render', () => this.focus(), true);
     }

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -216,6 +216,9 @@ export default class FormComponent extends Component {
     if (this.options.onChange) {
       options.onChange = this.options.onChange;
     }
+    if (this.options.preview) {
+      options.preview = this.options.preview;
+    }
     return options;
   }
 


### PR DESCRIPTION
… inside of the Nested forms

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7173

## Description

Added a recursive check to define if Parent form (for nested forms) is used as a Preview in formbuilder, so that autofocus doesn't get triggered in the component settings modal window.

## How has this PR been tested?

Tested locally.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
