### PR TITLE
FIO-7429: Remove columns component settings(pull, offset, push)

### DIFF
--- a/src/components/columns/editForm/Columns.edit.display.js
+++ b/src/components/columns/editForm/Columns.edit.display.js
@@ -84,24 +84,6 @@ export default [
         key: 'width',
         defaultValue: 6,
         label: 'Width'
-      },
-      {
-        type: 'number',
-        key: 'offset',
-        defaultValue: 0,
-        label: 'Offset'
-      },
-      {
-        type: 'number',
-        key: 'push',
-        defaultValue: 0,
-        label: 'Push'
-      },
-      {
-        type: 'number',
-        key: 'pull',
-        defaultValue: 0,
-        label: 'Pull'
       }
     ]
   },


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7429

## Description

**What changed?**

Previously, formio.js Columns component had width, offset, push and pull bootstrap classes adjustments through component settings. This PR leaves only the width property adjustable, leaving ability to configure all the classes through component JSON schema.

**Why have you chosen this solution?**

*Although there were many potential solutions such as ..., [my solution] was best because ...*

## Dependencies

[@formio/bootstrap:80](https://github.com/formio/bootstrap/pull/80)

## How has this PR been tested?

Manually through formio-app UI

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
