### PR TITLE
FIO-8570: fixed decimal symbol property on number component

### DIFF
--- a/src/components/number/Number.js
+++ b/src/components/number/Number.js
@@ -54,7 +54,7 @@ export default class NumberComponent extends Input {
 
     const separators = getNumberSeparators(this.options.language || navigator.language);
 
-    this.decimalSeparator = this.options.decimalSeparator = this.options.decimalSeparator
+    this.decimalSeparator = this.options.decimalSeparator = this.component.decimalSymbol || this.options.decimalSeparator
       || this.options.properties?.decimalSeparator
       || separators.decimalSeparator;
 

--- a/src/components/number/Number.unit.js
+++ b/src/components/number/Number.unit.js
@@ -13,6 +13,7 @@ import {
   comp5,
   comp6,
   comp7,
+  comp8
 } from './fixtures';
 
 describe('Number Component', () => {
@@ -421,6 +422,23 @@ describe('Number Component', () => {
       assert.equal(component.getValueAsString([1, 2, 3, 4, 5]), '1, 2, 3, 4, 5');
       done();
     }).catch(done);
+  });
+
+  it('Should not remove decimal symbol and numbers after decimal symbol when submit is pressed', (done) => {
+    Formio.createForm(document.createElement('div'), comp8, {}).then((form) => {
+      const inputEvent = new Event('input');
+      const numberComponent = form.getComponent('number');
+      const buttonComponent = form.getComponent('submit');
+      numberComponent.refs.input[0].value = "123-456";
+      numberComponent.refs.input[0].dispatchEvent(inputEvent);
+      setTimeout(()=>{
+        buttonComponent.refs.button.click();
+        setTimeout(()=>{
+          assert.equal(numberComponent.refs.input[0].value, "123-456");
+          done();
+        },200);
+      },200);
+    });
   });
 
   // it('Should add trailing zeros on blur, if decimal required', (done) => {

--- a/src/components/number/fixtures/comp8.js
+++ b/src/components/number/fixtures/comp8.js
@@ -1,0 +1,26 @@
+export default {
+  components: [
+    {
+      "label": "Number",
+      "applyMaskOn": "change",
+      "mask": false,
+      "tableView": false,
+      "delimiter": false,
+      "requireDecimal": false,
+      "inputFormat": "plain",
+      "truncateMultipleSpaces": false,
+      "key": "number",
+      "type": "number",
+      "input": true,
+      "decimalSymbol": "-"
+    },
+    {
+      "type": "button",
+      "label": "Submit",
+      "key": "submit",
+      "disableOnInvalid": true,
+      "input": true,
+      "tableView": false
+    }
+  ]
+}

--- a/src/components/number/fixtures/index.js
+++ b/src/components/number/fixtures/index.js
@@ -5,4 +5,5 @@ import comp4 from './comp4';
 import comp5 from './comp5';
 import comp6 from './comp6';
 import comp7 from './comp7';
-export { comp1, comp2, comp3, comp4, comp5, comp6, comp7 };
+import comp8 from './comp8';
+export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8570

## Description

**What changed?**

Previously, formio.js would strip the decimal symbol and numbers after the decimal symbol when the decimalSymbol property was set on the number component JSON. This PR replaces this behavior by setting the decimalSeparator instance variable in the number class to the component decimalSymbol property if given else falling back on previous decimal separator options.

**Why have you chosen this solution?**

Although there were many potential solutions my solution was best because it integrates with the current ways decimal separators are set and does not require any change of functions.

## Dependencies

N/A

## How has this PR been tested?

I added automated tests and manually tested

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
