### PR TITLE
FIO-8645: day component required validation error not correct

### DIFF
--- a/src/components/day/Day.unit.js
+++ b/src/components/day/Day.unit.js
@@ -233,11 +233,11 @@ describe('Day Component', () => {
         dayComponent.refs.day.dispatchEvent(new Event('input'));
 
         setTimeout(() => {
-          assert(dayComponent._errors.length && dayComponent._errors[0].message === 'requiredDayField', 'Day should be valid while changing');
+          assert(dayComponent._errors.length && dayComponent._errors[0].message === 'Day is required', 'Day should be valid while changing');
           dayComponent.refs.day.dispatchEvent(new Event('blur'));
 
           setTimeout(() => {
-            assert(dayComponent._errors.length && dayComponent._errors[0].message === 'requiredDayField', 'Should set error after Day component was blurred');
+            assert(dayComponent._errors.length && dayComponent._errors[0].message === 'Day is required', 'Should set error after Day component was blurred');
             done();
           }, 200);
         }, 200);

--- a/src/components/day/Day.unit.js
+++ b/src/components/day/Day.unit.js
@@ -11,7 +11,8 @@ import {
   comp4,
   comp5,
   comp6,
-  comp7
+  comp7,
+  comp8
 } from './fixtures';
 import PanelComponent from '../panel/Panel';
 
@@ -265,6 +266,7 @@ describe('Day Component', () => {
       }, 500);
     }).catch(done);
   });
+
   it('Should translate placeholder text', () => {
     const element = document.createElement('div');
     return Formio.createForm(element, comp7, {
@@ -282,5 +284,17 @@ describe('Day Component', () => {
       assert.equal(dayComponent.refs.month.placeholder, 'Month2');
       assert.equal(dayComponent.refs.year.placeholder, 'Year3');
     })
+  });
+
+  it('Should translate requiredDayField to {{ field }} is required', (done) => {
+    Formio.createForm(document.createElement('div'), comp8, {}).then((form) => {
+      const dayComponent = form.getComponent('dayTable');
+      const buttonComponent = form.getComponent('submit');
+      buttonComponent.refs.button.click();
+      setTimeout(()=>{
+        assert.equal(dayComponent.errors[0].message, 'Day - Table is required');
+        done();
+      },200);
+    });
   });
 });

--- a/src/components/day/fixtures/comp8.js
+++ b/src/components/day/fixtures/comp8.js
@@ -1,0 +1,38 @@
+export default {
+  "components": [
+    {
+      "label": "Day - Table",
+      "hideInputLabels": false,
+      "inputsLabelPosition": "top",
+      "useLocaleSettings": false,
+      "alwaysEnabled": false,
+      "tableView": false,
+      "fields": {
+        "day": {
+          "hide": false,
+          "required": true
+        },
+        "month": {
+          "hide": false,
+          "required": true
+        },
+        "year": {
+          "hide": false,
+          "required": true
+        }
+      },
+      "key": "dayTable",
+      "type": "day",
+      "input": true
+    },
+    {
+      "label": "Submit",
+      "showValidations": false,
+      "alwaysEnabled": false,
+      "tableView": false,
+      "key": "submit",
+      "type": "button",
+      "input": true
+    }
+  ]
+}

--- a/src/components/day/fixtures/index.js
+++ b/src/components/day/fixtures/index.js
@@ -5,4 +5,5 @@ import comp4 from './comp4';
 import comp5 from './comp5';
 import comp6 from './comp6';
 import comp7 from './comp7';
-export { comp1, comp2, comp3, comp4, comp5, comp6, comp7 };
+import comp8 from './comp8';
+export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8 };

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -73,5 +73,6 @@ export default {
   reCaptchaTokenNotSpecifiedError: 'ReCAPTCHA: Token is not specified in submission',
   apiKey: 'API Key is not unique: {{key}}',
   typeRemaining: '{{ remaining }} {{ type }} remaining.',
-  typeCount: '{{ count }} {{ type }}'
+  typeCount: '{{ count }} {{ type }}',
+  requiredDayField: '{{field}} is required'
 };

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -74,5 +74,5 @@ export default {
   apiKey: 'API Key is not unique: {{key}}',
   typeRemaining: '{{ remaining }} {{ type }} remaining.',
   typeCount: '{{ count }} {{ type }}',
-  requiredDayField: '{{field}} is required'
+  requiredDayField: '{{ field }} is required'
 };

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -73,5 +73,8 @@ export default {
   reCaptchaTokenNotSpecifiedError: 'ReCAPTCHA: Token is not specified in submission',
   apiKey: 'API Key is not unique: {{key}}',
   typeRemaining: '{{ remaining }} {{ type }} remaining.',
-  typeCount: '{{ count }} {{ type }}'
+  typeCount: '{{ count }} {{ type }}',
+  requiredDayField: '{{ field }} is required',
+  requiredMonthField: '{{ field }} is required',
+  requiredYearField: '{{ field }} is required'
 };

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -74,5 +74,7 @@ export default {
   apiKey: 'API Key is not unique: {{key}}',
   typeRemaining: '{{ remaining }} {{ type }} remaining.',
   typeCount: '{{ count }} {{ type }}',
-  requiredDayField: '{{ field }} is required'
+  requiredDayField: '{{ field }} is required',
+  requiredMonthField: '{{ field }} is required',
+  requiredYearField: '{{ field }} is required'
 };

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -73,8 +73,5 @@ export default {
   reCaptchaTokenNotSpecifiedError: 'ReCAPTCHA: Token is not specified in submission',
   apiKey: 'API Key is not unique: {{key}}',
   typeRemaining: '{{ remaining }} {{ type }} remaining.',
-  typeCount: '{{ count }} {{ type }}',
-  requiredDayField: '{{ field }} is required',
-  requiredMonthField: '{{ field }} is required',
-  requiredYearField: '{{ field }} is required'
+  typeCount: '{{ count }} {{ type }}'
 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8645

## Description

**What changed?**

Previously, formio.js did not have the requiredDayField translation key in the en.js file which caused the required validation to not display correctly. This PR replaces this behavior by adding requiredDayField translation key to the translation file

## Dependencies

N/A

## How has this PR been tested?

I added automated tests and manually tested

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
