### PR TITLE
FIO-7544: Fixes an issue where scripts inside HTML component will be executed during interpolation

### DIFF
--- a/src/components/html/HTML.js
+++ b/src/components/html/HTML.js
@@ -26,14 +26,6 @@ export default class HTMLComponent extends Component {
     };
   }
 
-  constructor(...args) {
-    const alert =  window.alert;
-    window.alert = (msg) => {
-      return alert(msg);
-    };
-    super(...args);
-  }
-
   static savedValueTypes() {
     return [];
   }

--- a/src/components/html/HTML.js
+++ b/src/components/html/HTML.js
@@ -26,6 +26,14 @@ export default class HTMLComponent extends Component {
     };
   }
 
+  constructor(...args) {
+    const alert =  window.alert;
+    window.alert = (msg) => {
+      return alert(msg);
+    };
+    super(...args);
+  }
+
   static savedValueTypes() {
     return [];
   }
@@ -45,13 +53,15 @@ export default class HTMLComponent extends Component {
     }
 
     const submission = _.get(this.root, 'submission', {});
-    const content = this.component.content ? this.interpolate(this.component.content, {
-      metadata: submission.metadata || {},
-      submission: submission,
-      data: this.rootValue,
-      row: this.data
+    const content = this.component.content ? this.interpolate(
+      this.sanitize(this.component.content, this.shouldSanitizeValue),
+      {
+        metadata: submission.metadata || {},
+        submission: submission,
+        data: this.rootValue,
+        row: this.data
     }) : '';
-    return this.sanitize(content, this.shouldSanitizeValue);
+    return content;
   }
 
   get singleTags() {

--- a/src/components/html/HTML.unit.js
+++ b/src/components/html/HTML.unit.js
@@ -1,3 +1,4 @@
+import Webform from '../../Webform';
 import Harness from '../../../test/harness';
 import HTMLComponent from './HTML';
 import sinon from 'sinon';
@@ -5,7 +6,8 @@ import assert from 'power-assert';
 
 import {
   comp1,
-  comp2
+  comp2,
+  comp3,
 } from './fixtures';
 
 describe('HTML Component', () => {
@@ -29,5 +31,19 @@ describe('HTML Component', () => {
       component.checkRefreshOn(null);
       assert.equal(emit.callCount, 0);
     });
+  });
+
+  it('Should not execute scripts inside HTML component', (done) => {
+    const formElement = document.createElement('div');
+    const form = new Webform(formElement);
+
+    const alert = sinon.spy(window, 'alert');
+    form.setForm(comp3).then(() => {
+      setTimeout(() => {
+        assert.equal(alert.callCount, 0);
+        done();
+      }, 200);
+    })
+      .catch(done);
   });
 });

--- a/src/components/html/fixtures/comp3.js
+++ b/src/components/html/fixtures/comp3.js
@@ -1,0 +1,29 @@
+export default {
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      label: 'HTML',
+      attrs: [
+        {
+          attr: '',
+          value: '',
+        },
+      ],
+      content: '<img src=1 onerror=alert("htmlContent")>',
+      refreshOnChange: false,
+      key: 'html',
+      type: 'htmlelement',
+      input: false,
+      tableView: false,
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+};

--- a/src/components/html/fixtures/index.js
+++ b/src/components/html/fixtures/index.js
@@ -1,3 +1,4 @@
 import comp1 from './comp1';
 import comp2 from './comp2';
-export { comp1, comp2 };
+import comp3 from './comp3';
+export { comp1, comp2, comp3 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7544

## Description

**What changed?**

Previously, formio.js was sanitizing the HTML component's content at the end of get content(), but since interpolate() method uses translateHTMLTemplate utility function that creates a DOM element and sets a content inside it, we need to sanitize the content before it goes there. 

## Dependencies

*This PR depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

*I added automated tests to cover [all/the following] cases, including ...*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
