### PR TITLE
FIO-7112: fixed issues with calendar widget display for value components in new simple conditionals ui

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -211,7 +211,12 @@ export default class Component extends Element {
     return {
       operators: ['isEqual', 'isNotEqual', 'isEmpty', 'isNotEmpty'],
       valueComponent() {
-        return { type: 'textfield' };
+        return {
+          type: 'textfield',
+          widget: {
+            type: 'input'
+          }
+        };
       }
     };
   }

--- a/src/components/textfield/TextField.js
+++ b/src/components/textfield/TextField.js
@@ -44,6 +44,12 @@ export default class TextFieldComponent extends Input {
     return {
       ...super.conditionOperatorsSettings,
       operators: [...super.conditionOperatorsSettings.operators, 'includes', 'notIncludes', 'endsWith', 'startsWith'],
+      valueComponent(classComp) {
+        return {
+          ...classComp,
+          type: 'textfield',
+        };
+      }
     };
   }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7112

## Description

**What changed?**

TextField component should inherit the widget settings of the original form component in new simple conditionals ui.
Base value component in new simple conditionals ui should always has input widget.

## Dependencies

https://github.com/formio/premium/pull/279

## How has this PR been tested?

manually

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
