### PR TITLE
FIO-7809 fixed pdf submission download error

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 import fetchPonyfill from 'fetch-ponyfill';
 import jsonLogic from 'json-logic-js';
-import moment from 'moment-timezone/moment-timezone';
+import * as moment from 'moment-timezone/moment-timezone';
 import jtz from 'jstimezonedetect';
 import { lodashOperators } from './jsonlogic/operators';
 import NativePromise from 'native-promise-only';


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7809

## Description

*Fixed Timout error for PDF download page. During the manual integration of the changes from 5.x, the [line](https://github.com/formio/formio.js/blob/5.x/src/utils/utils.js#L6) was omitted, which caused an error when download the PDF page*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*no*

## How has this PR been tested?

*Tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
