### PR TITLE
FIO-7631: Fixes an issue where timezone is added to the date in PDF download for TextField with CalendarWidget

### DIFF
--- a/src/widgets/CalendarWidget.js
+++ b/src/widgets/CalendarWidget.js
@@ -528,7 +528,7 @@ export default class CalendarWidget extends InputWidget {
     return (date, format) => {
       // Only format this if this is the altFormat and the form is readOnly.
       if (this.settings.readOnly && (format === this.settings.altFormat)) {
-        if (this.loadZones()) {
+        if (!this.settings.enableTime || this.loadZones()) {
           return Flatpickr.formatDate(date, format);
         }
 


### PR DESCRIPTION

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7631

## Description

We don't want to use formatOffset function if time is not enabled cause it will add timezone to the dates that have only day/month/year

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
