### PR TITLE
FIO-7733 remove form min height

### DIFF
--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -4,7 +4,6 @@ $autocomplete-in-dialog-z-index: $dialog-z-index + 1000;
 
 .formio-form {
   position: relative;
-  min-height: 80px;
 }
 
 .formio-error-wrapper,


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7733

## Description

Removes a 7 year old `min-heigh` CSS rule from forms.

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
