### PR TITLE
Fixing the formioReady promise to always resolve if you load it from the full source instead of the embed code.

### DIFF
--- a/src/Formio.js
+++ b/src/Formio.js
@@ -131,4 +131,5 @@ if (typeof window !== 'undefined') {
   FormioCore.addToGlobal(window);
 }
 
+FormioEmbed._formioReady(FormioCore);
 export { FormioCore as Formio };


### PR DESCRIPTION


## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-XXXX

## Description

With the introduction of the new Embed system, there is a new promise called "formioReady" which will resolve to the full Formio class once it is lazy loaded into place. This allows you to do something like...

```js
import { Formio } from '@formio/js/embed';
Formio.formioReady.then(function() {
  // Do something ONLY when the full code has been loaded.
});
```

The problem is that if you were to import Formio from the full source it would never resolve like so...

```js
import { Formio } from '@formio/js';
Formio.formioReady.then(function() {
  // Without this PR, this would never resolve!
});
```

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
