### PR TITLE
FIO-8302 Fixed issue with wizard api key overriding window.property objects 

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -8,7 +8,7 @@ import { processOne, processOneSync, validateProcessInfo } from '@formio/core/pr
 import { Formio } from '../../../Formio';
 import * as FormioUtils from '../../../utils/utils';
 import {
-  fastCloneDeep, boolValue, getComponentPath, isInsideScopingComponent, currentTimezone
+  fastCloneDeep, boolValue, getComponentPath, isInsideScopingComponent, currentTimezone, getScriptPlugin
 } from '../../../utils/utils';
 import Element from '../../../Element';
 import ComponentModal from '../componentModal/ComponentModal';
@@ -3750,7 +3750,7 @@ Component.requireLibrary = function(name, property, src, polling) {
       }.bind(Component.externalLibraries[name]);
     }
     // See if the plugin already exists.
-    const plugin = _.get(window, property);
+    const plugin = getScriptPlugin(property)
     if (plugin) {
       Component.externalLibraries[name].resolve(plugin);
     }
@@ -3795,7 +3795,7 @@ Component.requireLibrary = function(name, property, src, polling) {
       // if no callback is provided, then check periodically for the script.
       if (polling) {
         setTimeout(function checkLibrary() {
-          const plugin = _.get(window, property);
+          const plugin = getScriptPlugin(property)
           if (plugin) {
             Component.externalLibraries[name].resolve(plugin);
           }

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -3750,7 +3750,7 @@ Component.requireLibrary = function(name, property, src, polling) {
       }.bind(Component.externalLibraries[name]);
     }
     // See if the plugin already exists.
-    const plugin = getScriptPlugin(property)
+    const plugin = getScriptPlugin(property);
     if (plugin) {
       Component.externalLibraries[name].resolve(plugin);
     }
@@ -3795,7 +3795,7 @@ Component.requireLibrary = function(name, property, src, polling) {
       // if no callback is provided, then check periodically for the script.
       if (polling) {
         setTimeout(function checkLibrary() {
-          const plugin = getScriptPlugin(property)
+          const plugin = getScriptPlugin(property);
           if (plugin) {
             Component.externalLibraries[name].resolve(plugin);
           }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -151,6 +151,22 @@ export function getElementRect(element) {
 }
 
 /**
+ * Get non HTMLElement property in the window object
+ * @param {String} property
+ * @return {any || undefined}
+ */
+export function getScriptPlugin(property) {
+  const obj = window[property];
+  if (
+    typeof HTMLElement === 'object' ? obj instanceof HTMLElement : //DOM2
+      obj && typeof obj === 'object' && true && obj.nodeType === 1 && typeof obj.nodeName === 'string'
+  ) {
+    return undefined;
+  }
+  return obj;
+}
+
+/**
  * Determines the boolean value of a setting.
  *
  * @param value


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8302

## Description

The requireLibrary function in Formio.js now ignores any properties in the window object that are the type HTMLElement. Previously the window.property was unexpectedly being set by HTMLElements with an id attribute. This caused requireLibrary to pull in the HTMLElement instead of the expected object from <script src='...'>. A function was added to only get a window.property if it is not of the type HTMLElement

## Dependencies

## How has this PR been tested?

Manual testing

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
