### PR TITLE
FIO-7530: added ability to pass onSetItems component setting as a string (needed for builder mode)

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -400,8 +400,10 @@ export default class SelectComponent extends ListComponent {
     }
 
     // Allow js processing (needed for form builder)
-    if (this.component.onSetItems && typeof this.component.onSetItems === 'function') {
-      const newItems = this.component.onSetItems(this, items);
+    if (this.component.onSetItems) {
+      const newItems = typeof this.component.onSetItems === 'function'
+        ? this.component.onSetItems(this, items)
+        : this.evaluate(this.component.onSetItems, { items: items }, 'items');
       if (newItems) {
         items = newItems;
       }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7530

## Description

**What changed?**

added ability to pass onSetItems component setting as a string (needed for DataTable builder mode)

## Dependencies

https://github.com/formio/premium/pull/275

## How has this PR been tested?

manually

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
