### PR TITLE
FIO-7184 Fixed showing incorrect value for DateTime and Time componen…

### DIFF
--- a/src/components/datetime/DateTime.js
+++ b/src/components/datetime/DateTime.js
@@ -204,9 +204,13 @@ export default class DateTimeComponent extends Input {
     const timezone = this.timezone;
     if (value && !this.attached && timezone) {
       if (Array.isArray(value) && this.component.multiple) {
-        return value.map((item) => _.trim(FormioUtils.momentDate(item, format, timezone).format(format))).join(', ');
+        return value.map(item => _.trim(FormioUtils.momentDate(item, format, timezone).format(format))).join(', ');
       }
       return _.trim(FormioUtils.momentDate(value, format, timezone).format(format));
+    }
+
+    if (Array.isArray(value) && this.component.multiple) {
+      return value.map(item => _.trim(moment(item).format(format))).join(', ');
     }
     return (value ? _.trim(moment(value).format(format)) : value) || '';
   }

--- a/src/components/datetime/DateTime.js
+++ b/src/components/datetime/DateTime.js
@@ -203,6 +203,9 @@ export default class DateTimeComponent extends Input {
     format += format.match(/z$/) ? '' : ' z';
     const timezone = this.timezone;
     if (value && !this.attached && timezone) {
+      if (Array.isArray(value) && this.component.multiple) {
+        return value.map((item) => _.trim(FormioUtils.momentDate(item, format, timezone).format(format))).join(', ');
+      }
       return _.trim(FormioUtils.momentDate(value, format, timezone).format(format));
     }
     return (value ? _.trim(moment(value).format(format)) : value) || '';

--- a/src/components/time/Time.js
+++ b/src/components/time/Time.js
@@ -157,7 +157,7 @@ export default class TimeComponent extends TextFieldComponent {
 
   getValueAsString(value) {
     if (Array.isArray(value) && this.component.multiple) {
-      return value.map((item) => moment(item, this.component.dataFormat).format(this.component.format)).join(', ');
+      return value.map(item => moment(item, this.component.dataFormat).format(this.component.format)).join(', ');
     }
     return (value ? moment(value, this.component.dataFormat).format(this.component.format) : value) || '';
   }

--- a/src/components/time/Time.js
+++ b/src/components/time/Time.js
@@ -156,6 +156,9 @@ export default class TimeComponent extends TextFieldComponent {
   }
 
   getValueAsString(value) {
+    if (Array.isArray(value) && this.component.multiple) {
+      return value.map((item) => moment(item, this.component.dataFormat).format(this.component.format)).join(', ');
+    }
     return (value ? moment(value, this.component.dataFormat).format(this.component.format) : value) || '';
   }
 


### PR DESCRIPTION
…ts with multiple value enabled inside of the DataTable

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7184

## Description

Previously, DateTime and Time components didn't have support for multiple values inside of getValueAsString methods, which caused an error when the value was formatted by moment library. Added a case to format each value one by one.

## How has this PR been tested?

Tested locally

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
