### PR TITLE
Avoid passing 'undefined' to function getFocusableElements in DataGrid

### DIFF
--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -418,10 +418,13 @@ export default class DataGridComponent extends NestedArrayComponent {
 
   focusOnNewRowElement(row) {
     Object.keys(row).find((key) => {
-      const focusableElements = getFocusableElements(row[key].element);
-      if (focusableElements && focusableElements[0]) {
-        focusableElements[0].focus();
-        return true;
+      const element = row[key].element;
+      if (element) {
+        const focusableElements = getFocusableElements(element);
+        if (focusableElements && focusableElements[0]) {
+          focusableElements[0].focus();
+          return true;
+        }
       }
       return false;
     });


### PR DESCRIPTION
Avoid passing 'undefined' to function getFocusableElements in DataGrid

- Passing 'undefined' leads to an error (TypeError: Cannot read properties of undefined (reading 'querySelectorAll')) shown in console.

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-XXXX

## Description

**What changed?**

Previoulsy, an error was shown in the Browser console log when clicking the 'Add column' button in the Columns component.

Steps to reproduce: 

- In developer portal, drag new columns component into a new form 
- In the 'edit' modal, on the 'Display' tab, under 'Column Properties', press the 'Add column' button 
- Observe an error log in the Browser console

Error:

TypeError: Cannot read properties of undefined (reading '0')
    at scripts.js:2:7858764
    at c.$emit (scripts.js:2:4250942)
    at f.<anonymous> (scripts.js:2:6932320)
    at s.emit (scripts.js:2:5129483)
    at n.emit (scripts.js:2:5163988)
    at b.value (scripts.js:2:5154953)
    at b.value (scripts.js:2:5282517)
    at scripts.js:2:5282182

**Why have you chosen this solution?**

In the function DataGrid#focusOnNewRowElement, the call of getFocusableElements was not protected against row[key].element being undefined. We don't know if row[key].element must always be set or not. The function DataGrid#focusOnNewRowElement was dealing with not finding focusableElements anyway and we assumed that this is just another case in which a focusable element cannot be found. We decided to put a "defensive programming" shield here. This is the most local change that we could do.

## Dependencies

No special dependencies

## How has this PR been tested?

Manual tests have been applied. The desired behaviour can now be observed. The console log entry is gone.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
