### PR TITLE
FIO-8040: use core utils for evaluation instead of local ones

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -16,7 +16,7 @@ const { fetch } = fetchPonyfill({
   Promise: Promise
 });
 
-export * from Utils;
+export * from '@formio/core/lib/utils/formUtil';
 
 // Configure JsonLogic
 lodashOperators.forEach((name) => jsonLogic.add_operation(`_${name}`, _[name]));

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -8,6 +8,7 @@ import jtz from 'jstimezonedetect';
 import { lodashOperators } from './jsonlogic/operators';
 import dompurify from 'dompurify';
 import { getValue } from './formUtils';
+import { Utils } from '@formio/core';
 import Evaluator from './Evaluator';
 import ConditionOperators from './conditionOperators';
 const interpolate = Evaluator.interpolate;
@@ -15,7 +16,7 @@ const { fetch } = fetchPonyfill({
   Promise: Promise
 });
 
-export * from './formUtils';
+export * from Utils;
 
 // Configure JsonLogic
 lodashOperators.forEach((name) => jsonLogic.add_operation(`_${name}`, _[name]));


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8040

## Description

Previously, formio.js was using its own util function set for evalutions context. Now it's usng core functions.

## Dependencies

https://github.com/formio/core/pull/54

## How has this PR been tested?

manually

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
