### PR TITLE
Fix broken file exclusion patterns

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -622,8 +622,8 @@ export default class FileComponent extends Field {
     }
     valid = pattern.excludes.reduce((result, excludePattern) => {
       const exclude = new RegExp(excludePattern, 'i');
-      return result && (_.isNil(file.type) || !exclude.test(file.type)) &&
-        (_.isNil(file.name) || !exclude.test(file.name));
+      return result && (_.isNil(file.type) || exclude.test(file.type)) &&
+        (_.isNil(file.name) || exclude.test(file.name));
     }, valid);
     return valid;
   }


### PR DESCRIPTION
## Description

**What changed?**
Support filePatterns that include exclusions such as `'!.exe'`.

Looks like this refactor broke it:
https://github.com/formio/formio.js/commit/1c3fe1f8ee776fec12e89dee563023c646d7eb66#diff-88fcc2d2f31515efb91047d6564cc78e83922d7d795e776c2523d7c94f844e6dL450

**Why have you chosen this solution?**
The previous refactor added a negation to these results so any exclusion pattern will always fail.

The exclusion regular expressions are a negative lookahead for the exclusion.
Each exclusion pattern matches a string that does not contain the exclusion.


**Screenshot**
Example of it currently broken:
<img width="300" alt="image" src="https://github.com/formio/formio.js/assets/1170379/b50929ac-fb2d-4393-8ccc-ced05158edcd">


## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
