### PR TITLE
FIO-8438: fix datagrid addrow clearing checkbox

### DIFF
--- a/src/Wizard.unit.js
+++ b/src/Wizard.unit.js
@@ -41,6 +41,7 @@ import wizardPermission from '../test/forms/wizardPermission';
 import formWithFormController from '../test/forms/formWithFormController';
 import { fastCloneDeep } from './utils/utils';
 import formsWithAllowOverride from '../test/forms/formsWithAllowOverrideComps';
+import WizardWithCheckboxes from '../test/forms/wizardWithCheckboxes';
 
 global.requestAnimationFrame = (cb) => cb();
 global.cancelAnimationFrame = () => {};
@@ -1915,5 +1916,46 @@ it('Should show tooltip for wizard pages', function(done) {
       }, 50);
     })
     .catch((err) => done(err));
+  });
+
+  it('Should retain previous checkbox checked property when navigating to another page (checked)', (done) => {
+    const wizard = new Wizard(document.createElement('div'));
+    wizard.setForm(WizardWithCheckboxes).then(()=> {
+      const clickNavigationBtn = (pathPart) => {
+        const btn = _.get(wizard.refs, `${wizard.wizardKey}-${pathPart}`);
+        const clickEvent = new Event('click');
+        btn.dispatchEvent(clickEvent);
+      };
+      wizard.element.querySelector('input').click();
+      clickNavigationBtn('next');
+      setTimeout(()=>{
+        clickNavigationBtn('previous');
+        setTimeout(()=>{
+          assert.equal(wizard.element.querySelector('input').checked, true);
+          done();
+        },200);
+      },200);
+    });
+  });
+
+  it('Should retain previous checkbox checked property when navigating to another page (unchecked)', (done) => {
+    const wizard = new Wizard(document.createElement('div'));
+    wizard.setForm(WizardWithCheckboxes).then(()=> {
+      const clickNavigationBtn = (pathPart) => {
+        const btn = _.get(wizard.refs, `${wizard.wizardKey}-${pathPart}`);
+        const clickEvent = new Event('click');
+        btn.dispatchEvent(clickEvent);
+      };
+      wizard.element.querySelector('input').click();
+      wizard.element.querySelector('input').click();
+      clickNavigationBtn('next');
+      setTimeout(()=>{
+        clickNavigationBtn('previous');
+        setTimeout(()=>{
+          assert.equal(wizard.element.querySelector('input').checked, false);
+          done();
+        },200);
+      },200);
+    });
   });
 });

--- a/src/components/datagrid/DataGrid.unit.js
+++ b/src/components/datagrid/DataGrid.unit.js
@@ -22,7 +22,7 @@ import {
   withLogic,
   withCollapsibleRowGroups,
   withAllowCalculateOverride,
-  twoWithAllowCalculatedOverride,
+  twoWithAllowCalculatedOverride, withCheckboxes,
 } from './fixtures';
 
 describe('DataGrid Component', () => {
@@ -397,6 +397,23 @@ describe('DataGrid Component', () => {
         }, 300);
       })
       .catch(done);
+  });
+
+  it('Should retain previous checkboxes checked property when add another is pressed (checked)', () => {
+    return Harness.testCreate(DataGridComponent, withCheckboxes).then((component) => {
+      component.childComponentsMap['dataGrid[0].radio'].element.querySelector('input').click();
+      component.addRow();
+      assert.equal(component.childComponentsMap['dataGrid[0].radio'].element.querySelector('input').checked, true);
+    });
+  });
+
+  it('Should retain previous checkboxes checked property when add another is pressed (unchecked)', () => {
+    return Harness.testCreate(DataGridComponent, withCheckboxes).then((component) => {
+      component.childComponentsMap['dataGrid[0].radio'].element.querySelector('input').click();
+      component.childComponentsMap['dataGrid[0].radio'].element.querySelector('input').click();
+      component.addRow();
+      assert.equal(component.childComponentsMap['dataGrid[0].radio'].element.querySelector('input').checked, false);
+    });
   });
 });
 

--- a/src/components/datagrid/fixtures/comp-with-checkboxes.js
+++ b/src/components/datagrid/fixtures/comp-with-checkboxes.js
@@ -1,0 +1,34 @@
+export default {
+  'label': 'Data Grid',
+  'reorder': false,
+  'addAnotherPosition': 'bottom',
+  'layoutFixed': false,
+  'enableRowGroups': false,
+  'initEmpty': false,
+  'tableView': false,
+  'defaultValue': [
+    {}
+  ],
+  'key': 'dataGrid',
+  'type': 'datagrid',
+  'input': true,
+  'components': [
+    {
+      'label': 'Radio',
+      'optionsLabelPosition': 'right',
+      'inline': false,
+      'tableView': false,
+      'values': [
+        {
+          'label': 'yes',
+          'value': 'yes',
+          'shortcut': ''
+        }
+      ],
+      'key': 'radio',
+      'type': 'radio',
+      'input': true,
+      'inputType': 'checkbox'
+    }
+  ]
+};

