### PR TITLE
FIO-7334: Fixes an issue where Radio values do not appear for Action Conditions settings

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -48,6 +48,23 @@ export default class RadioComponent extends ListComponent {
     };
   }
 
+  static get serverConditionSettings() {
+    return {
+      ...super.serverConditionSettings,
+      valueComponent(classComp) {
+        return {
+          type: 'select',
+          dataSrc: 'custom',
+          valueProperty: 'value',
+          dataType: classComp.dataType || '',
+          data: {
+            custom: `values = ${classComp && classComp.values ? JSON.stringify(classComp.values) : []}`,
+          },
+        };
+      },
+    };
+  }
+
   static savedValueTypes(schema) {
     const { boolean, string, number, object, array } = componentValueTypes;
     const { dataType } = schema;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7334

## Description

The static method providing Value Component for each component of the form was not implmented for the Radio omponent

**Why have you chosen this solution?**

*Although there were many potential solutions such as ..., [my solution] was best because ...*

## Dependencies

*This PR depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

*I added automated tests to cover [all/the following] cases, including ...*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
