### PR TITLE
FIO-8647,8721: validation not triggered for each row after the first one in data and edit grid

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1297,7 +1297,7 @@ export default class Webform extends NestedDataComponent {
 
         const displayedErrors = [];
         if (errors.length) {
-            errors = _.uniqBy(errors, (error) => error.message);
+            errors = _.uniqBy(errors, (error) => [error.message, error.component?.id, error.context?.path].join());
             const createListItem = (message, index) => {
                 const err = errors[index];
                 const messageFromIndex = !_.isUndefined(index) && errors && errors[index];

--- a/src/Webform.unit.js
+++ b/src/Webform.unit.js
@@ -78,6 +78,7 @@ import formWithDeeplyNestedConditionalComps from '../test/forms/formWithDeeplyNe
 import formWithValidation from '../test/forms/formWithValidation';
 import formWithNotAllowedTags from '../test/forms/formWithNotAllowedTags';
 import formWithValidateWhenHidden from '../test/forms/formWithValidateWhenHidden';
+import formWithEditGrid from '../test/forms/formWithEditGrid';
 import formWithSelectRadioUrlDataSource from '../test/forms/selectRadioUrlDataSource';
 const SpySanitize = sinon.spy(FormioUtils, 'sanitize');
 
@@ -372,6 +373,20 @@ describe('Webform tests', function() {
           assert.deepEqual(dataGrid.dataValue, dataGridData);
           done();
       }, 200);
+    }).catch((err) => done(err));
+  });
+
+  it('Should trigger validation for each row of data and edit grid', function(done) {
+    const formElement = document.createElement('div');
+    Formio.createForm(formElement, formWithEditGrid).then((form) => {
+      form.setSubmission({ data: 
+        { dataGrid: [{ textField: '' }, { textField: '' }],
+         editGrid: [{ number: '' }, { number: '' }]} 
+        });
+      setTimeout(() => {
+        assert.equal(form.errors.length, 4);
+        done();
+      }, 500);
     }).catch((err) => done(err));
   });
 

--- a/test/forms/formWithEditGrid.js
+++ b/test/forms/formWithEditGrid.js
@@ -1,0 +1,85 @@
+export default {
+    "title": "formWithEditGrid",
+    "display": "form",
+    "type": "form",
+    "components": [
+      {
+        "label": "Data Grid",
+        "reorder": false,
+        "addAnotherPosition": "bottom",
+        "layoutFixed": false,
+        "enableRowGroups": false,
+        "initEmpty": false,
+        "tableView": false,
+        "defaultValue": [
+          {}
+        ],
+        "validateWhenHidden": false,
+        "key": "dataGrid",
+        "type": "datagrid",
+        "input": true,
+        "components": [
+          {
+            "collapsible": false,
+            "key": "panel",
+            "type": "panel",
+            "label": "Panel",
+            "input": false,
+            "tableView": false,
+            "components": [
+              {
+                "label": "Text Field",
+                "applyMaskOn": "change",
+                "tableView": true,
+                "validateWhenHidden": false,
+                "key": "textField",
+                "type": "textfield",
+                "input": true,
+                "validate": {
+                  "required": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Edit Grid",
+        "tableView": false,
+        "validateWhenHidden": false,
+        "rowDrafts": false,
+        "key": "editGrid",
+        "type": "editgrid",
+        "displayAsTable": false,
+        "input": true,
+        "components": [
+          {
+            "label": "Number",
+            "applyMaskOn": "change",
+            "mask": false,
+            "tableView": false,
+            "delimiter": false,
+            "requireDecimal": false,
+            "inputFormat": "plain",
+            "truncateMultipleSpaces": false,
+            "validate": {
+              "required": true
+            },
+            "validateWhenHidden": false,
+            "key": "number",
+            "type": "number",
+            "input": true
+          }
+        ]
+      },
+      {
+        "label": "Submit",
+        "showValidations": false,
+        "alwaysEnabled": false,
+        "tableView": false,
+        "key": "submit",
+        "type": "button",
+        "input": true
+      }
+    ],
+};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8647
https://formio.atlassian.net/browse/FIO-8721

## Description

Error messages for different rows are the same so they was deleted by _.uniqBy, this pr changes function so it considers not only message but path and id.

## Dependencies

n/a

## How has this PR been tested?

Added test.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
