### PR TITLE
FIO-8639 fixed error when adding address component

### DIFF
--- a/src/components/address/Address.js
+++ b/src/components/address/Address.js
@@ -123,6 +123,12 @@ export default class AddressComponent extends ContainerComponent {
           provider,
           providerOptions,
         } = this.component;
+
+        if (_.get(providerOptions, 'params.subscriptionKey')) {
+          _.set(providerOptions, "params['subscription-key']", _.get(providerOptions, 'params.subscriptionKey'));
+          _.unset(providerOptions, 'params.subscriptionKey');
+        }
+
         this.provider = this.initializeProvider(provider, providerOptions);
       }
       else if (this.component.map) {

--- a/src/components/address/editForm/Address.edit.provider.js
+++ b/src/components/address/editForm/Address.edit.provider.js
@@ -28,7 +28,7 @@ export default [
   {
     type: 'textfield',
     input: true,
-    key: "providerOptions.params['subscription-key']",
+    key: "providerOptions.params.subscriptionKey",
     label: 'Subscription Key',
     placeholder: 'Enter Subscription Key',
     weight: 10,


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8639

## Description

*The Subscription Key field key was the reason for the error when adding the address component, because it included characters that are invalid for the key field. This has been fixed and the key has been replaced with the correct one, followed by the use of the appropriate parameter of provider options for Azure maps*

## Dependencies

*https://github.com/formio/core/pull/118*

## How has this PR been tested?

*tests have been added to the core lib. All tests pass locally*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
