### PR TITLE
FIO-7936: showCounter messages not translating

### DIFF
--- a/src/components/_classes/input/Input.js
+++ b/src/components/_classes/input/Input.js
@@ -172,13 +172,15 @@ export default class Input extends Multivalue {
       else {
         this.addClass(element, 'text-danger');
       }
-      this.setContent(element, this.t(`{{ remaining }} ${type} remaining.`, {
-        remaining: remaining
+      this.setContent(element, this.t(`typeRemaining`, {
+        remaining: remaining,
+        type: type
       }));
     }
     else {
-      this.setContent(element, this.t(`{{ count }} ${type}`, {
-        count: count
+      this.setContent(element, this.t(`typeCount`, {
+        count: count,
+        type: type
       }));
     }
   }

--- a/src/components/textarea/TextArea.unit.js
+++ b/src/components/textarea/TextArea.unit.js
@@ -389,6 +389,34 @@ describe('TextArea Component', () => {
     }).catch(done);
   });
 
+  it('Should translate character counter if it is enabled', (done) => {
+    const form = _.cloneDeep(comp3);
+    form.components[0].showCharCount = true;
+    form.components[0].validate = {
+      maxLength: 20
+    }
+    Formio.createForm(document.createElement('div'), form, {
+      language: 'sp',
+      i18n: {
+        sp: {
+          characters: 'stafbil',
+          typeRemaining: '{{ remaining }} {{ type }} eftir.'
+        }
+      }
+    }).then((form) => {
+      let component = form.getComponent('textArea');
+      const inputEvent = new Event('input');
+      component.refs.input[0].value = 'test';
+      component.refs.input[0].dispatchEvent(inputEvent)
+
+      setTimeout(()=>{
+        component = form.getComponent('textArea');
+        assert.equal(component.refs.charcount[0].textContent, '16 stafbil eftir.');
+        done()
+      },200)
+    }).catch(done);
+  });
+
   describe('Rich text editors', () => {
     describe('CKEditor', () => {
       it('Should allow to insert media fiels and show the in them read-only mode', (done) => {

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -71,5 +71,7 @@ export default {
   submitButtonAriaLabel:'Submit Form button. Click to submit the form',
   reCaptchaTokenValidationError: 'ReCAPTCHA: Token validation error',
   reCaptchaTokenNotSpecifiedError: 'ReCAPTCHA: Token is not specified in submission',
-  apiKey: 'API Key is not unique: {{key}}'
+  apiKey: 'API Key is not unique: {{key}}',
+  typeRemaining: '{{ remaining }} {{ type }} remaining.',
+  typeCount: '{{ count }} {{ type }}'
 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7936

## Description

**What changed?**

Previously, formio.js did not translate the counter message when you had showCharCount and showWordCount enabled. This PR replaces this behavior by adding a translations for showCharCount and showWordCount.

**Why have you chosen this solution?**

This allows for users to override the the translation by adding the typeRemaining and typeCount to the i18n options.

## Dependencies

N/A

## How has this PR been tested?

I added automated tests to test translation and manually tested

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
