### PR TITLE
FIO-7304 Fixed issue when Select with logic was causing unexpected ta…

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -1716,7 +1716,6 @@ export default class SelectComponent extends ListComponent {
   }
 
   detach() {
-    super.detach();
     this.off('blur');
     if (this.choices) {
       if (this.choices.containerOuter?.element?.parentNode) {
@@ -1724,6 +1723,7 @@ export default class SelectComponent extends ListComponent {
       }
       this.choices = null;
     }
+    super.detach();
   }
 
   focus() {


### PR DESCRIPTION
…b switches of the Tabs component

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7304

## Description

Blur event wasn't registered properly for Select component when switching between tabs inside of the Tabs component, which led to unexpected behavior, and the reason for that was that the detach call, which removed event listeners before blur is processed.

## How has this PR been tested?

Tested locally.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
