### PR TITLE
Fix edit grid events in read only mode

### DIFF
--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -550,7 +550,7 @@ export default class EditGridComponent extends NestedArrayComponent {
         }) => {
           const elements = row.getElementsByClassName(className);
           Array.prototype.forEach.call(elements, (element) => {
-            if (this.options.readOnly && _.intersection(element.classList, ['editRow', 'removeRow']).length) {
+            if (this.options.pdf && _.intersection(element.classList, ['editRow', 'removeRow']).length) {
               element.style.display = 'none';
             }
             else {


### PR DESCRIPTION
## Link to Jira Ticket

Fixing issue opened here: https://github.com/formio/formio.js/issues/5420

## Description

Revert to adding events in read only mode and only removing them in pdf rendering mode, which seems to have been the intention in the original MR: https://github.com/formio/formio.js/pull/4850 


This solution ensures backward compatibility.

Although there were other solutions, such as:
* Firing a different event for viewing the grid row (eg: viewRow instead of editRow).

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
