### PR TITLE
Remove --frozen-lockfile from config.yml

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -83,7 +83,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: borales/actions-yarn@v4
         with:
-          cmd: install --frozen-lockfile
+          cmd: install
 
       - name: Lint
         uses: borales/actions-yarn@v4


### PR DESCRIPTION
## Description

The --frozen-lockfile looks to be causing github cicd to fail installation.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
