### PR TITLE
allow pathing in select boxes valueProperty

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -323,16 +323,17 @@ export default class RadioComponent extends ListComponent {
   setItems(items) {
     const listData = [];
     items?.forEach((item, i) => {
+      const valueAtProperty = _.get(item, this.component.valueProperty);
       this.loadedOptions[i] = {
-        value: this.component.valueProperty ? item[this.component.valueProperty] : item,
-        label: this.component.valueProperty ? this.itemTemplate(item, item[this.component.valueProperty]) : this.itemTemplate(item, item, i)
+        value: this.component.valueProperty ? valueAtProperty : item,
+        label: this.component.valueProperty ? this.itemTemplate(item, valueAtProperty) : this.itemTemplate(item, item, i)
       };
-      listData.push(this.templateData[this.component.valueProperty ? item[this.component.valueProperty] : i]);
+      listData.push(this.templateData[this.component.valueProperty ? valueAtProperty : i]);
 
       if ((this.component.valueProperty || !this.isRadio) && (
-        _.isUndefined(item[this.component.valueProperty]) ||
-        (!this.isRadio && _.isObject(item[this.component.valueProperty])) ||
-        (!this.isRadio && _.isBoolean(item[this.component.valueProperty]))
+        _.isUndefined(valueAtProperty) ||
+        (!this.isRadio && _.isObject(valueAtProperty)) ||
+        (!this.isRadio && _.isBoolean(valueAtProperty))
       )) {
         this.loadedOptions[i].invalid = true;
       }


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

Debugged an issue on a customer call where they couldn't use paths as valueProperties (e.g. pointing a Select Boxes component at a Form.io Resource URL and having a valueProperty of data.firstName). This PR works, but needs to be evaluated for thoroughness.

## Dependencies

n/a

## How has this PR been tested?

Automated tests should be added

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
