### PR TITLE
FIO-8109 fixed save draft triggering for nested components

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -794,12 +794,13 @@ export default class Webform extends NestedDataComponent {
    * @param {userId} - The user id where we need to restore the draft from.
    */
   restoreDraft(userId) {
-    if (!this.formio) {
+    const formio = this.formio || this.options.formio;
+    if (!formio) {
       this.handleDraftError('restoreDraftInstanceError', null, true);
       return;
     }
     this.savingDraft = true;
-    this.formio.loadSubmissions({
+    formio.loadSubmissions({
       params: {
         state: 'draft',
         owner: userId

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -164,6 +164,7 @@ export default class FormComponent extends Component {
     }
   }
 
+  /* eslint-disable max-statements */
   getSubOptions(options = {}) {
     options.parentPath = `${this.path}.data.`;
     options.events = this.createEmitter();
@@ -221,12 +222,14 @@ export default class FormComponent extends Component {
     }
     if (this.options.saveDraft) {
       options.saveDraft = this.options.saveDraft;
+      options.formio = new Formio(this.formSrc);
     }
     if (this.options.saveDraftThrottle) {
       options.saveDraftThrottle = this.options.saveDraftThrottle;
     }
     return options;
   }
+  /* eslint-enable max-statements */
 
   render() {
     if (this.builderMode) {
@@ -453,10 +456,6 @@ export default class FormComponent extends Component {
         this.subForm.nosubmit = true;
         this.subForm.root = this.root;
         this.subForm.localRoot = this.isNestedWizard ? this.localRoot : this.subForm;
-        if (this.parent) {
-          this.subForm.draftEnabled = this.parent.draftEnabled;
-          this.subForm.savingDraft = this.parent.savingDraft;
-        }
         this.restoreValue();
         this.valueChanged = this.hasSetValue;
         this.onChange();


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8109

## Description

*Previously, the Save Draft was not triggered for Nested Form components unless the additional properties form.draftEnabled and form.savingDraft were set. This has been fixed. Now Save Draft is triggered without form.draftEnabled and form.savingDraft for Nested forms*

## Dependencies

*no.*

## How has this PR been tested?

*Manually with using jsFiddle.*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
