### PR TITLE
FIO-6632: Automate @formio/js updates to formiojs.test-form.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '*' # This will make sure tag creations also trigger the workflow.
-
+      - '*'
 env:
   NODE_VERSION: 20.x
   AWS_DEFAULT_REGION: us-west-2
@@ -31,6 +30,11 @@ jobs:
       - name: Install Jekyll
         run: gem install jekyll
 
+      - name: Install awscli
+        run: |
+          sudo apt-get update
+          sudo apt install -y awscli
+
       - name: Restore node modules from cache
         uses: actions/cache@v3
         with:
@@ -39,12 +43,29 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install awscli
-        run: |
-          sudo apt-get update
-          sudo apt install -y awscli
+      - name: Installing dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: install --frozen-lockfile
+
+      - name: Build
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: build
 
       - name: Release
         uses: borales/actions-yarn@v4
         with:
           cmd: release
+
+      - name: Invalidate (formiojs.test-form.io) Cloudfront cache
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: invalidate
+
+      - name: Echo link to Test Page
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "The extracted version is $VERSION"
+          echo "https://formiojs.test-form.io/$VERSION"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formio/js",
-  "version": "5.0.0-rc.59",
+  "version": "5.0.0-rc.60",
   "description": "JavaScript powered Forms with JSON Form Builder",
   "main": "lib/cjs/index.js",
   "exports": {
@@ -38,7 +38,7 @@
     "lint"
   ],
   "scripts": {
-    "build": "yarn doc && yarn lib && yarn dist",
+    "build": "chmod +x update_semver.sh &&./update_semver.sh && yarn doc && yarn lib && yarn dist",
     "doc": "typedoc",
     "dist": "gulp clean:dist && webpack --config webpack.config.js && webpack --config webpack.prod.js && gulp build",
     "lib": "gulp clean:lib && tsc --project tsconfig.cjs.json && tsc --project tsconfig.mjs.json && yarn lib:package",
@@ -50,7 +50,7 @@
     "build-app:jekyll": "jekyll build --config _config.yml,_config.app.yml",
     "gh-pages": "rm -rf _site && npm run build && jekyll build --config _config.yml && cd _site && git init && git remote add origin git@github.com:formio/formio.js.git && git checkout -b gh-pages && git add . && git commit -m \"Deploy to GitHub Pages\" && git push origin gh-pages --force && cd ..",
     "deploy-s3": "$(node -e 'process.stdout.write(`aws s3 cp _site s3://formiojs.test-form.io/` + require(`./package.json`).version + `/ --recursive`)')",
-    "invalidate": "VERSION=$(yarn version);aws cloudfront create-invalidation --distribution-id E1MXNA5A4ZKRMZ --paths \"/$VERSION/*\"",
+    "invalidate": "VERSION=$(yarn version --json | jq -r '.data' | sed -n 's/.*: \\(.*\\)/\\1/p'); aws cloudfront create-invalidation --distribution-id E1MXNA5A4ZKRMZ --paths \"/$VERSION/*\"",
     "release": "yarn build-app && yarn deploy-s3",
     "tag": "VERSION=$(yarn version);git add -A; git commit -m \"Build $Version\";git push origin master;git tag v$VERSION;git push origin --tags;",
     "dopublish": "npm run build && npm run tag && npm publish",

--- a/update_semver.sh
+++ b/update_semver.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Function to extract version from package.json
+get_version_from_package_json() {
+  version=$(jq -r '.version' package.json)
+  echo $version
+}
+
+# Function to get the latest git tag
+get_latest_git_tag() {
+  tag=$(git describe --tags --abbrev=0)
+  if [ $? -ne 0 ]; then
+    echo "No git tags found."
+    exit 1
+  fi
+  echo $tag
+}
+
+# Function to strip the leading 'v' from the tag if it exists
+strip_leading_v() {
+  local tag=$1
+  echo "${tag#v}"
+}
+
+# Main script
+main() {
+  if ! [ -f "package.json" ]; then
+    echo "package.json not found."
+    exit 1
+  fi
+
+  version=$(get_version_from_package_json)
+  echo "Current package.json version: $version"
+
+  tag=$(get_latest_git_tag)
+  echo "Latest git tag: $tag"
+
+  stripped_tag=$(strip_leading_v "$tag")
+  echo "Stripped tag: $stripped_tag"
+
+  # Update package.json version with the stripped tag
+  jq --arg tag "$stripped_tag" '.version = $tag' package.json > temp.json && mv temp.json package.json
+
+  echo "Updated package.json version to: $stripped_tag"
+}
+
+# Execute the main script
+main


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6632

## Description

1. Noticed a few things weren't building quite right. The SemVer in the `package.json` was not being updated automatically during build process. Created a script that will run everytime `yarn build` is called to get the tag from git and update pacakge.json. Should ensure correct time every build.
https://github.com/formio/formio.js/actions/runs/9700333835 <- Happened to see that the version was v5.0.0-rc60 but did not see the version on the CDN. Saw v5.0.0-rc.59 and this was because the `package.json` version read 5.0.0-rc.59.
2. Noticed some differences in the CDN files based on looking at the artifact being distributed on [GH Pages](https://github.com/formio/formio.js/actions/runs/9701553308). 
3. Added updates to the `release.yml` to include the `yarn install`, `yarn build`, `yarn release`, and `yarn invalidate` to updates trigger properly in pipeline.

**Why have you chosen this solution?**

Was asked to provide some testing steps for previous issue FIO-6632 per Dane and noticed some issues in the process.

## Dependencies

n/a

## How has this PR been tested?

Pushed the updates to test CDN to test commands manually.
https://formiojs.test-form.io/5.0.0-rc.60/

Link to steps documented in Confluence -> https://formio.atlassian.net/wiki/x/AQCkCQ

![image](https://github.com/formio/formio.js/assets/112976114/32d871f7-a1e8-4063-a77f-ea5845f99bd1)

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
