### PR TITLE
FIO 7733: move polyfill to conditional lazy import

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,13 +2,13 @@
   "parser": "@typescript-eslint/parser",
   "extends": "formio",
   "parserOptions": {
-    "ecmaVersion": 2015,
+    "ecmaVersion": 2020,
     "sourceType": "module"
   },
   "plugins": ["@typescript-eslint"],
   "env": {
     "browser": true,
-    "es6": true,
+    "es2020": true,
     "node": true,
     "mocha": true
   },

--- a/src/providers/storage/s3.js
+++ b/src/providers/storage/s3.js
@@ -1,7 +1,12 @@
 import XHR from './xhr';
 import { withRetries } from './util';
 
-const AbortController = window.AbortController || require('abortcontroller-polyfill/dist/cjs-ponyfill');
+const loadAbortControllerPolyfill = async() => {
+  if (typeof AbortController === 'undefined') {
+    await import('abortcontroller-polyfill/dist/polyfill-patch-fetch');
+  }
+};
+
 function s3(formio) {
   return {
     async uploadFile(file, fileName, dir, progressCallback, url, options, fileKey, groupPermissions, groupId, abortCallback, multipartOptions) {
@@ -11,6 +16,7 @@ function s3(formio) {
         if (response.signed) {
           if (multipartOptions && Array.isArray(response.signed)) {
             // patch abort callback
+            await loadAbortControllerPolyfill();
             const abortController = new AbortController();
             const abortSignal = abortController.signal;
             if (typeof abortCallback === 'function') {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7733

## Description

Next.js, the [now de-facto standard React framework](https://react.dev/learn/start-a-new-react-project#nextjs-pages-router), incorporates both a server-side rendering phase along with a client-side rendering phase. This requires dependencies to be relatively isomorphic, or at least to account for globals like `window` possibly not being present in the runtime environment. 

This PR makes such a change by conditionally importing the AbortController polyfill only when it's needed and only if the browser runtime does not support it.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Existing tests around multi-part upload (where AbortController appears) continue to pass

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
