### PR TITLE
FIO-8126: Fixed select component emitting blur on click

### DIFF
--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -422,10 +422,10 @@ describe('Webform tests', function() {
       const blurEvent = new Event('blur');
 
       const selectChoices = form.getComponent('selectChoices');
-      selectChoices.focusableElement.dispatchEvent(focusEvent);
+      selectChoices.choices.input.element.dispatchEvent(focusEvent);
 
       setTimeout(() => {
-        selectChoices.focusableElement.dispatchEvent(blurEvent);
+        selectChoices.choices.input.element.dispatchEvent(blurEvent);
 
         const selectHtml = form.getComponent('selectHtml');
         selectHtml.refs.selectContainer.dispatchEvent(focusEvent);

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import { Formio } from '../../Formio';
 import ListComponent from '../_classes/list/ListComponent';
-import Input from '../_classes/input/Input';
 import Form from '../../Form';
 import { getRandomComponentId, boolValue, isPromise, componentValueTypes, getComponentSavedTypes, isSelectResourceWithObjectValue, removeHTML } from '../../utils/utils';
 
@@ -1015,7 +1014,7 @@ export default class SelectComponent extends ListComponent {
         this.addEventListener(this.choices.containerOuter.element, 'focus', () => this.focusableElement.focus());
       }
 
-      Input.prototype.addFocusBlurEvents.call(this, this.focusableElement);
+      this.addFocusBlurEvents(this.choices.input.element);
 
       if (this.itemsFromUrl && !this.component.noRefreshOnScroll) {
         this.scrollList = this.choices.choiceList.element;

--- a/src/components/select/Select.unit.js
+++ b/src/components/select/Select.unit.js
@@ -1108,12 +1108,12 @@ describe('Select Component', () => {
     Formio.createForm(element, comp19).then(form => {
       const select = form.components[0];
       select.setValue('banana');
-      select.focusableElement.focus();
+      select.choices.input.element.focus();
       select.pristine = false;
 
       setTimeout(() => {
         assert(!select.visibleErrors.length, 'Select should be valid while changing');
-        select.focusableElement.dispatchEvent(new Event('blur'));
+        select.choices.input.element.dispatchEvent(new Event('blur'));
 
         setTimeout(() => {
           assert(select.visibleErrors.length, 'Should set error after Select component was blurred');


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8126
## Description

**What changed?**

Previously, formio.js select component would trigger a blur event upon clicking the select. This PR replaces this behavior by adding the blur event listener to the choicesjs input element 

**Why have you chosen this solution?**

The choicesjs input element is focused upon clicking the select element. So adding the blur event listener to the input element fixes this issue

## Dependencies

N/A

## How has this PR been tested?

manual testing

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
