### PR TITLE
FIO-8359: Event No Longer Emitted on Submit

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1368,6 +1368,7 @@ export default class Webform extends NestedDataComponent {
     }
 
     const errors = this.showErrors(error, true);
+
     if (this.root && this.root.alert) {
       this.scrollIntoView(this.root.alert);
     }

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1367,13 +1367,7 @@ export default class Webform extends NestedDataComponent {
       return false;
     }
 
-    let errors;
-    if (this.submitted) {
-      errors = this.showErrors();
-    }
-    else {
-      errors = this.showErrors(error, true);
-    }
+    const errors = this.showErrors(error, true);
     if (this.root && this.root.alert) {
       this.scrollIntoView(this.root.alert);
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8359

## Description

**What changed?**

Previously formio.js was not emitting the error event on form submit.

**Why have you chosen this solution?**

Resolve error event emit

## Dependencies

n/a

## How has this PR been tested?

```
1. Check out 4.19.x branch in `formio.js`
2. yarn install && yarn build
3. change into the dist directory.
4. Use a simple http server to host files as if they were a local cdn `http-server -p 4003 --cors`
5. Set up a simple playground that listens for an error event to be emitted. (SEE ATTACHMENTS cdn.zip on this ticket)
6. Unzip cdn.zip and npm install && npm start
7. Submit form and view console.log statements.

Expected should see "Hello, World!" in console because the error event was emitted triggering this log message.

Actual result, do not see the message printed to console. Reverting line 1343 on https://github.com/formio/formio.js/pull/5101/files resolves this issue.
```

![image](https://github.com/formio/formio.js/assets/112976114/63172287-3653-4a2d-ba93-73ba7da8305e)


## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
