### PR TITLE
Add capability for adding sanitize profiles through sanitizeConfig in options

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1304,6 +1304,12 @@ export function sanitize(string, options) {
     ADD_ATTR: ['ref', 'target'],
     USE_PROFILES: { html: true }
   };
+  // Use profiles
+  if (options.sanitizeConfig && options.sanitizeConfig.useProfiles) {
+    Object.keys(options.sanitizeConfig.useProfiles).forEach(key => {
+      sanitizeOptions.USE_PROFILES[key] = options.sanitizeConfig.useProfiles[key];
+    });
+  }
   // Add attrs
   if (options.sanitizeConfig && Array.isArray(options.sanitizeConfig.addAttr) && options.sanitizeConfig.addAttr.length > 0) {
     options.sanitizeConfig.addAttr.forEach((attr) => {


### PR DESCRIPTION
With this modification we CAN make Formio render SVG and MathML by including the below under options in sandbox:

```
{
  "sanitizeConfig": {
    "useProfiles": {
      "mathMl": true,
      "svg": true
    }
  }
}
```

SVG and MathML in an HTML element are now rendered as expected.

## Link to Jira Ticket

No Jira ticket - but issue reported in GitHub:
https://github.com/formio/formio.js/issues/4224

## Description

**What changed?**

Previously, formio.js did not allow rendering svg and mathml.
This PR replaces this behavior by allowing to add additional sanitize profiles through options.
See GitHub issue.

**Why have you chosen this solution?**
Fits in the way tags and attributes are added.

## Dependencies
None.

## How has this PR been tested?
Manually in a local sandbox in FireFox and Chrome.
In JSFiddle with code below:

```js
let sanitizeOptions = {
    ADD_ATTR: ['ref', 'target'],
    USE_PROFILES: { html: true }
  };
let options = {
  "sanitizeConfig": {
    "useProfiles": {
      "mathMl": true,
      "svg": true
    }
  }
}

if (options.sanitizeConfig && options.sanitizeConfig.useProfiles) {
    Object.keys(options.sanitizeConfig.useProfiles).forEach(key => {
      sanitizeOptions.USE_PROFILES[key] = options.sanitizeConfig.useProfiles[key];
    });
  }

console.log(sanitizeOptions);
```

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
