### PR TITLE
FIO-7591: Error messages wrapping on letter instead of on word

### DIFF
--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -896,7 +896,7 @@ body.formio-dialog-open {
 
 .formio-component .table {
   margin-bottom: 0;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .formio-component-htmlelement {
@@ -999,7 +999,7 @@ body.formio-dialog-open {
 
 .datagrid-table {
   &>tbody>tr>td {
-    word-break: break-all;
+    word-break: auto-phrase;
   }
 }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7591

## Description

**What changed?**

Replace break-all CSS value to auto-phrase

**Why have you chosen this solution?**

It was changed to break-all which breaks no event the errors, the labels were breaking on word too.

## Breaking Changes / Backwards Compatibility

None

## Dependencies
None 

## How has this PR been tested?

Locally and manually 

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
