### PR TITLE
Wizard: Keep current page after language is changed

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -1013,7 +1013,7 @@ export default class Wizard extends Webform {
   rebuild() {
     const currentPage = this.page;
     const setCurrentPage = () => this.setPage(currentPage);
-    super.rebuild().then(setCurrentPage.bind(this));
+    super.rebuild().then(setCurrentPage);
   }
 
   checkValidity(data, dirty, row, currentPageOnly) {

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -1013,7 +1013,7 @@ export default class Wizard extends Webform {
   rebuild() {
     const currentPage = this.page;
     const setCurrentPage = () => this.setPage(currentPage);
-    super.rebuild().then(setCurrentPage);
+    return super.rebuild().then(setCurrentPage);
   }
 
   checkValidity(data, dirty, row, currentPageOnly) {

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -1010,6 +1010,12 @@ export default class Wizard extends Webform {
     return super.redraw();
   }
 
+  rebuild() {
+    const currentPage = this.page;
+    const setCurrentPage = () => this.setPage(currentPage);
+    super.rebuild().then(setCurrentPage.bind(this));
+  }
+
   checkValidity(data, dirty, row, currentPageOnly) {
     if (!this.checkCondition(row, data)) {
       this.setCustomValidity('');

--- a/src/Wizard.unit.js
+++ b/src/Wizard.unit.js
@@ -1276,6 +1276,25 @@ describe('Wizard tests', () => {
     .catch((err) => done(err));
   });
 
+  it('Should stay on current page when changing language', function(done) {
+    const formElement = document.createElement('div');
+    const wizard = new Wizard(formElement, { language: 'en' });
+    wizard.setForm(wizardTestForm.form).then(() => {
+      const checkPage = (page) => {
+        assert.equal(wizard.page, page, `Page ${page + 1} should be the current page`);
+      };
+
+      Harness.clickElement(wizard, wizard.refs[`${wizard.wizardKey}-link`][2]);
+      checkPage(2);
+
+      wizard.language = 'es';
+      setTimeout(() => {
+        checkPage(2);
+        done();
+      }, 50);
+    });
+  });
+
   it('Should correctly set values in HTML render mode', function(done) {
     const formElement = document.createElement('div');
     const formHTMLMode = new Wizard(formElement, {


### PR DESCRIPTION
## Link to Jira Ticket

N/A

## Description

**What changed?**

When rendering a form with display 'wizard' the current page will now be kept after language is changed.

**Why have you chosen this solution?**

After upgrading to the most recent version of formio.js we saw that when a form was rendered with display 'wizard' the current page was reset to zero after changing the language. Prior to https://github.com/formio/formio.js/pull/5176 (which changed the implementation of 'set language' to invoke rebuild instead of redraw) this did not happen.

## Breaking Changes / Backwards Compatibility

This is a breaking change if someone expects the form with display 'wizard' to reset current page to zero when the form is rebuilt.

## Dependencies

N/A

## How has this PR been tested?

Unit test, and in my team's application using formio.js.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above