### PR TITLE
FIO-8420: file component no defaults causes error

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -744,8 +744,7 @@ export default class FileComponent extends Field {
     const fileWithSameNameUploading = this.filesToSync.filesToUpload
       .some(fileToSync => fileToSync.file?.name === file.name);
 
-    const fileWithSameNameUploaded = this.dataValue && this.dataValue
-      .some(fileStatus => fileStatus.originalName === file.name);
+    const fileWithSameNameUploaded = _.some(this.dataValue, fileStatus => fileStatus.originalName === file.name);
 
     return fileWithSameNameUploaded || fileWithSameNameUploading
       ? {

--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -744,7 +744,7 @@ export default class FileComponent extends Field {
     const fileWithSameNameUploading = this.filesToSync.filesToUpload
       .some(fileToSync => fileToSync.file?.name === file.name);
 
-    const fileWithSameNameUploaded = this.dataValue
+    const fileWithSameNameUploaded = this.dataValue && this.dataValue
       .some(fileStatus => fileStatus.originalName === file.name);
 
     return fileWithSameNameUploaded || fileWithSameNameUploading

--- a/src/components/file/File.unit.js
+++ b/src/components/file/File.unit.js
@@ -271,4 +271,10 @@ describe('File Component', () => {
       }, 100);
     });
   });
+  it('should not error on upload when noDefaults is set to true', () => {
+    return Formio.createForm(document.createElement('div'), comp2,{ noDefaults: true }).then((form)=>{
+      const file = form.getComponent('file');
+      return file.handleFilesToUpload([{ name: 'mypdf.pdf', size: 123123, type: 'application/pdf' }]);
+    });
+  });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8420

## Description

**What changed?**

Previously, formio.js would error on a file upload if the noDefaults option in Formio.createForm function was set to true. This PR replaces this behavior by validating that this.dataValue exists before calling the .some function on it.

**Why have you chosen this solution?**

Although there were many potential solutions my solution was best because it does not cause any new errors/bugs to appear in the code and allows the next couple of lines of code to work without modification.

## Dependencies

N/A

## How has this PR been tested?

I added automated tests and manually tested

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
