### PR TITLE
FIO-7082: Moved Wizard Breadcrumbs Type to form settings

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1451,7 +1451,11 @@ export default class WebformBuilder extends Component {
       {
         ..._.omit(this.options, ['hooks', 'builder', 'events', 'attachMode', 'skipInit']),
         language: this.options.language,
-        ...editFormOptions
+        ...editFormOptions,
+        evalContext: {
+          ...(editFormOptions?.evalContext || this.options?.evalContext || {}),
+          buildingForm: this.form,
+        },
       }
     );
 

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -211,7 +211,9 @@ export default class Wizard extends Webform {
   }
 
   prepareHeaderSettings(ctx, headerType) {
-    if (this.currentPanel && this.currentPanel.breadcrumb === 'none' || ctx.isSubForm) {
+    const shouldHideBreadcrumbs = this.currentPanel?.breadcrumb === 'none' ||
+      _.get(this.form, 'settings.wizardBreadcrumbsType', '') === 'none';
+    if (shouldHideBreadcrumbs || ctx.isSubForm) {
       return null;
     }
     return this.renderTemplate(headerType, ctx);

--- a/src/components/panel/Panel.unit.js
+++ b/src/components/panel/Panel.unit.js
@@ -64,7 +64,6 @@ describe('Panel Component', () => {
       const components = flattenComponents(panelEditForm().components);
       const keys = Object.keys(components).map(path => components[path].key);
       const settings = [
-        'breadcrumb',
         'breadcrumbClickable'
       ];
 

--- a/src/components/panel/editForm/Panel.edit.display.js
+++ b/src/components/panel/editForm/Panel.edit.display.js
@@ -76,28 +76,23 @@ export default [
     input: false,
     components: [
       {
-        type: 'select',
-        input: true,
-        label: 'Breadcrumb Type',
-        key: 'breadcrumb',
-        dataSrc: 'values',
-        data: {
-          values: [
-            { label: 'Default', value: 'default' },
-            { label: 'Condensed', value: 'condensed' },
-            { label: 'Hidden', value: 'none' },
-          ]
-        }
-      },
-      {
         input: true,
         type: 'checkbox',
         label: 'Allow click on Breadcrumb',
         key: 'breadcrumbClickable',
         defaultValue: true,
-        conditional: {
-          json: { '!==': [{ var: 'data.breadcrumb' }, 'none'] }
+        customConditional({ data = {}, buildingForm = {} }) {
+          const formSettings = buildingForm.settings || {};
+          return ![data.breadcrumb, formSettings.wizardBreadcrumbsType].includes('none');
         }
+        // conditional: {
+        //   json: {
+        //     'and': [
+        //       { '!==': [{ var: 'data.breadcrumb' }, 'none'] },
+        //       { '!==': [{ var: 'buildingForm.settings.wizardBreadcrumbsType' }, 'none'] }
+        //     ]
+        //   }
+        // },
       },
       {
         input: true,

--- a/src/components/panel/editForm/Panel.edit.display.js
+++ b/src/components/panel/editForm/Panel.edit.display.js
@@ -85,14 +85,6 @@ export default [
           const formSettings = buildingForm.settings || {};
           return ![data.breadcrumb, formSettings.wizardBreadcrumbsType].includes('none');
         }
-        // conditional: {
-        //   json: {
-        //     'and': [
-        //       { '!==': [{ var: 'data.breadcrumb' }, 'none'] },
-        //       { '!==': [{ var: 'buildingForm.settings.wizardBreadcrumbsType' }, 'none'] }
-        //     ]
-        //   }
-        // },
       },
       {
         input: true,


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7082

## Description

Removed Condensed type cause it does nothing from the time when the feature was added. Breadcrumbs type select dropdown is moved to the form settings page instead. For the old forms that have breadcrumb type set per page everything will work the same. 
I also had to pass form schema from the form builder to the evalContext of the editForm to prevent showing settings that should not be available when breadcrumbs type is 'hidden'.

## Dependencies

*This PR depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

https://github.com/formio/formio-app/pull/1494

Manually

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
