### PR TITLE
add conditional to check for new headers object

### DIFF
--- a/src/providers/storage/s3.js
+++ b/src/providers/storage/s3.js
@@ -39,9 +39,11 @@ function s3(formio) {
           else {
             xhr.openAndSetHeaders('PUT', response.signed);
             xhr.setRequestHeader('Content-Type', file.type);
-            Object.keys(response.data.headers).forEach((key) => {
-              xhr.setRequestHeader(key, response.data.headers[key]);
-            });
+            if (response.data.headers) {
+              Object.keys(response.data.headers).forEach((key) => {
+                xhr.setRequestHeader(key, response.data.headers[key]);
+              });
+            }
             return file;
           }
         }


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

At some point a change was made [on the client](https://github.com/formio/formio.js/commit/640ffd74e6907f53619cfc93b2fd6e11c20144d6) and [on the server](https://github.com/formio/formio-server/commit/227ec27fc02ccbaf3893ae491ec75a0a34eefdb5) which added a `headers` object to the Enterprise Server's presigned url response to S3 upload requests. These changes didn't account for older deployments, which may not include the headers object, which results in a TypeError on newer clients that are connected to older server environments (see #5475 e.g.). This PR adds a simple conditional which should skip the new client logic if the headers object does not exist.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
