### PR TITLE
FIO-8240 fixed skipDraftRestore effect for the nested Forms

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -230,6 +230,9 @@ export default class FormComponent extends Component {
     if (this.options.saveDraftThrottle) {
       options.saveDraftThrottle = this.options.saveDraftThrottle;
     }
+    if (this.options.skipDraftRestore) {
+      options.skipDraftRestore = this.options.skipDraftRestore;
+    }
     return options;
   }
   /* eslint-enable max-statements */

--- a/src/components/form/fixtures/comp7.js
+++ b/src/components/form/fixtures/comp7.js
@@ -1,0 +1,35 @@
+export default {
+  _id: '66051dae494c977c47028fac',
+  title: 'test draft parent',
+  name: 'testDraftParent',
+  path: 'testdraftparent',
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      label: 'Parent Form Field',
+      tableView: true,
+      key: 'parent',
+      type: 'textfield',
+      input: true,
+    },
+    {
+      label: 'Form',
+      tableView: true,
+      src: 'http://localhost:3000/idwqwhclwioyqbw/testdraftnested',
+      key: 'form',
+      type: 'form',
+      input: true,
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  project: '63cead09be0090345b109e22',
+  machineName: 'idwqwhclwioyqbw:testdraftparent'
+};

--- a/src/components/form/fixtures/comp8.js
+++ b/src/components/form/fixtures/comp8.js
@@ -1,0 +1,27 @@
+export default {
+  _id: '63e4deda12b88c4f05c125cf',
+  title: 'test draft nested',
+  name: 'testDraftNested',
+  path: 'testdraftnested',
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      label: 'Nested Form Field',
+      tableView: true,
+      key: 'nested',
+      type: 'textfield',
+      input: true,
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  project: '63cead09be0090345b109e22',
+  machineName: 'idwqwhclwioyqbw:testdraftparent'
+};

--- a/src/components/form/fixtures/index.js
+++ b/src/components/form/fixtures/index.js
@@ -5,5 +5,7 @@ import comp3 from './comp3';
 import comp4 from './comp4';
 import comp5 from './comp5';
 import comp6 from './comp6';
-export { formModalEdit, comp1, comp2, comp3, comp4, comp5, comp6 };
+import comp7 from './comp7';
+import comp8 from './comp8';
+export { formModalEdit, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8 };
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8240

## Description

*Fixed restore data for nested form if skipDraftRestore is set as true for the parent form *

## Dependencies

*no*

## How has this PR been tested?

*automated tests have been added*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
