### PR TITLE
FIO-7481: handle 504 response from service worker in offline mode for file request

### DIFF
--- a/src/providers/storage/xhr.js
+++ b/src/providers/storage/xhr.js
@@ -49,6 +49,12 @@ const XHR = {
       throw err;
     }
     if (!response.ok) {
+      if (response.status === 504) {
+        const error = new Error('Network request failed');
+        error.networkError = true;
+        throw error;
+      }
+
       const message = await response.text();
       throw new Error(message || 'Unable to sign file.');
     }
@@ -94,6 +100,11 @@ const XHR = {
         xhr.onload = () => {
           if (xhr.status >= 200 && xhr.status < 300) {
             resolve(serverResponse);
+          }
+          else if (xhr.status === 504) {
+            const error = new Error('Network request failed');
+            error.networkError = true;
+            reject(error);
           }
           else {
             reject(xhr.response || 'Unable to upload file');


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7481

## Description

Added condition to check response status for file upload requests. More information about 504 status from the service worker can be found on angular documentation [Service worker requests when the server can't be reached](https://angular.io/guide/service-worker-devops#service-worker-requests-when-the-server-cant-be-reached).
Although there were many potential solutions:
1. Check by 504 status code
2. Include 'ngsw-bypass' header in a specific request to let the service worker know that he should skip this request and allow to do it directly to the server. (I don't think it's the best idea to include specific header for angular in our core library)
3. Extend our 'fix-sw' gulp task in the form manager to check the request URL and skip service worker safe fetch when our request points to any storage.

I've chosen this solution because we already have a check by 504 status code to perform offline operations.

## How has this PR been tested?

Manual testing.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
