### PR TITLE
FIO-7548: fixed an issue where select dropdown does not overlap the datagrid and causes vertical scroll

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -203,7 +203,7 @@ export default class Element {
    * @param persistent
    *   If this listener should persist beyond "destroy" commands.
    */
-  addEventListener(obj, type, func, persistent) {
+  addEventListener(obj, type, func, persistent, capture) {
     if (!obj) {
       return;
     }
@@ -211,7 +211,7 @@ export default class Element {
       this.eventHandlers.push({ id: this.id, obj, type, func });
     }
     if ('addEventListener' in obj) {
-      obj.addEventListener(type, func, false);
+      obj.addEventListener(type, func, !!capture);
     }
     else if ('attachEvent' in obj) {
       obj.attachEvent(`on${type}`, func);

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -140,6 +140,8 @@ export default class SelectComponent extends ListComponent {
       this.itemsLoadedResolve = resolve;
     });
 
+    this.shouldPositionDropdown = this.hasDataGridAncestor();
+
     if (this.isHtmlRenderMode()) {
       this.activate();
     }
@@ -1002,6 +1004,12 @@ export default class SelectComponent extends ListComponent {
       }
     }
 
+    if (window && this.choices && this.shouldPositionDropdown) {
+      this.addEventListener(window.document, 'scroll', () => {
+        this.positionDropdown(true);
+      }, false, true);
+    }
+
     this.focusableElement.setAttribute('tabIndex', tabIndex);
 
     // If a search field is provided, then add an event listener to update items on search.
@@ -1034,7 +1042,12 @@ export default class SelectComponent extends ListComponent {
       const updateComponent = (evt) => {
         this.triggerUpdate(evt.detail.value);
       };
-      this.addEventListener(input, 'search', _.debounce(updateComponent, debounceTimeout));
+
+      this.addEventListener(input, 'search', _.debounce((e) => {
+        updateComponent(e);
+        this.positionDropdown();
+      },  debounceTimeout));
+
       this.addEventListener(input, 'stopSearch', () => this.triggerUpdate());
       this.addEventListener(input, 'hideDropdown', () => {
         if (this.choices && this.choices.input && this.choices.input.element) {
@@ -1045,7 +1058,16 @@ export default class SelectComponent extends ListComponent {
       });
     }
 
-    this.addEventListener(input, 'showDropdown', () => this.update());
+    this.addEventListener(input, 'showDropdown', () => {
+      this.update();
+      this.positionDropdown();
+    });
+
+    if (this.shouldPositionDropdown) {
+      this.addEventListener(input, 'highlightChoice', () => {
+        this.positionDropdown();
+      });
+    }
 
     if (this.choices && choicesOptions.placeholderValue && this.choices._isSelectOneElement) {
       this.addPlaceholderItem(choicesOptions.placeholderValue);
@@ -1089,6 +1111,53 @@ export default class SelectComponent extends ListComponent {
     this.disabled = this.shouldDisabled;
     this.triggerUpdate();
     return superAttach;
+  }
+
+  setDropdownPosition() {
+    const dropdown = this.choices?.dropdown?.element;
+    const container = this.choices?.containerOuter?.element;
+
+    if (!dropdown || !container) {
+      return;
+    }
+
+    const containerPosition = container.getBoundingClientRect();
+    const isFlipped = container.classList.contains('is-flipped');
+
+    _.assign(dropdown.style, {
+      top: `${isFlipped ? containerPosition.top - dropdown.offsetHeight : containerPosition.top + containerPosition.height}px`,
+      left: `${containerPosition.left}px`,
+      width: `${containerPosition.width}px`,
+      position: 'fixed',
+      bottom: 'unset',
+      right: 'unset',
+    });
+  }
+
+  hasDataGridAncestor(comp) {
+    comp = comp || this;
+
+    if (comp.inDataGrid || comp.type === 'datagrid') {
+      return true;
+    }
+    else if (comp.parent) {
+      return this.hasDataGridAncestor(comp.parent);
+    }
+    else {
+      return false;
+    }
+  }
+
+  positionDropdown(scroll) {
+    if (!this.shouldPositionDropdown || !this.choices || (!this.choices.dropdown?.isActive && scroll)) {
+      return;
+    }
+
+    this.setDropdownPosition();
+
+    this.itemsLoaded.then(() => {
+      this.setDropdownPosition();
+    });
   }
 
   get isLoadingAvailable() {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7548

## Description

**What changed?**

The choices dropdown does not overlap the datagrid and causes vertical scroll because our datagrid component has overflow-x  set to auto so that the horizontal scroll appears when it has many child components that dees not fit the screen width. 
When overflow-x is set to any value except 'visible', the overflow-y gets value 'auto' even if we set it to 'visible' by css that causes vertical scroll when select dropdown is open. In other words, if we are using visible for either overflow-x or overflow-y and something other than visible for the other, the visible value is interpreted as auto.
The workaround for it is to position the dropdown against any element outside the container with overflow-x. 
So, this PR sets position 'fixed' for choices select dropdown when the component is inside the datagrid.

## How has this PR been tested?

Manually

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
