### PR TITLE
FIO-7809 fixed pdf submission download error

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -36,8 +36,7 @@ jsonLogic.add_operation('relativeMaxDate', (relativeMaxDate) => {
   return moment().add(relativeMaxDate, 'days').toISOString();
 });
 
-export { jsonLogic, ConditionOperators };
-export * as moment from 'moment-timezone/moment-timezone';
+export { jsonLogic, moment, ConditionOperators };
 
 function setPathToComponentAndPerentSchema(component) {
   component.path = getComponentPath(component);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7809

## Description

*Fixed Timeout error for PDF download page. In the process of manually integrating changes from 5.x, it turned out that [import](https://github.com/formio/formio.js/blob/4.19.x/src/utils/utils.js#L6) and [export](https://github.com/formio/formio.js/blob/4.19.x/src/utils/utils.js#L40) are different, which is the reason for the Timeout Error when download the PDF page*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*no*

## How has this PR been tested?

*all tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
