### PR TITLE
FIO-1217  fix shadowRoot for CalendarWidget

### DIFF
--- a/src/Element.js
+++ b/src/Element.js
@@ -406,7 +406,7 @@ export default class Element {
           inputElement: input,
           mask,
           placeholderChar: this.placeholderChar,
-          shadowRoot: this.root ? this.root.shadowRoot : null
+          shadowRoot: this.root?.shadowRoot || this?.options.shadowRoot || null
         });
       }
       catch (e) {


### PR DESCRIPTION
To fix an issue where calendar widget's masked date caret position is wrong on shadowDOM

CalendarWidget extends Element and uses setInputMask. setInputMask needs shadowRoot for text-mask to work properly. formio/formio.js#3693 previous fixed the text-mask for other inputs, but the fix does not appear to work for the CalendarWidget because it does not have a (WebForm) root.

Relates to https://github.com/text-mask/text-mask/pull/1034/files

https://formio.atlassian.net/browse/FIO-1217