### PR TITLE
FIO-8302 Fixed issue with wizard api key overriding window.property objects

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -37,6 +37,22 @@ function cloneResponse(response) {
 }
 
 /**
+ * Get non HTMLElement property in the window object
+ * @param {String} property
+ * @return {any || undefined}
+ */
+function getScriptPlugin(property) {
+  const obj = window[property];
+  if (
+    typeof HTMLElement === 'object' ? obj instanceof HTMLElement : //DOM2
+      obj && typeof obj === 'object' && true && obj.nodeType === 1 && typeof obj.nodeName === 'string'
+  ) {
+    return undefined;
+  }
+  return obj;
+}
+
+/**
  * The Formio interface class.
  *
  *   let formio = new Formio('https://examples.form.io/example');
@@ -1528,7 +1544,7 @@ class Formio {
       }
 
       // See if the plugin already exists.
-      const plugin = _get(window, property);
+      const plugin = getScriptPlugin(property);
       if (plugin) {
         Formio.libraries[name].resolve(plugin);
       }
@@ -1587,7 +1603,7 @@ class Formio {
         // if no callback is provided, then check periodically for the script.
         if (polling) {
           const interval = setInterval(() => {
-            const plugin = _get(window, property);
+            const plugin = getScriptPlugin(property);
             if (plugin) {
               clearInterval(interval);
               Formio.libraries[name].resolve(plugin);

--- a/src/templates/bootstrap/builderWizard/form.ejs
+++ b/src/templates/bootstrap/builderWizard/form.ejs
@@ -5,7 +5,7 @@
   <div class="col-xs-8 col-sm-9 col-md-10 formarea">
     <ol class="breadcrumb wizard-pages">
         {% ctx.pages.forEach(function(page, pageIndex) { %}
-          <li id="{{page.key}}">
+          <li>
             <span title="{{page.title}}" class="mr-2 badge {% if (pageIndex === ctx.self.page) { %}badge-primary{% } else { %}badge-info{% } %} wizard-page-label" ref="gotoPage">{{page.title}}</span>
           </li>
         {% }) %}


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8302

## Description

The requireLibrary function in Formio.js now ignores any properties in the window object that are the type HTMLElement. Previously the window.property was unexpectedly being set by HTMLElements with an id attribute. This caused requireLibrary to pull in the HTMLElement instead of the expected object from <script src='...'>. A function was added to only get a window.property if it is not of the type HTMLElement and the id in &lt;li> was removed as well

## Dependencies

## How has this PR been tested?

Manual testing

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
