### PR TITLE
Remove *zoom (IE7 hack)

### DIFF
--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -700,10 +700,6 @@ body.formio-dialog-open {
   justify-content: flex-end;
 }
 
-.formio-dialog.formio-dialog-theme-default .formio-dialog-buttons {
-  *zoom: 1;
-}
-
 .formio-dialog.formio-dialog-theme-default .formio-dialog-buttons:after {
   content: '';
   display: table;


### PR DESCRIPTION
Currently this file includes invalid CSS which fails to parse on some of the modern tooling like lightningcss.dev.

Since IE7 is severely outdated I don't think this property is needed nowadays, given that even IE11 is fully deprecated.

Details on the Next.js repo: https://github.com/vercel/next.js/issues/66394

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-XXXX

## Description

**What changed?**

*Previously, formio.js ... This PR replaces this behavior by ...*

**Why have you chosen this solution?**

*Although there were many potential solutions such as ..., [my solution] was best because ...*

## Dependencies

*This PR depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

*I added automated tests to cover [all/the following] cases, including ...*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
