### PR TITLE
FIO-4235 Fixed confirmation dialog popping up when the data is empty …

### DIFF
--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -709,6 +709,10 @@ export default class EditGridComponent extends NestedArrayComponent {
     const rowIndex = this.editRows.length;
     const editRow = this.createRow(dataObj, rowIndex);
 
+    if (editRow.state === EditRowState.New) {
+      this.emptyRow = fastCloneDeep(editRow.data);
+    }
+
     if (this.inlineEditMode) {
       this.triggerChange();
     }
@@ -787,7 +791,7 @@ export default class EditGridComponent extends NestedArrayComponent {
 
   showDialog(rowIndex) {
     const editRow = this.editRows[rowIndex];
-    if (_.isNil(editRow.backup) || _.isEqual(editRow.backup, editRow.data)) {
+    if (editRow.state === EditRowState.New ? _.isEqual(this.emptyRow, editRow.data) : _.isEqual(editRow.backup, editRow.data)) {
       return Promise.resolve();
     }
 

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -787,7 +787,7 @@ export default class EditGridComponent extends NestedArrayComponent {
 
   showDialog(rowIndex) {
     const editRow = this.editRows[rowIndex];
-    if (_.isEqual(editRow.backup, editRow.data)) {
+    if (_.isNil(editRow.backup) || _.isEqual(editRow.backup, editRow.data)) {
       return Promise.resolve();
     }
 


### PR DESCRIPTION
…in EditGrid

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-4235

## Description

Fixed the case when confirmation dialog showed up when the EditGrid row was empty

## How has this PR been tested?

Tested locally

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
