### PR TITLE
4.x - FIO-7478: fixed an issue where select component displays incorrect label after datagrid rows reorder

### DIFF
--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -411,6 +411,18 @@ export default class DataGridComponent extends NestedArrayComponent {
     return this.component.components;
   }
 
+  reorderValues(valuesArr, oldPosition, newPosition, movedBelow) {
+    if (!_.isArray(valuesArr) || _.isEmpty(valuesArr)) {
+      return;
+    }
+
+    const draggedRowData = valuesArr[oldPosition];
+    //insert element at new position
+    valuesArr.splice(newPosition, 0, draggedRowData);
+    //remove element from old position (if was moved above, after insertion it's at +1 index)
+    valuesArr.splice(movedBelow ? oldPosition : oldPosition + 1, 1);
+  }
+
   onReorder(element, _target, _source, sibling) {
     if (!element.dragInfo || (sibling && !sibling.dragInfo)) {
       console.warn('There is no Drag Info available for either dragged or sibling element');
@@ -422,12 +434,10 @@ export default class DataGridComponent extends NestedArrayComponent {
     const newPosition = sibling ? sibling.dragInfo.index : this.dataValue.length;
     const movedBelow = newPosition > oldPosition;
     const dataValue = fastCloneDeep(this.dataValue);
-    const draggedRowData = dataValue[oldPosition];
+    this.reorderValues(dataValue, oldPosition, newPosition, movedBelow);
 
-    //insert element at new position
-    dataValue.splice(newPosition, 0, draggedRowData);
-    //remove element from old position (if was moved above, after insertion it's at +1 index)
-    dataValue.splice(movedBelow ? oldPosition : oldPosition + 1, 1);
+    //reorder select data
+    this.reorderValues(_.get(this.root, `submission.metadata.selectData.${this.path}`, []), oldPosition, newPosition, movedBelow);
 
     //need to re-build rows to re-calculate indexes and other indexed fields for component instance (like rows for ex.)
     this.setValue(dataValue, { isReordered: true });

--- a/src/components/datagrid/DataGrid.unit.js
+++ b/src/components/datagrid/DataGrid.unit.js
@@ -23,6 +23,7 @@ import {
   withCollapsibleRowGroups,
   withAllowCalculateOverride,
   twoWithAllowCalculatedOverride,
+  withReorder
 } from './fixtures';
 
 describe('DataGrid Component', () => {
@@ -703,6 +704,56 @@ describe('DataGrid calculated values', () => {
             }, 300);
           }, 300);
         }, 300);
+      })
+      .catch(done);
+  });
+});
+
+describe('DataGrid Reorder', () => {
+  it('Should display select components labels correctly on rows reorder', (done) => {
+    Formio.createForm(document.createElement('div'), withReorder.form)
+      .then((form) => {
+        form.setSubmission(withReorder.submission)
+        .then(() => {
+          const values = [
+            { value: '11', label: 1 },
+            { value: '22', label: 2 },
+            { value: '33', label: 3 },
+            { value: '44', label: 4 },
+            { value: '55', label: 5 },
+          ];
+
+          const dataGrid = form.getComponent('dataGrid');
+          _.each(dataGrid.components, (selectComp, ind) => {
+            const expectedValue = values[ind];
+            assert.equal(ind, selectComp.rowIndex);
+            assert.equal(selectComp.dataValue, expectedValue.value);
+            assert.equal(selectComp.templateData[expectedValue.value].data.number, expectedValue.label);
+          });
+
+          dataGrid.onReorder({ dragInfo: { index: 4 } }, null, null, { dragInfo: { index: 0 } });
+          dataGrid.onReorder({ dragInfo: { index: 4 } }, null, null, { dragInfo: { index: 1 } });
+          dataGrid.onReorder({ dragInfo: { index: 2 } }, null, null, { dragInfo: { index: 4 } });
+
+          setTimeout(() => {
+            const values = [
+              { value: '55', label: 5 },
+              { value: '44', label: 4 },
+              { value: '22', label: 2 },
+              { value: '11', label: 1 },
+              { value: '33', label: 3 },
+            ];
+
+            _.each(dataGrid.components, (selectComp, ind) => {
+              const expectedValue = values[ind];
+              assert.equal(ind, selectComp.rowIndex, 'Component index after reorder');
+              assert.equal(selectComp.dataValue, expectedValue.value, 'Component value after reorder');
+              assert.equal(selectComp.templateData[expectedValue.value].data.number, expectedValue.label, 'Component label value after reorder');
+            });
+
+            done();
+          }, 600);
+        });
       })
       .catch(done);
   });

--- a/src/components/datagrid/fixtures/comp-with-reorder.js
+++ b/src/components/datagrid/fixtures/comp-with-reorder.js
@@ -1,0 +1,139 @@
+const form = {
+  _id: '66742f4146717b98a9fa280f',
+  title: 'test reorder',
+  name: 'testReorder',
+  path: 'testreorder',
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      label: 'Data Grid',
+      reorder: true,
+      addAnotherPosition: 'bottom',
+      layoutFixed: false,
+      enableRowGroups: false,
+      initEmpty: false,
+      tableView: false,
+      defaultValue: [
+        {
+          select: '',
+        },
+      ],
+      key: 'dataGrid',
+      type: 'datagrid',
+      input: true,
+      components: [
+        {
+          label: 'Select',
+          widget: 'choicesjs',
+          tableView: true,
+          dataSrc: 'resource',
+          data: {
+            resource: '66742ee946717b98a9fa1b0b',
+          },
+          dataType: 'string',
+          valueProperty: 'data.textField',
+          template: '<span>{{ item.data.number }}</span>',
+          validate: {
+            select: false,
+          },
+          key: 'select',
+          type: 'select',
+          searchField: 'data.textField__regex',
+          limit: 10,
+          noRefreshOnScroll: false,
+          addResource: false,
+          reference: false,
+          input: true,
+        },
+      ],
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  created: '2024-06-20T13:31:45.177Z',
+  modified: '2024-06-25T10:32:46.577Z',
+  machineName: 'tifwklexhyrgxbr:testReorder',
+};
+
+const submission = {
+  form: '66742f4146717b98a9fa280f',
+  metadata: {
+    selectData: {
+      dataGrid: [
+        {
+          select: {
+            data: {
+              number: 1,
+            },
+          },
+        },
+        {
+          select: {
+            data: {
+              number: 2,
+            },
+          },
+        },
+        {
+          select: {
+            data: {
+              number: 3,
+            },
+          },
+        },
+        {
+          select: {
+            data: {
+              number: 4,
+            },
+          },
+        },
+        {
+          select: {
+            data: {
+              number: 5,
+            },
+          },
+        },
+      ],
+    },
+  },
+  data: {
+    dataGrid: [
+      {
+        select: '11',
+      },
+      {
+        select: '22',
+      },
+      {
+        select: '33',
+      },
+      {
+        select: '44',
+      },
+      {
+        select: '55',
+      },
+    ],
+    dataTable: [],
+    submit: true,
+  },
+  _id: '667ab5ee6a69739703d30def',
+  project: '65df46bc93bcfaa231f3db1c',
+  state: 'submitted',
+  created: '2024-06-25T12:19:58.626Z',
+  modified: '2024-06-25T12:19:58.627Z',
+};
+
+export default {
+  form,
+  submission,
+};

--- a/src/components/datagrid/fixtures/index.js
+++ b/src/components/datagrid/fixtures/index.js
@@ -14,3 +14,4 @@ export withLogic from './comp-with-logic';
 export withCollapsibleRowGroups from './comp-with-collapsible-groups';
 export withAllowCalculateOverride from './comp-with-allow-calculate-override';
 export twoWithAllowCalculatedOverride from './two-comp-with-allow-calculate-override';
+export withReorder from './comp-with-reorder';


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7478

## Description

**What changed?**

Reorder submission selectData when the dataGrid rows are reordered

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
