### PR TITLE
FIO-8570: fixed thousandSeparator problem and decimal symbol problem

### DIFF
--- a/src/components/number/Number.js
+++ b/src/components/number/Number.js
@@ -59,13 +59,12 @@ export default class NumberComponent extends Input {
       || separators.decimalSeparator;
 
     if (this.component.delimiter) {
-      if (this.options.hasOwnProperty('thousandsSeparator')) {
-        console.warn("Property 'thousandsSeparator' is deprecated. Please use i18n to specify delimiter.");
-      }
-
-      this.delimiter = this.options.properties?.thousandsSeparator || this.options.thousandsSeparator || separators.delimiter;
+      this.delimiter = this.component.thousandsSeparator || this.options.properties?.thousandsSeparator || this.options.thousandsSeparator || separators.delimiter;
     }
     else {
+      if (this.component.thousandsSeparator || this.options.properties?.thousandsSeparator || this.options.thousandsSeparator){
+        console.warn('In order for thousands separator to work properly, you must set the delimiter to true in the component json');
+      }
       this.delimiter = '';
     }
 
@@ -90,7 +89,7 @@ export default class NumberComponent extends Input {
       prefix: '',
       suffix: '',
       requireDecimal: _.get(this.component, 'requireDecimal', false),
-      thousandsSeparatorSymbol: _.get(this.component, 'thousandsSeparator', this.delimiter),
+      thousandsSeparatorSymbol: this.delimiter || '',
       decimalSymbol: _.get(this.component, 'decimalSymbol', this.decimalSeparator),
       decimalLimit: _.get(this.component, 'decimalLimit', this.decimalLimit),
       allowNegative: _.get(this.component, 'allowNegative', true),
@@ -169,6 +168,15 @@ export default class NumberComponent extends Input {
     return super.setValueAt(index, this.formatValue(this.parseValue(value)), flags);
   }
 
+  /**
+   * Converts a string to a floating point number, formats the number based on the parsed float function
+   * (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat) and then returns the
+   * formatted number back as a string
+   * Example Input: "123.456,22"
+   * Example Output: "123456,22"
+   * @param {string | number} input the numeric string to parse
+   * @returns {string | null} a parsed string
+   */
   parseValue(input) {
     if (typeof input === 'string') {
       input = input.split(this.delimiter).join('').replace(this.decimalSeparator, '.');

--- a/src/components/number/Number.unit.js
+++ b/src/components/number/Number.unit.js
@@ -13,8 +13,10 @@ import {
   comp5,
   comp6,
   comp7,
-  comp8
+  comp8,
+  comp9
 } from './fixtures';
+import CurrencyComponent from "../currency/Currency";
 
 describe('Number Component', () => {
   it('Should build an number component', () => {
@@ -439,6 +441,26 @@ describe('Number Component', () => {
         },200);
       },200);
     });
+  });
+
+  it('Should remove thousands separator in parseValue function if set on component JSON', () => {
+    const numberComponent = new NumberComponent({thousandsSeparator: '.', decimalSymbol: ',', delimiter: true});
+    assert.equal(numberComponent.parseValue('123.456.789,1'), '123456789,1');
+  });
+
+  it('Should use a . thousands separator when delimiter is true and thousands separator is set to .', (done) => {
+    Formio.createForm(document.createElement('div'), comp9, {}).then((form) => {
+      const numberComponent = form.getComponent('number');
+      const inputEvent = new Event('input');
+      const blurEvent = new Event('blur');
+      numberComponent.refs.input[0].value = '111222333';
+      numberComponent.refs.input[0].dispatchEvent(inputEvent);
+      numberComponent.refs.input[0].dispatchEvent(blurEvent);
+      setTimeout(()=>{
+        assert.equal(numberComponent.refs.input[0].value, '111.222.333');
+        done();
+      },200)
+    })
   });
 
   // it('Should add trailing zeros on blur, if decimal required', (done) => {

--- a/src/components/number/fixtures/comp9.js
+++ b/src/components/number/fixtures/comp9.js
@@ -1,0 +1,19 @@
+export default {
+  components: [
+    {
+      "label": "Number",
+      "applyMaskOn": "change",
+      "mask": false,
+      "tableView": false,
+      "delimiter": true,
+      "requireDecimal": false,
+      "inputFormat": "plain",
+      "truncateMultipleSpaces": false,
+      "key": "number",
+      "type": "number",
+      "input": true,
+      "decimalSymbol": ",",
+      "thousandsSeparator": "."
+    }
+  ]
+}

--- a/src/components/number/fixtures/index.js
+++ b/src/components/number/fixtures/index.js
@@ -6,4 +6,5 @@ import comp5 from './comp5';
 import comp6 from './comp6';
 import comp7 from './comp7';
 import comp8 from './comp8';
-export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8 };
+import comp9 from './comp9';
+export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8570

## Description

**What changed?**

this.delimiter can now be set by thousandsSeparator component JSON property. 

**Why have you chosen this solution?**

I choose this solution because it creates a single source of truth for what the delimiter is.

## Dependencies

N/A

## How has this PR been tested?

I have added automated tests and manually tested

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
