### PR TITLE
FIO-8402: fixed an issue where Validation Triggering on initial Form load

### DIFF
--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -2297,6 +2297,46 @@ describe('Webform tests', function() {
     });
   });
 
+  it('Should not fire validation on calculated values init.', (done) => {
+    formElement.innerHTML = '';
+    const form = new Webform(formElement,{ language: 'en' });
+    form.setForm(
+      { title: 'noValidation flag',
+        components: [{
+          label: 'minMax',
+          calculateValue: 'value = {minAmount: \'5.00\', maxAmount: \'50000.00\'};',
+          calculateServer: true,
+          key: 'minMax',
+          type: 'hidden',
+          input: true
+        }, {
+          label: 'A',
+          key: 'a',
+          type: 'number',
+          input: true
+        }, {
+          label: 'B',
+          key: 'b',
+          type: 'number',
+          input: true
+        }, {
+          label: 'Sum',
+          validate: {
+            required: true,
+            min: 10
+          },
+          calculateValue: 'var total = _.isNumber(data.a) ? data.a : 0;\ntotal += _.isNumber(data.b) ? data.b : 0;\n\nvalue = parseFloat(total.toFixed(2));',
+          calculateServer: true,
+          key: 'sum',
+          type: 'number',
+          input: true
+        }],
+      }
+    ).then(() => {
+      checkForErrors(form, {}, { data: {} }, 0, done);
+    });
+  });
+
   it('Should set calculated value correctly', (done) => {
     formElement.innerHTML = '';
     const form = new Webform(formElement);

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2975,7 +2975,7 @@ export default class Component extends Element {
     this.calculatedValue = fastCloneDeep(calculatedValue);
 
     if (changed) {
-      if (!flags.noPristineChangeOnModified) {
+      if (!flags.noPristineChangeOnModified && this.root.initialized) {
         this.pristine = false;
       }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8402

## Description

**What changed?**

The issue was caused by calculated values, form load use onChange method that performs calculation and set pristine flag to false even if form wasn't initialized and user hasn't made any changes. Choose adding check for form initialization. 

## Dependencies

n/a

## How has this PR been tested?

Tested manually, all unit/integration tests pass locally

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above