### PR TITLE
FIO-7514: fixed an isse where new simple conditionals do not work when condition is based on the value of resource select with object value

### DIFF
--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -35,6 +35,7 @@ import {
   formWithCollapsedPanel,
   formWithCustomFormatDate,
   tooltipActivateCheckbox,
+  formWithObjectValueSelect
 } from '../test/formtest';
 import UpdateErrorClassesWidgets from '../test/forms/updateErrorClasses-widgets';
 import nestedModalWizard from '../test/forms/nestedModalWizard';
@@ -2644,6 +2645,94 @@ describe('Webform tests', function() {
           }, 300);
         }, 300);
       }).catch((err) => done(err));
+    });
+
+    it('Should show field when condition is based on the values of select resource with object value', (done) => {
+      const element = document.createElement('div');
+      const values = [
+        {
+          _id: '656daabeebc67ecca1141569',
+          form: '656daab0ebc67ecca1141226',
+          data: {
+            number: 4,
+            notes: 'notes 4',
+          },
+          project: '656daa20ebc67ecca1140e8d',
+          state: 'submitted',
+          created: '2023-12-04T10:32:30.821Z',
+          modified: '2023-12-06T14:25:00.886Z',
+        },
+        {
+          _id: '656daabbebc67ecca11414a7',
+          form: '656daab0ebc67ecca1141226',
+          data: {
+            number: 3,
+            notes: 'notes 3',
+          },
+          project: '656daa20ebc67ecca1140e8d',
+          state: 'submitted',
+          created: '2023-12-04T10:32:27.322Z',
+          modified: '2023-12-06T14:25:07.494Z',
+        },
+        {
+          _id: '656daab8ebc67ecca11413e5',
+          form: '656daab0ebc67ecca1141226',
+          data: {
+            number: 2,
+            notes: 'notes 2',
+          },
+          project: '656daa20ebc67ecca1140e8d',
+          state: 'submitted',
+          created: '2023-12-04T10:32:24.514Z',
+          modified: '2023-12-06T14:25:13.610Z',
+        },
+        {
+          _id: '656daab5ebc67ecca1141322',
+          form: '656daab0ebc67ecca1141226',
+          data: {
+            number: 1,
+            notes: 'notes 1',
+          },
+          project: '656daa20ebc67ecca1140e8d',
+          state: 'submitted',
+          created: '2023-12-04T10:32:21.205Z',
+          modified: '2023-12-06T14:25:20.930Z',
+        },
+      ];
+      const originalMakeRequest = Formio.makeRequest;
+      Formio.makeRequest = function() {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            resolve(values);
+          }, 50);
+        });
+      };
+
+      Formio.createForm(element, formWithObjectValueSelect)
+        .then(form => {
+          const numberComp = form.getComponent('number');
+          assert.equal(numberComp.visible, false);
+
+          const selectRef = form.getComponent('selectRef');
+          selectRef.setValue(fastCloneDeep(values[3]));
+          const selectNoValuePropertyMult = form.getComponent('selectNoValueProperty');
+          selectNoValuePropertyMult.setValue([fastCloneDeep(values[2])]);
+          const selectEntireObject = form.getComponent('selectEntireObject');
+          selectEntireObject.setValue(fastCloneDeep(values[1].data));
+          const selectEntireObjectMult = form.getComponent('selectEntireObjectMult');
+          selectEntireObjectMult.setValue([fastCloneDeep(values[0].data)]);
+
+          setTimeout(() => {
+            assert.equal(numberComp.visible, true);
+            selectRef.setValue(fastCloneDeep(values[2]));
+              setTimeout(() => {
+                assert.equal(numberComp.visible, false);
+                Formio.makeRequest = originalMakeRequest;
+                done();
+              }, 400);
+          }, 400);
+        })
+        .catch(done);
     });
   });
 

--- a/src/components/_classes/list/ListComponent.js
+++ b/src/components/_classes/list/ListComponent.js
@@ -1,6 +1,7 @@
 import Field from '../field/Field';
 import { Formio } from '../../../Formio';
 import _ from 'lodash';
