### PR TITLE
Revert "Fio 7074 setting submission on wizard does not update data"

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -897,29 +897,26 @@ export default class Wizard extends Webform {
   }
 
   setValue(submission, flags = {}, ignoreEstablishment) {
-    const changed = this.getPages({ all: true }).reduce((changed, page) => {
-      return this.setNestedValue(page, submission.data, flags, changed) || changed;
-    }, false);
-
-    if (!flags.sanitize ||
+    this._submission = submission;
+    if (
+      (flags && flags.fromSubmission && (this.options.readOnly || this.editMode) && !this.isHtmlRenderMode()) ||
       (flags && flags.fromSubmission && (this.prefixComps.length || this.suffixComps.length) && submission._id) ||
       (this.options.server && (this.prefixComps.length || this.suffixComps.length))
     ) {
-      this.mergeData(this.data, submission.data);
+      this._data = submission.data;
     }
-
-    if (changed) {
-      this.pageFieldLogic(this.page);
-    }
-
-    this.setEditMode(submission);
-
-    submission.data = this.data;
-    this._submission = submission;
 
     if (!ignoreEstablishment) {
       this.establishPages(submission.data);
     }
+    const changed = this.getPages({ all: true }).reduce((changed, page) => {
+      return this.setNestedValue(page, submission.data, flags, changed) || changed;
+    }, false);
+
+    if (changed) {
+      this.pageFieldLogic(this.page);
+    }
+    this.setEditMode(submission);
 
     return changed;
   }

--- a/src/Wizard.unit.js
+++ b/src/Wizard.unit.js
@@ -161,7 +161,7 @@ describe('Wizard tests', () => {
                   }, 'Should contain correct submission data');
 
                   done();
-                }, 500);
+                }, 200);
               }, 200);
             }, 200);
           }, 200);


### PR DESCRIPTION
Reverts formio/formio.js#5351 as a result of Brendan's investigation below.

Brendan:
It looks to me like the Sasha's solution for FIO-7074 (https://github.com/formio/formio.js/pull/5351) and Hanna's solution for FIO-7351 (https://github.com/formio/formio/pull/1634) are conflicting: when the submission reaches the server, we almost always pass the sanitize flag, which has been added to the insanely long conditional check that decides whether or not to call the `mergeData()` method in Wizard's `setValue()` method. This results in mergeData() not being called, and the submission coming back mutated and saved to the database incorrectly. 