### PR TITLE
Bugfix: WizardBuilder removes page when saving other component with duplicate API key

### DIFF
--- a/src/WizardBuilder.js
+++ b/src/WizardBuilder.js
@@ -71,7 +71,7 @@ export default class WizardBuilder extends WebformBuilder {
       }
       else {
         // Fallback to look for panel based on key.
-        const formComponentIndex = this._form.components.findIndex((comp) => originalComponent.key === comp.key);
+        const formComponentIndex = this._form.components.findIndex((comp) => originalComponent.id === comp.id);
         if (formComponentIndex !== -1) {
           this._form.components[formComponentIndex] = component;
           this.rebuild();

--- a/src/WizardBuilder.js
+++ b/src/WizardBuilder.js
@@ -70,7 +70,7 @@ export default class WizardBuilder extends WebformBuilder {
         this.rebuild();
       }
       else {
-        // Fallback to look for panel based on key.
+        // Fallback to look for panel based on id.
         const formComponentIndex = this._form.components.findIndex((comp) => originalComponent.id === comp.id);
         if (formComponentIndex !== -1) {
           this._form.components[formComponentIndex] = component;


### PR DESCRIPTION
## Link to Jira Ticket

N/A

## Description

How to reproduce the bug:

1. Go to formio [sandbox](https://formio.github.io/formio.js/app/sandbox.html)
2. Change form display to 'wizard'
3. Insert a new component (e.g. Text Field) in page, provide same API key as the page and save
4. Observe error 'API key is not unique'
5. Edit component, provide a unique API key and save
6. The page has now been removed (actually replaced by the component that was changed)

What is changed in this PR:

The lookup in WizardBuilder's saveComponent event handler is done based on id instead of key.

## Dependencies

N/A

## How has this PR been tested?

I added unit tests.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
