### PR TITLE
FIO-7466: Make tooltips show non-rendered HTML

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -959,7 +959,15 @@ export default class Component extends Element {
   renderTemplate(name, data = {}, modeOption) {
     // Need to make this fall back to form if renderMode is not found similar to how we search templates.
     const mode = modeOption || this.options.renderMode || 'form';
-    data.component = this.component;
+    data.component = {
+      ...this.component,
+    };
+
+    // Escape HTML provided in component description and render it as a string instead
+    if (this.component.description) {
+      data.component.description = FormioUtils.escapeHTML(this.component.description);
+    }
+
     data.self = this;
     data.options = this.options;
     data.readOnly = this.options.readOnly;

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1218,12 +1218,12 @@ export default class Component extends Element {
                                 .replace(/(?:\r\n|\r|\n)/g, '<br />');
 
         this.tooltips[index] = tippy(tooltip, {
-          allowHTML: true,
+          allowHTML: false,
           trigger: 'mouseenter click focus',
           placement: 'right',
           zIndex: 10000,
           interactive: true,
-          content: this.t(this.sanitize(tooltipText), { _userInput: true }),
+          content: this.t(tooltipText, { _userInput: true }),
         });
       }
     });

--- a/src/components/_classes/component/fixtures/comp5.js
+++ b/src/components/_classes/component/fixtures/comp5.js
@@ -4,8 +4,8 @@ export default {
   components: [
     {
       label: 'Text Field',
-      description: "<img <img src='https://somesite' onerror='var _ee = 2' >",
-      tooltip: "<img src='https://somesite' onerror='var _ee = 1 >",
+      description: "<img src='https://somesite' onerror='var _ee = 2' >",
+      tooltip: "<img src='https://somesite' onerror='var _ee = 1' >",
       applyMaskOn: 'change',
       tableView: true,
       key: 'textField',

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -447,6 +447,22 @@ export function unescapeHTML(str) {
 }
 
 /**
+ * Escape HTML characters like <, >, & and etc.
+ * @param str
+ * @returns {string}
+ */
+export function escapeHTML(html) {
+  if (html) {
+    return html.replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+  return '';
+}
+
+/**
  * Make HTML element from string
  * @param str
  * @param selector


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7466

## Description

Now Tooltips will show non-rendered HTML


## Dependencies

*This PR depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

*I added automated tests to cover [all/the following] cases, including ...*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