+import { getItemTemplateKeys } from '../../../utils/utils';
 
 export default class ListComponent extends Field {
   static schema(...extend) {
@@ -50,18 +51,10 @@ export default class ListComponent extends Field {
   }
 
   getTemplateKeys() {
-    this.templateKeys = [];
-    if (this.options.readOnly && this.component.template) {
-      const keys = this.component.template.match(/({{\s*(.*?)\s*}})/g);
-      if (keys) {
-        keys.forEach((key) => {
-          const propKey = key.match(/{{\s*item\.(.*?)\s*}}/);
-          if (propKey && propKey.length > 1) {
-            this.templateKeys.push(propKey[1]);
-          }
-        });
-      }
-    }
+    const template = this.component.template;
+    this.templateKeys = this.options.readOnly && template
+      ? getItemTemplateKeys(template)
+      : [];
   }
 
   get requestHeaders() {

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -3,7 +3,7 @@ import { Formio } from '../../Formio';
 import ListComponent from '../_classes/list/ListComponent';
 import Input from '../_classes/input/Input';
 import Form from '../../Form';
-import { getRandomComponentId, boolValue, isPromise, componentValueTypes, getComponentSavedTypes } from '../../utils/utils';
+import { getRandomComponentId, boolValue, isPromise, componentValueTypes, getComponentSavedTypes, isSelectResourceWithObjectValue } from '../../utils/utils';
 import Choices from '../../utils/ChoicesWrapper';
 
 export default class SelectComponent extends ListComponent {
@@ -65,7 +65,21 @@ export default class SelectComponent extends ListComponent {
     return {
       ...super.conditionOperatorsSettings,
       valueComponent(classComp) {
-        return { ... classComp, type: 'select' };
+        const valueComp = { ... classComp, type: 'select' };
+
+        if (isSelectResourceWithObjectValue(classComp)) {
+          valueComp.reference = false;
+          valueComp.onSetItems = `
+            var templateKeys = utils.getItemTemplateKeys(component.template) || [];
+            items = _.map(items || [], i => {
+              var item = {};
+              _.each(templateKeys, k =>  _.set(item, k, _.get(i, k)));
+              return item;
+            })
+          `;
+        }
+
+        return valueComp;
       }
     };
   }

--- a/src/utils/conditionOperators/IsEqualTo.js
+++ b/src/utils/conditionOperators/IsEqualTo.js
@@ -1,5 +1,6 @@
 import ConditionOperator from './ConditionOperator';
 import _ from 'lodash';
+import { getItemTemplateKeys, isSelectResourceWithObjectValue } from '../utils';
 
 export default class IsEqualTo extends ConditionOperator {
     static get operatorKey() {
@@ -10,13 +11,36 @@ export default class IsEqualTo extends ConditionOperator {
         return 'Is Equal To';
     }
 
-    execute({ value, comparedValue }) {
+    execute({ value, comparedValue, instance, conditionComponentPath }) {
         if (value && comparedValue && typeof value !== typeof comparedValue && _.isString(comparedValue)) {
             try {
                 comparedValue = JSON.parse(comparedValue);
             }
             // eslint-disable-next-line no-empty
             catch (e) {}
+        }
+
+        if (instance && instance.root) {
+            const conditionTriggerComponent = instance.root.getComponent(conditionComponentPath);
+
+            if (
+                conditionTriggerComponent
+                && isSelectResourceWithObjectValue(conditionTriggerComponent.component)
+                && conditionTriggerComponent.component?.template
+            ) {
+                if (!value || !_.isPlainObject(value)) {
+                    return false;
+                }
+
+                const { template, valueProperty } = conditionTriggerComponent.component;
+
+                if (valueProperty === 'data') {
+                    value = { data: value };
+                    comparedValue = { data: comparedValue };
+                }
+
+                return _.every(getItemTemplateKeys(template) || [], k => _.isEqual(_.get(value, k), _.get(comparedValue, k)));
+            }
         }
 
         //special check for select boxes

--- a/src/utils/conditionOperators/IsNotEqualTo.js
+++ b/src/utils/conditionOperators/IsNotEqualTo.js
@@ -1,7 +1,6 @@
-import ConditionOperator from './ConditionOperator';
-import _ from 'lodash';
+import IsEqualTo from './IsEqualTo';
 
-export default class IsNotEqualTo extends ConditionOperator {
+export default class IsNotEqualTo extends IsEqualTo {
     static get operatorKey() {
         return 'isNotEqual';
     }
@@ -10,7 +9,7 @@ export default class IsNotEqualTo extends ConditionOperator {
         return 'Is Not Equal To';
     }
 
-    execute({ value, comparedValue }) {
-        return  !_.isEqual(value, comparedValue);
+    execute(options) {
+        return !super.execute(options);
     }
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1581,3 +1581,27 @@ export function getComponentSavedTypes(fullSchema) {
 
   return null;
 }
+
+export function getItemTemplateKeys(template) {
+  const templateKeys = [];
+  if (!template) {
+    return templateKeys;
+  }
+  const keys = template.match(/({{\s*(.*?)\s*}})/g);
+
+  if (keys) {
+    keys.forEach((key) => {
+      const propKey = key.match(/{{\s*item\.(.*?)\s*}}/);
+      if (propKey && propKey.length > 1) {
+        templateKeys.push(propKey[1]);
+      }
+    });
+  }
+
+  return templateKeys;
+}
+
+export function isSelectResourceWithObjectValue(comp = {}) {
+  const { reference, dataSrc, valueProperty } = comp;
+  return reference || (dataSrc === 'resource' && (!valueProperty || valueProperty === 'data'));
+}

--- a/test/formtest/formWithObjectValueSelect.json
+++ b/test/formtest/formWithObjectValueSelect.json
@@ -1,0 +1,146 @@
+{
+  "_id": "656dabe1ebc67ecca11415f7",
+  "title": "test conditions select",
+  "name": "testConditionsSelect",
+  "path": "testconditionsselect",
+  "type": "form",
+  "display": "form",
+  "components": [{
+      "label": "Select ref",
+      "widget": "choicesjs",
+      "tableView": true,
+      "dataSrc": "resource",
+      "data": {
+        "resource": "656daab0ebc67ecca1141226"
+      },
+      "template": "<span>Number {{ item.data.number }}<span>({{item.data.notes}})</span></span>",
+      "key": "selectRef",
+      "type": "select",
+      "noRefreshOnScroll": false,
+      "addResource": false,
+      "reference": true,
+      "input": true
+    },
+    {
+      "label": "Select no value property",
+      "widget": "choicesjs",
+      "tableView": true,
+      "multiple": true,
+      "dataSrc": "resource",
+      "data": {
+        "resource": "656daab0ebc67ecca1141226"
+      },
+      "template": "<span>{{ item.data.number }}</span>",
+      "key": "selectNoValueProperty",
+      "type": "select",
+      "noRefreshOnScroll": false,
+      "addResource": false,
+      "reference": false,
+      "input": true
+    },
+    {
+      "label": "Select entire object",
+      "widget": "choicesjs",
+      "tableView": true,
+      "dataSrc": "resource",
+      "data": {
+        "resource": "656daab0ebc67ecca1141226"
+      },
+      "valueProperty": "data",
+      "template": "<span>{{ item.data.number }}</span>",
+      "validate": {
+        "select": false
+      },
+      "key": "selectEntireObject",
+      "type": "select",
+      "searchField": "data__regex",
+      "noRefreshOnScroll": false,
+      "addResource": false,
+      "reference": false,
+      "input": true
+    },
+    {
+      "label": "Select entire object mult",
+      "widget": "choicesjs",
+      "tableView": true,
+      "multiple": true,
+      "dataSrc": "resource",
+      "data": {
+        "resource": "656daab0ebc67ecca1141226"
+      },
+      "valueProperty": "data",
+      "template": "<span>{{ item.data.number }}</span>",
+      "validate": {
+        "select": false
+      },
+      "key": "selectEntireObjectMult",
+      "type": "select",
+      "searchField": "data__regex",
+      "noRefreshOnScroll": false,
+      "addResource": false,
+      "reference": false,
+      "input": true
+    },
+    {
+      "label": "Number",
+      "applyMaskOn": "change",
+      "mask": false,
+      "tableView": false,
+      "delimiter": false,
+      "requireDecimal": false,
+      "inputFormat": "plain",
+      "truncateMultipleSpaces": false,
+      "key": "number",
+      "conditional": {
+        "show": true,
+        "conjunction": "all",
+        "conditions": [{
+            "component": "selectRef",
+            "operator": "isEqual",
+            "value": {
+              "data": {
+                "number": 1,
+                "notes": "notes 1"
+              }
+            }
+          },
+          {
+            "component": "selectNoValueProperty",
+            "operator": "isEqual",
+            "value": {
+              "data": {
+                "number": 2
+              }
+            }
+          },
+          {
+            "component": "selectEntireObject",
+            "operator": "isEqual",
+            "value": {
+              "number": 3
+            }
+          },
+          {
+            "component": "selectEntireObjectMult",
+            "operator": "isEqual",
+            "value": {
+              "number": 4
+            }
+          }
+        ]
+      },
+      "type": "number",
+      "input": true
+    },
+    {
+      "type": "button",
+      "label": "Submit",
+      "key": "submit",
+      "disableOnInvalid": true,
+      "input": true,
+      "tableView": false
+    }
+  ],
+  "project": "656daa20ebc67ecca1140e8d",
+  "machineName": "yyyy-acvcpvwwqbabawl:testConditionsSelect"
+}

--- a/test/formtest/index.js
+++ b/test/formtest/index.js
@@ -41,6 +41,7 @@ const wizardWithSimpleConditionalPage = require('./wizardWithSimpleConditionalPa
 const wizardWithTooltip = require('./wizardWithTooltip.json');
 const resourceKeyCamelCase = require('./resourceKeyCamelCase.json');
 const tooltipActivateCheckbox = require('./tooltipActivateCheckbox.json');
+const formWithObjectValueSelect = require('./formWithObjectValueSelect.json');
 
 module.exports = {
   advanced,
@@ -86,4 +87,5 @@ module.exports = {
   wizardWithTooltip,
   resourceKeyCamelCase,
   tooltipActivateCheckbox,
+  formWithObjectValueSelect
 };

--- a/test/renders/form-bootstrap-formWithObjectValueSelect.html
+++ b/test/renders/form-bootstrap-formWithObjectValueSelect.html
@@ -1,0 +1,48 @@
+<div id="" class="formio-component formio-component-form  formio-component-label-hidden" ref="component">
+  <div class="formio-form" ref="webform" novalidate>
+    <div id="selectRef" class="mb-2 formio-form-group has-feedback formio-component formio-component-select formio-component-selectRef " ref="component">
+      <label ref="label" class="col-form-label " for="selectRef-selectRef" id="l-selectRef-selectRef">
+        Select ref
+      </label>
+      <select ref="selectContainer" name="data[selectRef]" type="text" class="form-control" lang="en" id="selectRef-selectRef" aria-required="false"></select>
+      <input type="text" class="formio-select-autocomplete-input" ref="autocompleteInput" tabindex="-1" aria-label="autocomplete" />
+      <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+    </div>
+    <div id="selectNoValueProperty" class="mb-2 formio-form-group has-feedback formio-component formio-component-select formio-component-selectNoValueProperty formio-component-multiple " ref="component">
+      <label ref="label" class="col-form-label " for="selectNoValueProperty-selectNoValueProperty" id="l-selectNoValueProperty-selectNoValueProperty">
+        Select no value property
+      </label>
+      <select ref="selectContainer" multiple name="data[selectNoValueProperty]" type="text" class="form-control" lang="en" id="selectNoValueProperty-selectNoValueProperty" aria-required="false"></select>
+      <input type="text" class="formio-select-autocomplete-input" ref="autocompleteInput" tabindex="-1" aria-label="autocomplete" />
+      <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+    </div>
+    <div id="selectEntireObject" class="mb-2 formio-form-group has-feedback formio-component formio-component-select formio-component-selectEntireObject " ref="component">
+      <label ref="label" class="col-form-label " for="selectEntireObject-selectEntireObject" id="l-selectEntireObject-selectEntireObject">
+        Select entire object
+      </label>
+      <select ref="selectContainer" name="data[selectEntireObject]" type="text" class="form-control" lang="en" id="selectEntireObject-selectEntireObject" aria-required="false"></select>
+      <input type="text" class="formio-select-autocomplete-input" ref="autocompleteInput" tabindex="-1" aria-label="autocomplete" />
+      <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+    </div>
+    <div id="selectEntireObjectMult" class="mb-2 formio-form-group has-feedback formio-component formio-component-select formio-component-selectEntireObjectMult formio-component-multiple " ref="component">
+      <label ref="label" class="col-form-label " for="selectEntireObjectMult-selectEntireObjectMult" id="l-selectEntireObjectMult-selectEntireObjectMult">
+        Select entire object mult
+      </label>
+      <select ref="selectContainer" multiple name="data[selectEntireObjectMult]" type="text" class="form-control" lang="en" id="selectEntireObjectMult-selectEntireObjectMult" aria-required="false"></select>
+      <input type="text" class="formio-select-autocomplete-input" ref="autocompleteInput" tabindex="-1" aria-label="autocomplete" />
+      <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+    </div>
+    <div id="number" class="mb-2 formio-form-group has-feedback formio-component formio-component-number formio-component-number  formio-hidden" ref="component">
+    </div>
+    <div id="submit" class="mb-2 formio-form-group has-feedback formio-component formio-component-button formio-component-submit  mb-2 formio-form-group" ref="component">
+      <button ref="button" name="data[submit]" type="submit" class="btn btn-primary btn-md" lang="en">
+        Submit
+      </button>
+      <div ref="buttonMessageContainer">
+        <span class="help-block" ref="buttonMessage"></span>
+      </div>
+      <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+    </div>
+  </div>
+  <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+</div>

--- a/test/renders/form-bootstrap-readOnly-formWithObjectValueSelect.html
+++ b/test/renders/form-bootstrap-readOnly-formWithObjectValueSelect.html
@@ -1,0 +1,48 @@
+<div id="" class="formio-component formio-component-form  formio-component-label-hidden" ref="component">
+  <div class="formio-form formio-read-only" ref="webform" novalidate>
+    <div id="selectRef" class="mb-2 formio-form-group has-feedback formio-component formio-component-select formio-component-selectRef " ref="component">
+      <label ref="label" class="col-form-label " for="selectRef-selectRef" id="l-selectRef-selectRef">
+        Select ref
+      </label>
+      <select ref="selectContainer" name="data[selectRef]" type="text" class="form-control" lang="en" disabled="disabled" id="selectRef-selectRef" aria-required="false"></select>
+      <input type="text" class="formio-select-autocomplete-input" ref="autocompleteInput" tabindex="-1" aria-label="autocomplete" />
+      <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+    </div>
+    <div id="selectNoValueProperty" class="mb-2 formio-form-group has-feedback formio-component formio-component-select formio-component-selectNoValueProperty formio-component-multiple " ref="component">
+      <label ref="label" class="col-form-label " for="selectNoValueProperty-selectNoValueProperty" id="l-selectNoValueProperty-selectNoValueProperty">
+        Select no value property
+      </label>
+      <select ref="selectContainer" multiple name="data[selectNoValueProperty]" type="text" class="form-control" lang="en" disabled="disabled" id="selectNoValueProperty-selectNoValueProperty" aria-required="false"></select>
+      <input type="text" class="formio-select-autocomplete-input" ref="autocompleteInput" tabindex="-1" aria-label="autocomplete" />
+      <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+    </div>
+    <div id="selectEntireObject" class="mb-2 formio-form-group has-feedback formio-component formio-component-select formio-component-selectEntireObject " ref="component">
+      <label ref="label" class="col-form-label " for="selectEntireObject-selectEntireObject" id="l-selectEntireObject-selectEntireObject">
+        Select entire object
+      </label>
+      <select ref="selectContainer" name="data[selectEntireObject]" type="text" class="form-control" lang="en" disabled="disabled" id="selectEntireObject-selectEntireObject" aria-required="false"></select>
+      <input type="text" class="formio-select-autocomplete-input" ref="autocompleteInput" tabindex="-1" aria-label="autocomplete" />
+      <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+    </div>
+    <div id="selectEntireObjectMult" class="mb-2 formio-form-group has-feedback formio-component formio-component-select formio-component-selectEntireObjectMult formio-component-multiple " ref="component">
+      <label ref="label" class="col-form-label " for="selectEntireObjectMult-selectEntireObjectMult" id="l-selectEntireObjectMult-selectEntireObjectMult">
+        Select entire object mult
+      </label>
+      <select ref="selectContainer" multiple name="data[selectEntireObjectMult]" type="text" class="form-control" lang="en" disabled="disabled" id="selectEntireObjectMult-selectEntireObjectMult" aria-required="false"></select>
+      <input type="text" class="formio-select-autocomplete-input" ref="autocompleteInput" tabindex="-1" aria-label="autocomplete" />
+      <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+    </div>
+    <div id="number" class="mb-2 formio-form-group has-feedback formio-component formio-component-number formio-component-number  formio-hidden" ref="component">
+    </div>
+    <div id="submit" class="mb-2 formio-form-group has-feedback formio-component formio-component-button formio-component-submit  mb-2 formio-form-group" ref="component">
+      <button ref="button" name="data[submit]" type="submit" class="btn btn-primary btn-md" lang="en" disabled="disabled">
+        Submit
+      </button>
+      <div ref="buttonMessageContainer">
+        <span class="help-block" ref="buttonMessage"></span>
+      </div>
+      <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+    </div>
+  </div>
+  <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
+</div>


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7514

## Description

**What changed?**

When the resource select with object value (select with reference, select resource without value property or select resource with 'entire object' value property) is used in the new conditional logic, we suppose that user expects the equality of labels of the value in condition and the actual value of the select component. This PRs makes so the select component label data is saved as a value for the condition and than compared with the label data of the actual select value.

**Why have you chosen this solution?**

Discussed with Travis as best solution for this use case.

## Dependencies


## How has this PR been tested?

Manually + added tests
All tests passed locally

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
