### PR TITLE
FIO-6859: update-s3-to-accept-headers-from-signer-presign

### DIFF
--- a/src/providers/storage/s3.js
+++ b/src/providers/storage/s3.js
@@ -5,7 +5,7 @@ const s3 = (formio) => ({
       response.data.fileName = fileName;
       response.data.key = XHR.path([response.data.key, dir, fileName]);
       if (response.signed) {
-        xhr.openAndSetHeaders('PUT', response.signed.url);
+        xhr.openAndSetHeaders('PUT', response.signed);
         Object.keys(response.data.headers).forEach(key => {
           xhr.setRequestHeader(key, response.data.headers[key]);
         });

--- a/src/providers/storage/s3.js
+++ b/src/providers/storage/s3.js
@@ -5,8 +5,10 @@ const s3 = (formio) => ({
       response.data.fileName = fileName;
       response.data.key = XHR.path([response.data.key, dir, fileName]);
       if (response.signed) {
-        xhr.openAndSetHeaders('PUT', response.signed);
-        xhr.setRequestHeader('Content-Type', file.type);
+        xhr.openAndSetHeaders('PUT', response.signed.url);
+        Object.keys(response.data.headers).forEach(key => {
+          xhr.setRequestHeader(key, response.data.headers[key]);
+        });
         return file;
       }
       else {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6859

## Description

Loops over the headers that have been sent from server at src/storage/s3/aws.js signed.presigned()
![image](https://github.com/formio/formio.js/assets/112976114/cec93eca-7be9-44bd-a17e-c6311f0b4e90)

**Why have you chosen this solution?**

These headers are coming directly from the `presigned.headers` WITH the presignedUrl from the server that should be necessary to make the request.
![image](https://github.com/formio/formio.js/assets/112976114/c35c7ead-30cb-47b3-a556-80fa3c1c1841)
![image](https://github.com/formio/formio.js/assets/112976114/78564c32-fdea-4938-891c-e5447a644d67)

## Dependencies

### Pull requests
- https://github.com/formio/formio-server/pull/1336

## How has this PR been tested?

Refer to https://github.com/formio/formio-server/pull/1336, I had made this small change to the formio.js node_modules in formio-app when running the portal locally.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
