### PR TITLE
FIO-8457: set pristine flag when datagrid reorders rows

### DIFF
--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -424,6 +424,10 @@ export default class DataGridComponent extends NestedArrayComponent {
     //remove element from old position (if was moved above, after insertion it's at +1 index)
     dataValue.splice(movedBelow ? oldPosition : oldPosition + 1, 1);
 
+    // When components are reordered we need to set the dataGrid and form pristine properties to false
+    this.root.pristine = false;
+    this.pristine = false;
+
     //need to re-build rows to re-calculate indexes and other indexed fields for component instance (like rows for ex.)
     this.setValue(dataValue, { isReordered: true });
     this.rebuild();

--- a/src/components/datagrid/DataGrid.unit.js
+++ b/src/components/datagrid/DataGrid.unit.js
@@ -423,6 +423,20 @@ describe('DataGrid Component', () => {
       assert(dataGridComponent.root.dragulaLib, 'could not find dragulaLib');
     });
   });
+
+  it('Should set the pristine of itself and the form the false when reordering occurs', () => {
+    return Formio.createForm(document.createElement('div'), comp9, {}).then((form) => {
+      const dataGridComponent = form.getComponent('dataGrid');
+      const element = document.createElement('tr');
+      element.dragInfo = {};
+      _.set(element, 'dragInfo.index', 0);
+      const tableBody = document.createElement('tbody');
+      const sibling = document.createElement('tr');
+      sibling.dragInfo = {};
+      dataGridComponent.onReorder(element,tableBody, tableBody, sibling);
+      assert(!form.pristine, 'form pristine should be set to false when datagrid reordering occurs');
+    });
+  });
 });
 
 describe('DataGrid Panels', () => {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8457

## Description

**What changed?**

Previously, formio.js would not set the forms pristine property to false when the datagrid rows were reordered. This PR replaces this behavior by setting the forms pristine property to false when the datagrid rows are reordered.

## Dependencies

N/A

## How has this PR been tested?

I added automated tests and manually tested

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
