### PR TITLE
FIO-3703: Fixes an issue where NestedData components with modal view do not render values inside Layout components in modal preview table

### DIFF
--- a/src/components/_classes/nestedarray/NestedArrayComponent.js
+++ b/src/components/_classes/nestedarray/NestedArrayComponent.js
@@ -207,7 +207,7 @@ export default class NestedArrayComponent extends NestedDataComponent {
   }
 
   getComponents(rowIndex) {
-    if (rowIndex !== undefined) {
+    if (rowIndex !== undefined && rowIndex !== null) {
       if (!this.iteratableRows[rowIndex]) {
         return [];
       }

--- a/src/components/_classes/nesteddata/NestedDataComponent.js
+++ b/src/components/_classes/nesteddata/NestedDataComponent.js
@@ -80,7 +80,7 @@ export default class NestedDataComponent extends NestedComponent {
 
     const htmlTagRegExp = new RegExp('<(.*?)>');
 
-    this.components.forEach((component) => {
+    this.everyComponent((component) => {
       if (component.isInputComponent && component.visible && !component.skipInEmail) {
         const componentValue = component.getView(component.dataValue, options);
         result += (`

--- a/src/components/_classes/nesteddata/NestedDataComponent.unit.js
+++ b/src/components/_classes/nesteddata/NestedDataComponent.unit.js
@@ -7,7 +7,7 @@ import nestedDataCompWithModalPreview from '../../../../test/forms/nestedDataWit
 
 let component = null;
 describe('NestedDataComponent class', () => {
-  it('Should create a new NestedDataComponent class', (done) => {
+  it('Should create a new NestedDataComponent class', () => {
     return Harness.testCreate(NestedDataComponent, {
       // key: 'nested',
       components: [
@@ -28,7 +28,7 @@ describe('NestedDataComponent class', () => {
       Harness.testElements(component, 'input[name="data[lastName]"]', 1);
     });
   });
-  it('Should show preview of the modal view component properly', () => {
+  it('Should show preview of the modal view component properly', (done) => {
     Formio.createForm(document.createElement('div'), nestedDataCompWithModalPreview)
       .then((form) => {
         const openModalBtn = form.element.querySelector('.open-modal-button');

--- a/src/components/_classes/nesteddata/NestedDataComponent.unit.js
+++ b/src/components/_classes/nesteddata/NestedDataComponent.unit.js
@@ -1,10 +1,13 @@
 'use strict';
+import { Formio } from '../../../Formio';
 import NestedDataComponent from './NestedDataComponent';
 import Harness from '../../../../test/harness';
+import assert from 'power-assert';
+import nestedDataCompWithModalPreview from '../../../../test/forms/nestedDataWithModalViewAndLayoutComponents';
 
 let component = null;
 describe('NestedDataComponent class', () => {
-  it('Should create a new NestedDataComponent class', () => {
+  it('Should create a new NestedDataComponent class', (done) => {
     return Harness.testCreate(NestedDataComponent, {
       // key: 'nested',
       components: [
@@ -24,5 +27,30 @@ describe('NestedDataComponent class', () => {
       Harness.testElements(component, 'input[name="data[firstName]"]', 1);
       Harness.testElements(component, 'input[name="data[lastName]"]', 1);
     });
+  });
+  it('Should show preview of the modal view component properly', () => {
+    Formio.createForm(document.createElement('div'), nestedDataCompWithModalPreview)
+      .then((form) => {
+        const openModalBtn = form.element.querySelector('.open-modal-button');
+        const openModalBtnRows = openModalBtn.querySelectorAll('tr');
+        assert.equal(openModalBtnRows.length, 1);
+
+        const dataGrid = form.geComponent(['dataGrid']);
+        dataGrid.setValue([
+          {
+            textField: 'test'
+          },
+          {
+            textField: 'test2'
+          }
+        ]);
+
+        setTimeout(() => {
+          const modalPreviewValues = form.element.querySelector('.open-modal-button tr td input');
+          assert.equal(modalPreviewValues.length, 2);
+          assert.deepEqual(Array.prototype.map.call(modalPreviewValues, (i) => i.value), ['test', 'test2']);
+          done();
+        }, 300);
+      }).catch(done);
   });
 });

--- a/src/components/_classes/nesteddata/NestedDataComponent.unit.js
+++ b/src/components/_classes/nesteddata/NestedDataComponent.unit.js
@@ -35,7 +35,7 @@ describe('NestedDataComponent class', () => {
         const openModalBtnRows = openModalBtn.querySelectorAll('tr');
         assert.equal(openModalBtnRows.length, 1);
 
-        const dataGrid = form.geComponent(['dataGrid']);
+        const dataGrid = form.getComponent(['dataGrid']);
         dataGrid.setValue([
           {
             textField: 'test'

--- a/src/components/_classes/nesteddata/NestedDataComponent.unit.js
+++ b/src/components/_classes/nesteddata/NestedDataComponent.unit.js
@@ -46,7 +46,7 @@ describe('NestedDataComponent class', () => {
         ]);
 
         setTimeout(() => {
-          const modalPreviewValues = form.element.querySelector('.open-modal-button tr td input');
+          const modalPreviewValues = form.element.querySelectorAll('.open-modal-button tr td input');
           assert.equal(modalPreviewValues.length, 2);
           assert.deepEqual(Array.prototype.map.call(modalPreviewValues, (i) => i.value), ['test', 'test2']);
           done();

--- a/test/forms/nestedDataWithModalViewAndLayoutComponents
+++ b/test/forms/nestedDataWithModalViewAndLayoutComponents
@@ -1,0 +1,54 @@
+{
+  "name": "fio3703",
+  "path": "fio3703",
+  "type": "form",
+  "display": "form",
+  "components": [
+    {
+      "label": "Data Grid",
+      "reorder": false,
+      "addAnotherPosition": "bottom",
+      "layoutFixed": false,
+      "enableRowGroups": false,
+      "initEmpty": false,
+      "tableView": true,
+      "modalEdit": true,
+      "defaultValue": [
+        {
+          "textField": ""
+        }
+      ],
+      "key": "dataGrid",
+      "type": "datagrid",
+      "input": true,
+      "components": [
+        {
+          "collapsible": false,
+          "key": "panel",
+          "type": "panel",
+          "label": "Panel",
+          "input": false,
+          "tableView": false,
+          "components": [
+            {
+              "label": "Text Field",
+              "applyMaskOn": "change",
+              "tableView": true,
+              "key": "textField",
+              "type": "textfield",
+              "input": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "button",
+      "label": "Submit",
+      "key": "submit",
+      "disableOnInvalid": true,
+      "input": true,
+      "tableView": false
+    }
+  ],
+}

--- a/test/forms/nestedDataWithModalViewAndLayoutComponents.json
+++ b/test/forms/nestedDataWithModalViewAndLayoutComponents.json
@@ -50,5 +50,5 @@
       "input": true,
       "tableView": false
     }
-  ],
+  ]
 }


### PR DESCRIPTION

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-3703

## Description

NestedDataComponent was not iterating through layout components to render the values of the components inside them. Also, getComponents method was checking only in rowIndex is undefined, but it also could be null because inside everyComponent method it is set to null if not provided. 

## Dependencies

*This PR depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

*I added automated tests to cover [all/the following] cases, including ...*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
