### PR TITLE
FIO-8493: Added null check for this.root in builder mode

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -502,7 +502,7 @@ export default class FormComponent extends Component {
     }
     else if (this.formSrc) {
       this.subFormLoading = true;
-      const options = this.root.formio?.base && this.root.formio?.projectUrl
+      const options = this.root?.formio?.base && this.root?.formio?.projectUrl
         ? {
             base: this.root.formio.base,
             project: this.root.formio.projectUrl,
@@ -711,7 +711,7 @@ export default class FormComponent extends Component {
     if (shouldLoadSubmissionById || shouldLoadDraftById) {
       const formId = submission.form || this.formObj.form || this.component.form;
       const submissionUrl = `${this.subForm.formio.formsUrl}/${formId}/submission/${submission._id || this.subForm.submission._id}`;
-      const options = this.root.formio?.base && this.root.formio?.projectUrl
+      const options = this.root?.formio?.base && this.root?.formio?.projectUrl
       ? {
           base: this.root.formio.base,
           project: this.root.formio.projectUrl,


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8493

## Description

This PR addresses an issue in the 4.x versions of formio.js where `this.root` is `undefined` when the edit button of the form component is clicked in builder mode. This issue does not occur in the master branch, as it was resolved by [this commit](https://github.com/formio/formio.js/commit/715ab01afae255f52af07a34ffb6a575c45f7d77)

The fix involves adding additional null checks to the root of the form component to prevent errors when  `this.root` is `undefined`. This ensures that the builder mode operates as expected across all versions of the library.

## How has this PR been tested?

This fix has been tested by cherry-picking the commit onto the 4.19.x branch

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
