### PR TITLE
FIO-7675: Remove maps key from repo

### DIFF
--- a/src/components/address/fixtures/comp3.js
+++ b/src/components/address/fixtures/comp3.js
@@ -12,7 +12,7 @@ export default {
       providerOptions: {
         params: {
           autocompleteOptions: {},
-          key: 'AIzaSyBNL2e4MnmyPj9zN7SVAe428nCSLP1X144',
+          key: '',
         },
       },
       input: true,

--- a/src/components/datagrid/fixtures/comp6.js
+++ b/src/components/datagrid/fixtures/comp6.js
@@ -138,7 +138,7 @@ export default {
           providerOptions: {
             params: {
               autocompleteOptions: {},
-              key: 'AIzaSyBNL2e4MnmyPj9zN7SVAe428nCSLP1X144',
+              key: '',
             },
           },
           input: true,

--- a/test/formtest/settingErrors.json
+++ b/test/formtest/settingErrors.json
@@ -1420,7 +1420,7 @@
               "description": "",
               "map": {
                 "region": "",
-                "key": "AIzaSyBNL2e4MnmyPj9zN7SVAe428nCSLP1X144"
+                "key": ""
               },
               "tooltip": "",
               "customClass": "",


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7675

## Description

**What changed?**

Previously formio.js had a hardcoded api key set in a few places. Removed them due to it being a public repository.

**Why have you chosen this solution?**

No other criteria were stated on the ticket and clear that they should not be in a public repo.

## Dependencies

n/a

## How has this PR been tested?

Ran tests locally
![image](https://github.com/formio/formio.js/assets/112976114/8476f49c-ccd6-49e6-9dab-3e938a314c27)

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
