### PR TITLE
Pass options to the deleteFile method for file components with URL storage

### DIFF
--- a/src/providers/storage/url.js
+++ b/src/providers/storage/url.js
@@ -1,4 +1,19 @@
 function url(formio) {
+  function setOptions(options, xhr) {
+    const parsedOptions = typeof options === 'string' ? JSON.parse(options) : options;
+    for (const prop in parsedOptions) {
+      if (prop === 'headers') {
+        const headers = parsedOptions['headers'];
+        for (const header in headers) {
+          xhr.setRequestHeader(header, headers[header]);
+        }
+      }
+      else {
+        xhr[prop] = parsedOptions[prop];
+      }
+    }
+  }
+  
   const xhrRequest = (url, name, query, data, options, progressCallback, abortCallback) => {
     return new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();
@@ -67,18 +82,7 @@ function url(formio) {
 
       //Overrides previous request props
       if (options) {
-        const parsedOptions = typeof options === 'string' ? JSON.parse(options) : options;
-        for (const prop in parsedOptions) {
-          if (prop === 'headers') {
-            const headers = parsedOptions['headers'];
-            for (const header in headers) {
-              xhr.setRequestHeader(header, headers[header]);
-            }
-          }
-          else {
-            xhr[prop] = parsedOptions[prop];
-          }
-        }
+        setOptions(options, xhr);
       }
       xhr.send(json ? data : fd);
     });
@@ -120,7 +124,7 @@ function url(formio) {
         return uploadRequest();
       }
     },
-    deleteFile(fileInfo) {
+    deleteFile(fileInfo, options) {
       return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();
         xhr.open('DELETE', fileInfo.url, true);
@@ -132,6 +136,9 @@ function url(formio) {
             reject(xhr.response || 'Unable to delete file');
           }
         };
+        if (options) {
+          setOptions(options, xhr);
+        }
         xhr.send(null);
       });
     },

--- a/src/providers/storage/url.js
+++ b/src/providers/storage/url.js
@@ -13,7 +13,7 @@ function url(formio) {
       }
     }
   }
-  
+
   const xhrRequest = (url, name, query, data, options, progressCallback, abortCallback) => {
     return new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();

--- a/src/providers/storage/url.js
+++ b/src/providers/storage/url.js
@@ -1,4 +1,19 @@
 function url(formio) {
+  function setOptions(options, xhr) {
+    const parsedOptions = typeof options === 'string' ? JSON.parse(options) : options;
+    for (const prop in parsedOptions) {
+      if (prop === 'headers') {
+        const headers = parsedOptions['headers'];
+        for (const header in headers) {
+          xhr.setRequestHeader(header, headers[header]);
+        }
+      }
+      else {
+        xhr[prop] = parsedOptions[prop];
+      }
+    }
+  }
+
   const xhrRequest = (url, name, query, data, options, progressCallback, abortCallback) => {
     return new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();
@@ -67,18 +82,7 @@ function url(formio) {
 
       //Overrides previous request props
       if (options) {
-        const parsedOptions = typeof options === 'string' ? JSON.parse(options) : options;
-        for (const prop in parsedOptions) {
-          if (prop === 'headers') {
-            const headers = parsedOptions['headers'];
-            for (const header in headers) {
-              xhr.setRequestHeader(header, headers[header]);
-            }
-          }
-          else {
-            xhr[prop] = parsedOptions[prop];
-          }
-        }
+        setOptions(options, xhr);
       }
       xhr.send(json ? data : fd);
     });
@@ -132,6 +136,9 @@ function url(formio) {
             reject(xhr.response || 'Unable to delete file');
           }
         };
+        if (options) {
+          setOptions(options, xhr);
+        }
         xhr.send(null);
       });
     },

--- a/src/providers/storage/url.js
+++ b/src/providers/storage/url.js
@@ -1,19 +1,4 @@
 function url(formio) {
-  function setOptions(options, xhr) {
-    const parsedOptions = typeof options === 'string' ? JSON.parse(options) : options;
-    for (const prop in parsedOptions) {
-      if (prop === 'headers') {
-        const headers = parsedOptions['headers'];
-        for (const header in headers) {
-          xhr.setRequestHeader(header, headers[header]);
-        }
-      }
-      else {
-        xhr[prop] = parsedOptions[prop];
-      }
-    }
-  }
-
   const xhrRequest = (url, name, query, data, options, progressCallback, abortCallback) => {
     return new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();
@@ -82,7 +67,18 @@ function url(formio) {
 
       //Overrides previous request props
       if (options) {
-        setOptions(options, xhr);
+        const parsedOptions = typeof options === 'string' ? JSON.parse(options) : options;
+        for (const prop in parsedOptions) {
+          if (prop === 'headers') {
+            const headers = parsedOptions['headers'];
+            for (const header in headers) {
+              xhr.setRequestHeader(header, headers[header]);
+            }
+          }
+          else {
+            xhr[prop] = parsedOptions[prop];
+          }
+        }
       }
       xhr.send(json ? data : fd);
     });
@@ -136,9 +132,6 @@ function url(formio) {
             reject(xhr.response || 'Unable to delete file');
           }
         };
-        if (options) {
-          setOptions(options, xhr);
-        }
         xhr.send(null);
       });
     },


### PR DESCRIPTION
**What changed?**

*Previously, formio.js did not pass http request options to the `deleteFile` method for file components with URL storage.  This PR replaces this behavior by passing the options to the `deleteFile` method, allowing users to better secure their files by requiring authorization headers.*