### PR TITLE
FIO-8445: Fixed searchbar not focusing when navigating using up and down arrows

### DIFF
--- a/src/utils/ChoicesWrapper.js
+++ b/src/utils/ChoicesWrapper.js
@@ -122,13 +122,24 @@ class ChoicesWrapper extends Choices {
     }
   }
 
-  _selectHighlightedChoice(activeItems) {
+  _selectHighlightedChoice() {
     const highlightedChoice = this.dropdown.getChild(
       `.${this.config.classNames.highlightedState}`,
     );
 
     if (highlightedChoice) {
-      this._handleChoiceAction(activeItems, highlightedChoice);
+      const id = highlightedChoice.dataset.id;
+      const choice = id && this._store.getChoiceById(id);
+      this._addItem({
+        value: choice.value,
+        label: choice.label,
+        choiceId: choice.id,
+        groupId: choice.groupId,
+        customProperties: choice.customProperties,
+        placeholder: choice.placeholder,
+        keyCode: choice.keyCode
+      });
+      this._triggerChange(choice.value);
     }
 
     event.preventDefault();


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8445

## Description

**What changed?**

Previously, formio.js would unfocus the search bar when navigating the select component with the up and down keyboard arrows. This PR replaces this behavior by modifying the selectHighlightedChoice function to use the addItem choicesjs function instead of the handleChoiceAction choicesjs function. This allows the selectHighlightedChoices function to behave more like a highlighting choices instead of selecting choices when navigating using arrow keys.

**Why have you chosen this solution?**

*Although there were many potential solutions my solution was best because it introduces no new errors or bugs

## Dependencies

N/A

## How has this PR been tested?

manual testing

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
