### PR TITLE
FIO-7764: Fixes a typo in File component settings

### DIFF
--- a/src/components/file/editForm/File.edit.file.js
+++ b/src/components/file/editForm/File.edit.file.js
@@ -185,7 +185,7 @@ export default [
     input: true,
     key: 'fileNameTemplate',
     label: 'File Name Template',
-    placeholder: '(optional) { {name} }-{ {guid} }"',
+    placeholder: '(optional) { {name} }-{ {guid} }',
     tooltip: 'Specify template for name of uploaded file(s). Regular template variables are available (`data`, `component`, `user`, `value`, `moment` etc.), also `fileName`, `guid` variables are available. `guid` part must be present, if not found in template, will be added at the end.',
     weight: 25
   },


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7764

## Description

Removed an extra quotation from File Template Name placeholder

**Why have you chosen this solution?**

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
