### PR TITLE
FIO-4242 updated input mask for TextField

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "fast-json-patch": "^3.1.1",
     "fetch-ponyfill": "^7.1.0",
     "idb": "^7.1.1",
+    "inputmask": "^5.0.8",
     "ismobilejs": "^1.1.1",
     "json-logic-js": "^2.0.2",
     "jstimezonedetect": "^1.0.7",

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2570,11 +2570,13 @@ export default class Component extends Element {
 
     const checkMask = (value) => {
       if (typeof value === 'string') {
-        const placeholderChar = this.placeholderChar;
+        if (this.component.type !== 'textfield') {
+          const placeholderChar = this.placeholderChar;
 
-        value = conformToMask(value, this.defaultMask, { placeholderChar }).conformedValue;
-        if (!FormioUtils.matchInputMask(value, this.defaultMask)) {
-          value = '';
+          value = conformToMask(value, this.defaultMask, { placeholderChar }).conformedValue;
+          if (!FormioUtils.matchInputMask(value, this.defaultMask)) {
+            value = '';
+          }
         }
       }
       else {
@@ -2684,11 +2686,11 @@ export default class Component extends Element {
     const input = this.performInputMapping(this.refs.input[index]);
     const valueMaskInput = this.refs.valueMaskInput;
 
-    if (valueMaskInput?.mask) {
+    if (valueMaskInput?.mask && valueMaskInput.mask.textMaskInputElement) {
       valueMaskInput.mask.textMaskInputElement.update(value);
     }
 
-    if (input.mask) {
+    if (input.mask && input.mask.textMaskInputElement) {
       input.mask.textMaskInputElement.update(value);
     }
     else if (input.widget && input.widget.setValue) {

--- a/src/components/_classes/multivalue/Multivalue.js
+++ b/src/components/_classes/multivalue/Multivalue.js
@@ -119,7 +119,7 @@ export default class Multivalue extends Field {
     if (this.refs.input && this.refs.input.length) {
       this.refs.input.forEach((input) => {
         if (input.mask) {
-          input.mask.destroy();
+          input.mask.destroy ? input.mask.destroy() : input.mask.remove();
         }
         if (input.widget) {
           input.widget.destroy();
@@ -129,7 +129,7 @@ export default class Multivalue extends Field {
     if (this.refs.mask && this.refs.mask.length) {
       this.refs.mask.forEach((input) => {
         if (input.mask) {
-          input.mask.destroy();
+          input.mask.destroy ? input.mask.destroy() : input.mask.remove();
         }
       });
     }

--- a/src/components/textfield/TextField.unit.js
+++ b/src/components/textfield/TextField.unit.js
@@ -423,6 +423,64 @@ describe('TextField Component', () => {
     testFormatting(values, values[values.length-1]);
   });
 
+  it('Should allow dynamic syntax for input mask', (done) => {
+    const form = _.cloneDeep(comp6);
+    form.components[0].inputMask = 'aa-9{1,3}/9[99]';
+
+    const validValues = [
+      '',
+      'bB-77/555',
+      'bc-789/8',
+      'De-7/8',
+      'tr-81/888'
+    ];
+
+    const invalidValues = [
+      '123',
+      '12-hh/789',
+      'dd-/893',
+      'he-538/',
+      'e1-77/790'
+    ];
+
+    const testValidity = (values, valid, lastValue) => {
+      _.each(values, (value) => {
+        const element = document.createElement('div');
+
+        Formio.createForm(element, form).then(form => {
+          form.setPristine(false);
+
+          const component = form.getComponent('textField');
+          const changed = component.setValue(value);
+          const error = 'Text Field does not match the mask.';
+
+          if (value) {
+            assert.equal(changed, true, 'Should set value');
+          }
+
+          setTimeout(() => {
+            if (valid) {
+              assert.equal(!!component.error, false, 'Should not contain error');
+            }
+            else {
+              assert.equal(!!component.error, true, 'Should contain error');
+              assert.equal(component.error.message, error, 'Should contain error message');
+              assert.equal(component.element.classList.contains('has-error'), true, 'Should contain error class');
+              assert.equal(component.refs.messageContainer.textContent.trim(), error, 'Should show error');
+            }
+
+            if (_.isEqual(value, lastValue)) {
+              done();
+            }
+          }, 300);
+        }).catch(done);
+      });
+    };
+
+    testValidity(validValues, true);
+    testValidity(invalidValues, false, invalidValues[invalidValues.length-1]);
+  });
+
   it('Should provide validation for alphabetic input mask after setting value', (done) => {
     const form = _.cloneDeep(comp6);
     form.components[0].inputMask = 'a/A/a-a:a.a,aa';
@@ -430,7 +488,7 @@ describe('TextField Component', () => {
     const validValues = [
       '',
       'b/V/r-y:d.d,as',
-      'b/b/r-y:d.d,as',
+      'b/B/r-y:d.d,as',
     ];
 
     const invalidValues = [
@@ -513,7 +571,7 @@ describe('TextField Component', () => {
 
           setTimeout(() => {
             assert.equal(!!component.error, false, 'Should not contain error');
-            assert.equal(component.getValue(), 's/s/s-s:s.s,ss', 'Should set and format value');
+            assert.equal(component.getValue().toLowerCase(), 's/s/s-s:s.s,ss', 'Should set and format value');
 
             if (_.isEqual(value, lastValue)) {
               done();
@@ -638,10 +696,10 @@ describe('TextField Component', () => {
       '46/34-yy',
       'ye/56-op',
       'We/56-op',
+      'te/56-Dp',
     ];
 
     const invalidValues = [
-      'te/56-Dp',
       'te/E6-pp',
       'tdddde/E6-pp',
       'te/E6',
@@ -695,7 +753,7 @@ describe('TextField Component', () => {
 
     const values = [
       { value:'S67gf-+f34cfd', expected: 'S6/73-cf' },
-      { value:'56DDDfdsf23,DDdsf', expected: '56/23-ds' },
+      { value:'56DDDfdsf23,DDdsf', expected: '56/23-DD' },
       { value:'--fs344d.g234df', expected: 'fs/34-dg' },
       { value:'000000000g234df', expected: '00/00-gd' },
     ];
@@ -814,7 +872,7 @@ describe('TextField Component', () => {
           const component = form.getComponent('textField');
           const input = component.refs.input[0];
 
-          assert.equal(input.placeholder, '.._../..', 'Should set placeholder using the char setting');
+          assert.equal(input.inputmask.undoValue, '.._../..', 'Should set placeholder using the char setting');
 
           const changed = component.setValue(value);
           const error = 'Text Field does not match the mask.';

--- a/src/validator/Validator.js
+++ b/src/validator/Validator.js
@@ -9,6 +9,7 @@ import {
   convertFormatToMoment, getArrayFromComponentPath, unescapeHTML
 } from '../utils/utils';
 import moment from 'moment';
+import Inputmask from 'inputmask';
 import fetchPonyfill from 'fetch-ponyfill';
 const { fetch, Headers, Request } = fetchPonyfill({
   Promise: Promise
@@ -692,6 +693,10 @@ class ValidationChecker {
           }
           else {
             inputMask = setting;
+          }
+
+          if (value && inputMask && typeof value === 'string' && component.type === 'textfield' ) {
+            return Inputmask.isValid(value, inputMask);
           }
 
           inputMask = inputMask ? getInputMask(inputMask) : null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4366,6 +4366,11 @@ ini@^1.3.4:
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+inputmask@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/inputmask/-/inputmask-5.0.8.tgz#cd0f70b058c3291a0d4f27de25dbfc179c998bb4"
+  integrity sha512-1WcbyudPTXP1B28ozWWyFa6QRIUG4KiLoyR6LFHlpT4OfTzRqFfWgHFadNvRuMN1S9XNVz9CdNvCGjJi+uAMqQ==
+
 inquirer@^7.0.0:
   version "7.3.3"
   resolved "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-4242

## Description

*The InputMask for the TextField component has been updated and works according to the [documentation](https://github.com/RobinHerbots/Inputmask). After the changes, the inputmask supports dynamic syntax:*

- *9{1,4} meant to mean that it accepts one, two, three or four numbers*
- *9[99] meant to mean that it accepts one number and two additional optional numbers*

*Also according to the [documentation](https://github.com/RobinHerbots/Inputmask), "a" allows to enter lowercase and uppercase letters, and "A" allows to enter only uppercase letters*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*no*

## How has this PR been tested?

*Tests have been added and updated*

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
