### PR TITLE
FIO-7355 Fixed issue with HTML5 select flickering on initial click

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -943,6 +943,11 @@ export default class SelectComponent extends ListComponent {
       }
 
       this.focusableElement = input;
+
+      if (this.component.dataSrc === 'custom') {
+        this.addEventListener(input, 'focus', () => this.updateCustomItems());
+      }
+
       this.addEventListener(input, 'keydown', (event) => {
         const { key } = event;
 

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -943,7 +943,6 @@ export default class SelectComponent extends ListComponent {
       }
 
       this.focusableElement = input;
-      this.addEventListener(input, 'focus', () => this.update());
       this.addEventListener(input, 'keydown', (event) => {
         const { key } = event;
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7355

## Description

Removed handler that called update() function for HTML5 select on focus, because there is no mechanisms to change Select options data after the element was already initialized, and any custom/url and other dynamic data gets set on init

## How has this PR been tested?

Tested locally

<img width="121" alt="image" src="https://github.com/formio/formio.js/assets/61691723/06d72bdc-7aba-4068-8524-30590ab9d7af">

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
