### PR TITLE
Revert FIO-4405: fixed an issue where walidation error displays with empty value even if it is not required (#4746)

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -3321,8 +3321,6 @@ export default class Component extends Element {
 
   shouldSkipValidation(data, dirty, row) {
     const rules = [
-      // Do not check custom validation for empty data if it is not required
-      () => this.component.validate.custom && !this.dataValue && !this.component.validate.required,
       // Force valid if component is read-only
       () => this.options.readOnly,
       // Do not check validations if component is not an input component.


### PR DESCRIPTION
This reverts commit 3a8d7d6be224dac2bfc0e0b1dc31ddd2f89075a3.

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7528

## Description 

There is a "shouldSkipValidation" function that checks for, among other things, whether or not the following conditions are satisfied:

(A) there is a custom validation

(B) the dataValue of the component is truthy

(C) the component is required

if A && !B && !C, the component will skip validating. In this case, since the value of an un-blurred select component is "", it is falsy and satisfies A && !B && !C. I'm not sure why this was introduced (I imagine to ensure that empty values that aren't required don't get validated) but we may need to reexamine our thinking behind this. In the meantime, the only workaround I can think of is to both set the field to `required` and maintain the custom validation, so both are ensured to run.

Here's the line in question: https://github.com/formio/formio.js/blob/51f82ab5fe9c71de31e2779f2956d23670e8da97/src/components/_classes/component/Component.js#L3325

from this commit: [formio.js: //github FIO-4405: fixed an issue where walidation error displays with empty value even if it is not required](https://github.com/formio/formio.js/commit/3a8d7d6be224dac2bfc0e0b1dc31ddd2f89075a3)

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
