### PR TITLE
FIO-7206: Fixes an issue where API keys of the removed components are…

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1132,7 +1132,12 @@ export default class WebformBuilder extends Component {
         parent.formioComponent.removeChildComponent(component);
       }
       if (component.input && componentInstance && componentInstance.parent) {
-        _.unset(componentInstance._data, componentInstance.key);
+        if (Array.isArray(parent.formioComponent.component.defaultValue)) {
+          parent.formioComponent.component.defaultValue.forEach(v => _.unset(v, componentInstance.key));
+        }
+        else if (typeof parent.formioComponent.component.defaultValue === 'object') {
+          _.unset(parent.formioComponent.component.defaultValue, componentInstance.key);
+        }
       }
       const rebuild = parent.formioComponent.rebuild() || Promise.resolve();
       rebuild.then(() => {

--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1131,12 +1131,13 @@ export default class WebformBuilder extends Component {
       else if (parent.formioComponent && parent.formioComponent.removeChildComponent) {
         parent.formioComponent.removeChildComponent(component);
       }
-      if (component.input && componentInstance && componentInstance.parent) {
-        if (Array.isArray(parent.formioComponent.component.defaultValue)) {
-          parent.formioComponent.component.defaultValue.forEach(v => _.unset(v, componentInstance.key));
+      if (component.input && componentInstance && parent.formioComponent) {
+        const parentDefaultValue = _.get(parent.formioComponent, 'component.defaultValue', null);
+        if (Array.isArray(parentDefaultValue)) {
+          parentDefaultValue.forEach(v => _.unset(v, componentInstance.key));
         }
-        else if (typeof parent.formioComponent.component.defaultValue === 'object') {
-          _.unset(parent.formioComponent.component.defaultValue, componentInstance.key);
+        else if (typeof parentDefaultValue === 'object') {
+          _.unset(parentDefaultValue, componentInstance.key);
         }
       }
       const rebuild = parent.formioComponent.rebuild() || Promise.resolve();

--- a/src/WebformBuilder.unit.js
+++ b/src/WebformBuilder.unit.js
@@ -257,40 +257,53 @@ describe('WebformBuilder tests', function() {
 
   it('Should remove deleted components keys from default value', (done) => {
     const builder = Harness.getBuilder();
-    builder.setForm({}).then(() => {
-      Harness.buildComponent('datagrid');
+    builder.setForm({
+      display: 'form',
+      type: 'form',
+      components: [
+        {
+          label: 'Data Grid',
+          reorder: false,
+          addAnotherPosition: 'bottom',
+          layoutFixed: false,
+          enableRowGroups: false,
+          initEmpty: false,
+          tableView: false,
+          defaultValue: [
+            {
+              textField: '',
+            },
+          ],
+          validateWhenHidden: false,
+          key: 'dataGrid',
+          type: 'datagrid',
+          input: true,
+          components: [
+            {
+              label: 'Text Field',
+              applyMaskOn: 'change',
+              tableView: true,
+              validateWhenHidden: false,
+              key: 'textField',
+              type: 'textfield',
+              input: true,
+            },
+          ],
+        },
+      ],
+    }).then(() => {
+      const textField = builder.webform.getComponent(['dataGrid', 'textField'])[0];
+      textField.refs.removeComponent.dispatchEvent( new MouseEvent('click', {
+        view: window,
+        bubbles: true,
+        cancelable: true
+      }));
 
       setTimeout(() => {
-        const dataGridDefaultValue = builder.editForm.getComponent('defaultValue');
-        dataGridDefaultValue.removeRow(0);
-
-        setTimeout(() => {
-          Harness.saveComponent();
-          setTimeout(() => {
-            const dataGridContainer = builder.webform.element.querySelector('[ref="dataGrid-container"]');
-            Harness.buildComponent('textfield', dataGridContainer);
-
-            setTimeout(() => {
-              Harness.saveComponent();
-
-              setTimeout(() => {
-                const textField = builder.webform.getComponent(['dataGrid', 'textField'])[0];
-                textField.refs.removeComponent.dispatchEvent( new MouseEvent('click', {
-                  view: window,
-                  bubbles: true,
-                  cancelable: true
-                }));
-
-                setTimeout(() => {
-                  const dataGrid = builder.webform.getComponent(['dataGrid']);
-                  assert.deepEqual(dataGrid.schema.defaultValue, [{}], 'Should remove TextField key');
-                  done();
-                }, 300);
-              });
-            }, 300);
-          }, 300);
-        }, 350);
-      }, 350);
+        const dataGrid = builder.webform.getComponent(['dataGrid']);
+        assert.deepEqual(dataGrid.schema.defaultValue, [{}], 'Should remove TextField key');
+        done();
+      }, 300);
     }).catch(done);
   });
 });


### PR DESCRIPTION
## Link to Jira Ticket
https://formio.atlassian.net/browse/FIO-7206

## Description

In some cases when Data Grid has a defaultValue with nested components' API keys inside, thoe keys were not removed after removing the child components. 

## Dependencies

*This PR depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

*I added automated tests to cover [all/the following] cases, including ...*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
