### PR TITLE
Fixing choices css issue

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,7 +112,7 @@ gulp.task('styles-builder', function builderStyles() {
 });
 gulp.task('styles-full', gulp.series('builder-fonts', function fullStyles() {
   return compileStyles([
-    './node_modules/@formio/choices.js/public/assets/styles/choices.min.css',
+    './node_modules/@formio/choices.js/public/assets/styles/choices.css',
     './node_modules/tippy.js/dist/tippy.css',
     './node_modules/dialog-polyfill/dialog-polyfill.css',
     './node_modules/dragula/dist/dragula.css',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,7 +94,7 @@ gulp.task('styles-embed', function embedStyles() {
 });
 gulp.task('styles-form', function formStyles() {
   return compileStyles([
-    './node_modules/@formio/choices.js/public/assets/styles/choices.min.css',
+    './node_modules/@formio/choices.js/public/assets/styles/choices.css',
     './node_modules/tippy.js/dist/tippy.css',
     './node_modules/dialog-polyfill/dialog-polyfill.css',
     './src/sass/formio.form.scss'
@@ -102,7 +102,7 @@ gulp.task('styles-form', function formStyles() {
 });
 gulp.task('styles-builder', function builderStyles() {
   return compileStyles([
-    './node_modules/@formio/choices.js/public/assets/styles/choices.min.css',
+    './node_modules/@formio/choices.js/public/assets/styles/choices.css',
     './node_modules/tippy.js/dist/tippy.css',
     './node_modules/dialog-polyfill/dialog-polyfill.css',
     './node_modules/dragula/dist/dragula.css',

--- a/src/CDN.unit.js
+++ b/src/CDN.unit.js
@@ -25,7 +25,7 @@ describe('Formio.js CDN class Tests', () => {
   it('Shoudl override CDN urls', () => {
     cdn.setOverrideUrl('grid', 'http://cdn.test-form.io');
     cdn.setVersion('grid', 'latest');
-    assert.equal(cdn.grid, `http://cdn.test-form.io/grid`);
+    assert.equal(cdn.grid, 'http://cdn.test-form.io/grid');
 
     cdn.setOverrideUrl('ace', 'http://cdn.test-form.io');
   });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-XXXX

## Description

formio.full.css caused project compile error. The original commit (already applied to 4.18.x and 4.17.x updated gulp.task('styles-form') and gulp.task('styles-builder'). The added commit also applies it to gulp.task('styles-full')

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
