### PR TITLE
FIO-8280: Fixed setting incorrect option label

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -258,7 +258,7 @@ export default class SelectComponent extends ListComponent {
   }
 
   get selectData() {
-    return this.component.selectData || this.selectMetadata;
+    return this.selectMetadata || this.component.selectData;
   }
 
   isEntireObjectDisplay() {

--- a/src/components/select/Select.unit.js
+++ b/src/components/select/Select.unit.js
@@ -1015,6 +1015,33 @@ describe('Select Component', () => {
     }).catch(done);
   });
 
+  it('Should set correct label from metadata for ChoicesJS Select with default value', (done) => {
+    const form = _.cloneDeep(comp22);
+    form.components[0].widget='choicesjs';
+    const element = document.createElement('div');
+
+    Formio.createForm(element, form).then(form => {
+      const select = form.getComponent('select');
+      form.submission = {
+        data: {
+          select: 'value2',
+        },
+        metadata: {
+          selectData: {
+            select: {
+              label: 'Label 2',
+            },
+          },
+        },
+      };
+
+      setTimeout(()=> {
+        assert.equal(select.templateData['value2'].label, 'Label 2');
+        done();
+      }, 200);
+    }).catch(done);
+  });
+
   it('OnBlur validation should work properly with Select component', function(done) {
     this.timeout(0);
     const element = document.createElement('div');

--- a/src/components/select/fixtures/comp22.js
+++ b/src/components/select/fixtures/comp22.js
@@ -10,7 +10,7 @@ export default {
     tableView: true,
     dataSrc: 'url',
     data: {
-      url: 'https://fake_url',
+      url: 'https://fake_url.com',
       headers: [
         {
           key: '',


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8280

## Description

It was an incorrect order of resolvers to get select data, as it was trying to get selectData from select component settings in the first order, it always returns selectData from the form configuration instead of selectData from the metadata. Just fixed the order.

## How has this PR been tested?

Unit test

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
