### PR TITLE
FIO-7146: disable circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,3 +19,11 @@ jobs:
           command: npm test
       - store_artifacts:
           path: test-results.xml
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,21 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: cimg/node:lts
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-      - run:
-          name: Install modules
-          command: yarn install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-          paths:
-            - node_modules
-      - run:
-          name: Test
-          command: npm test
-      - store_artifacts:
-          path: test-results.xml
-workflows:
-  version: 2
-  build-and-test:
-    jobs:
-      - build:
-          filters:
-            branches:
-              ignore: /.*/
+# version: 2
+# jobs:
+#   build:
+#     docker:
+#       - image: cimg/node:lts
+#     steps:
+#       - checkout
+#       - restore_cache:
+#           key: dependency-cache-{{ checksum "package.json" }}
+#       - run:
+#           name: Install modules
+#           command: yarn install
+#       - save_cache:
+#           key: dependency-cache-{{ checksum "package.json" }}
+#           paths:
+#             - node_modules
+#       - run:
+#           name: Test
+#           command: npm test
+#       - store_artifacts:
+#           path: test-results.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,33 @@
-# version: 2
-# jobs:
-#   build:
-#     docker:
-#       - image: cimg/node:lts
-#     steps:
-#       - checkout
-#       - restore_cache:
-#           key: dependency-cache-{{ checksum "package.json" }}
-#       - run:
-#           name: Install modules
-#           command: yarn install
-#       - save_cache:
-#           key: dependency-cache-{{ checksum "package.json" }}
-#           paths:
-#             - node_modules
-#       - run:
-#           name: Test
-#           command: npm test
-#       - store_artifacts:
-#           path: test-results.xml
+version: 2
+jobs:
+  build:
+    docker:
+      - image: cimg/node:lts
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Install modules
+          command: yarn install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run:
+          name: Test
+          command: npm test
+      - store_artifacts:
+          path: test-results.xml
+
+#########################################################
+## Disables Config (Comment/Remove to re-enable CircleCI)
+#########################################################
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7146

## Description

**What changed?**

Adds a workflow that disables all jobs in the config from running.

**Why have you chosen this solution?**

Leaves the CircleCI pipeline intact just adds a config for disabling the workflow from running
![image](https://github.com/formio/formio.js/assets/112976114/6d04e720-2e70-47f6-9429-5c87ea47e98b)


## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
