### PR TITLE
FIO-8659: no modal edit in display tab

### DIFF
--- a/src/components/_classes/component/editForm/Component.edit.display.js
+++ b/src/components/_classes/component/editForm/Component.edit.display.js
@@ -187,5 +187,13 @@ export default [
     key: 'tableView',
     input: true
   },
+  {
+    weight: 1600,
+    type: 'checkbox',
+    label: 'Modal Edit',
+    tooltip: 'Opens up a modal to edit the value of this component.',
+    key: 'modalEdit',
+    input: true
+  }
 ];
 /* eslint-enable max-len */


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8659

## Description

**What changed?**

Previously, formio.js had the modal checkbox removed by [Adding JSDocs and fixes for the 5x Renderer Version.](https://github.com/formio/formio.js/commit/95760937e01133b1428bd253751536814dee5f92) This PR replaces this behavior by adding the modal checkbox option back to the component edit display json

## Dependencies

N/A

## How has this PR been tested?

manually tested

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