--- a/src/components/datagrid/fixtures/index.js
+++ b/src/components/datagrid/fixtures/index.js
@@ -14,4 +14,5 @@ import withLogic from './comp-with-logic';
 import withCollapsibleRowGroups from './comp-with-collapsible-groups';
 import withAllowCalculateOverride from './comp-with-allow-calculate-override';
 import twoWithAllowCalculatedOverride from './two-comp-with-allow-calculate-override';
-export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, withCollapsibleRowGroups, withConditionalFieldsAndValidations, withDefValue, withLogic, withRowGroupsAndDefValue, modalWithRequiredFields, withAllowCalculateOverride, twoWithAllowCalculatedOverride };
+import withCheckboxes from './comp-with-checkboxes';
+export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, withCollapsibleRowGroups, withConditionalFieldsAndValidations, withDefValue, withLogic, withRowGroupsAndDefValue, modalWithRequiredFields, withAllowCalculateOverride, twoWithAllowCalculatedOverride, withCheckboxes };

--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -229,7 +229,8 @@ export default class RadioComponent extends ListComponent {
     if (this.viewOnly || !this.refs.input || !this.refs.input.length) {
       return this.dataValue;
     }
-    let value = this.dataValue;
+    // If the input type of the component is checkbox the value should be determined by the checkboxes checked property
+    let value = this.component.inputType === 'checkbox' ? '' : this.dataValue;
     this.refs.input.forEach((input, index) => {
       if (input.checked) {
         value = (this.isSelectURL && _.isObject(this.loadedOptions[index].value)) ?
@@ -374,7 +375,7 @@ export default class RadioComponent extends ListComponent {
       const value = this.dataValue;
       this.refs.wrapper.forEach((wrapper, index) => {
         const input = this.refs.input[index];
-        const checked  = (input.type === 'checkbox') ? value[input.value] || this.element?.querySelector('input').checked : (input.value.toString() === value.toString());
+        const checked  = (input.type === 'checkbox') ? value[input.value] || input.checked : (input.value.toString() === value.toString());
         if (checked) {
           //add class to container when selected
           this.addClass(wrapper, this.optionSelectedClass);

--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -374,7 +374,7 @@ export default class RadioComponent extends ListComponent {
       const value = this.dataValue;
       this.refs.wrapper.forEach((wrapper, index) => {
         const input = this.refs.input[index];
-        const checked  = (input.type === 'checkbox') ? value[input.value] : (input.value.toString() === value.toString());
+        const checked  = (input.type === 'checkbox') ? value[input.value] || this.element?.querySelector('input').checked : (input.value.toString() === value.toString());
         if (checked) {
           //add class to container when selected
           this.addClass(wrapper, this.optionSelectedClass);

--- a/test/forms/index.js
+++ b/test/forms/index.js
@@ -16,6 +16,7 @@ import ComponentsBasicSettingsTests from './componentsBasicSettingsTests';
 // import ChildMetadata from './childMetadata';
 import NestedFormValidation from './nested-form-validation';
 import WizardWithPrefixComps from './wizardWithPrefixComps';
+import WizardWithCheckboxes from './wizardWithCheckboxes';
 
 export default [
   Simple,
@@ -35,5 +36,6 @@ export default [
   // WysiwygCursor
   ClearOnHide,
   WizardWithPrefixComps,
+  WizardWithCheckboxes,
   ...ComponentsBasicSettingsTests,
 ];

--- a/test/forms/wizardWithCheckboxes.js
+++ b/test/forms/wizardWithCheckboxes.js
@@ -1,0 +1,44 @@
+export default {
+  'title': 'wizardWithCheckbox',
+  'name': 'wizardWithCheckbox',
+  'type': 'form',
+  'display': 'wizard',
+  'components': [
+    {
+      'title': 'Page 1',
+      'label': 'Page 1',
+      'type': 'panel',
+      'key': 'page1',
+      'components': [
+        {
+          'label': 'Radio',
+          'optionsLabelPosition': 'right',
+          'inline': false,
+          'tableView': false,
+          'values': [
+            {
+              'label': 'a',
+              'value': 'a',
+              'shortcut': ''
+            }
+          ],
+          'key': 'radio',
+          'type': 'radio',
+          'input': true,
+          'inputType': 'checkbox'
+        }
+      ],
+      'input': false,
+      'tableView': false
+    },
+    {
+      'title': 'Page 2',
+      'label': 'Page 2',
+      'type': 'panel',
+      'key': 'page2',
+      'input': false,
+      'tableView': false,
+      'components': []
+    }
+  ]
+};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8438

## Description

**What changed?**

Previously, formio.js would clear radio components with the option inputType: checkbox when a new row was added to the datagrid.  This PR replaces this behavior by retaining the state of the checkbox when data grid adds a new row

**Why have you chosen this solution?**

Although there were many potential solutions, my solution was best because it adds a check to see if the element property on the component has the property checked to true to verify that the component is checked. It also does not remove value[input.value] to allow for reverse compatibility. 

## Dependencies

N/A

## How has this PR been tested?

I added automated tests to cover checkbox when checked and checkbox when unchecked cases. I also verified that removing my change from this PR will break these tests to validate that my tests are working as intended. 

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
