### PR TITLE
FIO 7603 Edit Grid With Empty Rows Not Submitting Form

### DIFF
--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -1268,8 +1268,10 @@ export default class EditGridComponent extends NestedArrayComponent {
       return false;
     }
     else if (rowsEditing && this.saveEditMode) {
-      this.setCustomValidity(this.t(this.errorMessage('unsavedRowsError')), dirty);
-      return false;
+      if (!this.component.openWhenEmpty) {
+        this.setCustomValidity(this.t(this.errorMessage('unsavedRowsError')), dirty);
+        return false;
+      }
     }
 
     const message = this.invalid || this.invalidMessage(data, dirty);

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -1267,11 +1267,9 @@ export default class EditGridComponent extends NestedArrayComponent {
       }
       return false;
     }
-    else if (rowsEditing && this.saveEditMode) {
-      if (!this.component.openWhenEmpty) {
-        this.setCustomValidity(this.t(this.errorMessage('unsavedRowsError')), dirty);
-        return false;
-      }
+    else if (rowsEditing && this.saveEditMode && !this.component.openWhenEmpty) {
+      this.setCustomValidity(this.t(this.errorMessage('unsavedRowsError')), dirty);
+      return false;
     }
 
     const message = this.invalid || this.invalidMessage(data, dirty);

--- a/src/components/editgrid/EditGrid.unit.js
+++ b/src/components/editgrid/EditGrid.unit.js
@@ -23,6 +23,7 @@ import {
 } from './fixtures';
 
 import ModalEditGrid from '../../../test/forms/modalEditGrid';
+import EditGridOpenWhenEmpty from '../../../test/forms/editGridOpenWhenEmpty';
 import Webform from '../../Webform';
 import { displayAsModalEditGrid } from '../../../test/formtest';
 import { Formio } from '../../Formio';
@@ -1381,5 +1382,47 @@ describe('EditGrid Open when Empty', () => {
         }, 200);
       })
       .catch(done);
+  });
+
+  it('Should submit form with empty rows when submit button is pressed and no rows are saved', (done) => {
+    const formElement = document.createElement('div');
+    const form = new Webform(formElement);
+
+    form.setForm(compOpenWhenEmpty).then(() => {
+      const editGrid = form.components[0];
+
+      setTimeout(() => {
+        Harness.dispatchEvent('click', form.element, '[name="data[submit]"]');
+          setTimeout(() => {
+            const editRow = editGrid.editRows[0];
+            assert(!editGrid.error, 'Should be no errors on EditGrid');
+            assert.equal(editRow.errors, null, 'Should not be any errors on open row');
+            assert.equal(form.submission.state, 'submitted', 'Form should be submitted');
+            done();
+          }, 450);
+      }, 100);
+    }).catch(done);
+  });
+
+  it('Should not submit form if any row inputs are set as required', (done) => {
+    const formElement = document.createElement('div');
+    const form = new Webform(formElement);
+
+    form.setForm(EditGridOpenWhenEmpty).then(() => {
+      const editGrid = form.components[0];
+
+      setTimeout(() => {
+        Harness.dispatchEvent('click', form.element, '[name="data[submit]"]');
+          setTimeout(() => {
+            assert(!form.submission.state, 'Form should not be submitted');
+            const editRow = editGrid.editRows[0];
+            assert(editGrid.error, 'Should show error on EditGrid');
+            assert.equal(editRow.errors.length, 1, 'Should show error on row');
+            const textField = editRow.components[0];
+            assert(textField.element.className.includes('formio-error-wrapper'), 'Should add error class to component');
+            done();
+          }, 450);
+      }, 100);
+    }).catch(done);
   });
 });

--- a/test/forms/editGridOpenWhenEmpty.js
+++ b/test/forms/editGridOpenWhenEmpty.js
@@ -1,0 +1,67 @@
+export default {
+    _id: '65b119c4414257179284c2b4',
+    type: 'form',
+    tags: [],
+    owner: '5e05a6b7549cdc2ece30c6b0',
+    components: [
+    {
+        label: 'Edit Grid',
+        openWhenEmpty: true,
+        tableView: false,
+        rowDrafts: false,
+        key: 'editGrid',
+        type: 'editgrid',
+        input: true,
+        components: [
+            {
+                label: 'Text Field',
+                applyMaskOn: 'change',
+                tableView: true,
+                validate: { required: true },
+                key: 'textField',
+                type: 'textfield',
+                input: true
+            },
+            {
+                label: 'Text Area',
+                applyMaskOn: 'change',
+                autoExpand: false,
+                tableView: true,
+                key: 'textArea',
+                type: 'textarea',
+                input: true
+            }
+        ]
+    },
+    {
+        type: 'button',
+        label: 'Submit',
+        key: 'submit',
+        input: true,
+        tableView: false,
+        showValidations: false,
+    }
+    ],
+    controller: '',
+    revisions: '',
+    _vid: 0,
+    title: 'Edit Grid',
+    display: 'form',
+    access: [
+        {
+            roles: [
+            '5e96e79ee1c3ad3178454100',
+            '5e96e79ee1c3ad3178454101',
+            '5e96e79ee1c3ad3178454102'
+            ],
+            type: 'read_all'
+        }
+    ],
+    submissionAccess: [],
+    settings: {},
+    properties: {},
+    name: 'editGrid',
+    path: 'editgrid',
+};
+  
+  


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7603

## Description

Added check for openWhenEmpty on submission to allow empty rows.

**Why have you chosen this solution?**

Previous code did not allow form submission on empty rows even when openWhenEmpty flag is enabled.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Tested manually and with unit tests.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
