### PR TITLE
FIO-8330 fixed saving draft if saveDraft and skipDraftRestore are true

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -303,12 +303,19 @@ export default class Webform extends NestedDataComponent {
     this.language = this.i18next.language;
 
     // See if we need to restore the draft from a user.
-    if (this.options.saveDraft && !this.options.skipDraftRestore) {
+    if (this.options.saveDraft) {
       this.formReady.then(()=> {
-        const user = Formio.getUser();
-        // Only restore a draft if the submission isn't explicitly set.
-        if (user && !this.submissionSet) {
-          this.restoreDraft(user._id);
+        if (!this.options.skipDraftRestore) {
+          const user = Formio.getUser();
+          // Only restore a draft if the submission isn't explicitly set.
+          if (user && !this.submissionSet) {
+            this.restoreDraft(user._id);
+          }
+        }
+        else {
+          // Enable drafts
+          this.draftEnabled = true;
+          this.savingDraft = false;
         }
       });
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8330

## Description

*Fixed saving drafts when changing the form if saveDraft and skipDraftRestore are set as true*

## Dependencies

*no*

## How has this PR been tested?

*automated tests have been added*

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
