### PR TITLE
Bugfix: allow paths for `valueProperty`

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -342,16 +342,17 @@ export default class RadioComponent extends ListComponent {
   setItems(items) {
     const listData = [];
     items?.forEach((item, i) => {
+      const valueAtProperty = _.get(item, this.component.valueProperty);
       this.loadedOptions[i] = {
-        value: this.component.valueProperty ? item[this.component.valueProperty] : item,
-        label: this.component.valueProperty ? this.itemTemplate(item, item[this.component.valueProperty]) : this.itemTemplate(item, item, i)
+        value: this.component.valueProperty ? valueAtProperty : item,
+        label: this.component.valueProperty ? this.itemTemplate(item, valueAtProperty) : this.itemTemplate(item, item, i)
       };
-      listData.push(this.templateData[this.component.valueProperty ? item[this.component.valueProperty] : i]);
+      listData.push(this.templateData[this.component.valueProperty ? valueAtProperty : i]);
 
       if ((this.component.valueProperty || !this.isRadio) && (
-        _.isUndefined(item[this.component.valueProperty]) ||
-        (!this.isRadio && _.isObject(item[this.component.valueProperty])) ||
-        (!this.isRadio && _.isBoolean(item[this.component.valueProperty]))
+        _.isUndefined(valueAtProperty) ||
+        (!this.isRadio && _.isObject(valueAtProperty)) ||
+        (!this.isRadio && _.isBoolean(valueAtProperty))
       )) {
         this.loadedOptions[i].invalid = true;
       }

--- a/src/components/radio/fixtures/comp12.js
+++ b/src/components/radio/fixtures/comp12.js
@@ -1,0 +1,34 @@
+export default {
+  components: [
+    {
+      "label": "Select Boxes",
+      "optionsLabelPosition": "right",
+      "tableView": false,
+      "dataSrc": "url",
+      "values": [
+        {
+          "label": "",
+          "value": "",
+          "shortcut": ""
+        }
+      ],
+      "valueProperty": "data.name",
+      "validateWhenHidden": false,
+      "key": "selectBoxes",
+      "type": "selectboxes",
+      "data": {
+        "url": "https://remote-dev.form.io/projectId/name/submission",
+        "headers": [
+          {
+            "key": "",
+            "value": ""
+          }
+        ]
+      },
+      "template": "<span>{{ item.data.name }}</span>",
+      "authenticate": true,
+      "input": true,
+      "inputType": "checkbox"
+    }
+  ]
+}

--- a/src/components/radio/fixtures/index.js
+++ b/src/components/radio/fixtures/index.js
@@ -9,4 +9,5 @@ import comp8 from './comp8';
 import comp9 from './comp9';
 import comp10 from './comp10';
 import comp11 from './comp11';
-export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11 };
+import comp12 from './comp12';
+export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12 };

--- a/src/components/selectboxes/SelectBoxes.unit.js
+++ b/src/components/selectboxes/SelectBoxes.unit.js
@@ -13,6 +13,7 @@ import {
   comp7,
 } from './fixtures';
 import wizardWithSelectBoxes from '../../../test/forms/wizardWithSelectBoxes';
+import {comp12} from "../radio/fixtures";
 
 describe('SelectBoxes Component', () => {
   it('Should build a SelectBoxes component', () => {
@@ -349,6 +350,78 @@ describe('SelectBoxes Component', () => {
         }, 200);
       }, 200);
     }).catch(done);
+  });
+
+  it('Should have correct submission data when setting the value property', (done) => {
+    const originalMakeRequest = Formio.makeRequest;
+    Formio.makeRequest = async ()=> {
+      return [
+        {
+          data: {
+            name: 'Bob',
+            referenceId: '1'
+          }
+        },
+        {
+          data: {
+            name: 'Tom',
+            referenceId: '2'
+          }
+        },
+        {
+          data: {
+            name: 'Joe',
+            referenceId: '3'
+          }
+        }
+      ]
+    }
+    const changeEvent = new Event('change');
+    Formio.createForm(document.createElement('div'), comp12, {}).then((form) => {
+      setTimeout(()=>{
+        const selectBoxesComponent = form.getComponent('selectBoxes');
+        selectBoxesComponent.refs.input[0].checked = true;
+        selectBoxesComponent.refs.input[0].dispatchEvent(changeEvent);
+        setTimeout(()=>{
+          assert.deepEqual(form.getValue().data, {selectBoxes : {Bob: true, Tom: false, Joe: false}});
+          done();
+        },200);
+        Formio.makeRequest = originalMakeRequest;
+      }, 200)
+    });
+  });
+
+  it('Should show validation errors when the value property is set', () => {
+    const originalMakeRequest = Formio.makeRequest;
+    Formio.makeRequest = async () => {
+      return [
+        {
+          data: {
+            name: 'Bob',
+            referenceId: '1'
+          }
+        },
+        {
+          data: {
+            name: 'Tom',
+            referenceId: '2'
+          }
+        },
+        {
+          data: {
+            name: 'Joe',
+            referenceId: '3'
+          }
+        }
+      ]
+    }
+    let newComp12 = _.cloneDeep(comp12);
+    _.set(newComp12.components[0], 'validate.required', true);
+    return Formio.createForm(document.createElement('div'), newComp12, {}).then((form) => {
+      const selectBoxesComponent = form.getComponent('selectBoxes');
+      assert.equal(selectBoxesComponent.errors.length, 1);
+      Formio.makeRequest = originalMakeRequest;
+    })
   });
 });
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8714

## Description

Debugged an issue on a customer call where they couldn't use paths as valueProperties (e.g. pointing a Select Boxes component at a Form.io Resource URL and having a valueProperty of data.firstName). This PR works but needs to be evaluated for thoroughness and tested.

## Dependencies

n/a

## How has this PR been tested?

Automated tests

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above