### PR TITLE
FIO-8326: Recaptcha now requires type of event to be selected

### DIFF
--- a/src/components/recaptcha/editForm/ReCaptcha.edit.display.js
+++ b/src/components/recaptcha/editForm/ReCaptcha.edit.display.js
@@ -15,6 +15,9 @@ export default [
         value: 'buttonClick'
       }
     ],
+    validate: {
+      required: true
+    },
     weight: 650
   },
   {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8326

## Description

**What changed?**

Changed recaptcha to require the **type of event** radio button to be selected in its edit form. This change was made because if you submit a form without selecting one of the radio buttons then the form will throw a **token is not specified in submission** error
 
## Dependencies

N/A

## How has this PR been tested?

Manually tested using formio.js form builder

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
