### PR TITLE
FIO-8395: html in error message not evaluating

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2156,9 +2156,6 @@ export default class Component extends Element {
 
     if (this.refs.messageContainer) {
       this.setContent(this.refs.messageContainer, messages.map((message) => {
-        if (message.message && typeof message.message === 'string') {
-          message.message = message.message.replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-        }
         return this.renderTemplate('message', { ...message });
       }
       ).join(''));

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -3,7 +3,7 @@ import { Formio } from '../../Formio';
 import ListComponent from '../_classes/list/ListComponent';
 import Input from '../_classes/input/Input';
 import Form from '../../Form';
-import { getRandomComponentId, boolValue, isPromise, componentValueTypes, getComponentSavedTypes, unescapeHTML, isSelectResourceWithObjectValue } from '../../utils/utils';
+import { getRandomComponentId, boolValue, isPromise, componentValueTypes, getComponentSavedTypes, unescapeHTML, isSelectResourceWithObjectValue, removeHTML } from '../../utils/utils';
 
 import Choices from '../../utils/ChoicesWrapper';
 
@@ -1820,7 +1820,7 @@ export default class SelectComponent extends ListComponent {
     const getTemplateValue = (v) => {
       const itemTemplate = this.itemTemplate(v);
       return options.csv && itemTemplate
-        ? unescapeHTML(itemTemplate)
+        ? removeHTML(itemTemplate)
         : itemTemplate;
     };
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -457,9 +457,9 @@ export function unescapeHTML(str) {
   if (typeof window === 'undefined' || !('DOMParser' in window)) {
     return str;
   }
-
-  const doc = new window.DOMParser().parseFromString(str, 'text/html');
-  return doc.documentElement.textContent;
+  const elem = document.createElement('textarea');
+  elem.innerHTML = str;
+  return elem.value;
 }
 
 /**

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -449,6 +449,16 @@ export function setActionProperty(component, action, result, row, data, instance
 }
 
 /**
+ * Removes HTML tags from string e.g. <div>Hello World</div> => Hello World
+ * @param {string} str
+ * @returns {string}
+ */
+export function removeHTML(str) {
+  const doc = new window.DOMParser().parseFromString(str, 'text/html');
+  return (doc.body.textContent || '').trim();
+}
+
+/**
  * Unescape HTML characters like &lt, &gt, &amp and etc.
  * @param str
  * @returns {string}

--- a/src/utils/utils.unit.js
+++ b/src/utils/utils.unit.js
@@ -820,8 +820,15 @@ describe('Util Tests', () => {
         done(error);
       }
     });
+  });
 
-    it('Should return string without HTML characters', () => {
+  describe('unescapeHTML', () => {
+    it('should not remove html tags from string', () => {
+      const unescapedString = utils.unescapeHTML('<div><p>This is a paragraph.</p> <p>This is another paragraph.</p></div>');
+      expect(unescapedString).to.equal('<div><p>This is a paragraph.</p> <p>This is another paragraph.</p></div>');
+    });
+
+    it('should return string without HTML characters', () => {
       const unescapedString = utils.unescapeHTML('&lt;p&gt;ampersand &amp; &#34;quotes&#34; test&lt;&#47;p&gt;');
       expect(unescapedString).to.equal('<p>ampersand & "quotes" test</p>');
     });

--- a/src/utils/utils.unit.js
+++ b/src/utils/utils.unit.js
@@ -834,6 +834,13 @@ describe('Util Tests', () => {
     });
   });
 
+  describe('removeHTML', () => {
+    it('should remove html tags from string', () => {
+      const removedHTML = utils.removeHTML('<div><p> Hello</p> <p>World</p></div>');
+      expect(removedHTML).to.equal('Hello World');
+    });
+  });
+
   describe('getCurrencyAffixes', () => {
     it('USD en', (done) => {
       try {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8395

## Description

**What changed?**

Previously, formio.js would remove the html tags from error messages. This PR replaces this behavior by removing the code that causes the removal of the html tags. This PR also updates the unescapeHTML function in utils to stop removing the html tags from the string. This PR also adds a new removeHTML function that removes html from a string. I added this to replace areas of the code that used unescapeHTML because the actual functionality that is needed is to remove html not unescape characters.

**Why have you chosen this solution?**

I choose this solution because it allows for other areas of the code to now utilize unescapeHTML without the unexpected behavior of removing html tags.

## Dependencies

N/A

## How has this PR been tested?

Manually tested and added tests

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
