### PR TITLE
added decimalSymbol and thousandsSeparator to number edit form

### DIFF
--- a/src/components/number/editForm/Number.edit.data.js
+++ b/src/components/number/editForm/Number.edit.data.js
@@ -8,9 +8,36 @@ export default [
     tooltip: 'Separate thousands by local delimiter.'
   },
   {
-    type: 'number',
+    type: "textfield",
     input: true,
     weight: 80,
+    key: "thousandsSeparator",
+    label: "Thousands Separator",
+    conditional: {
+      show: true,
+      conjunction: "all",
+      conditions: [
+        {
+          component: "delimiter",
+          operator: "isEqual",
+          value: true
+        }
+      ]
+    },
+    defaultValue: ","
+  },
+  {
+    type: "textfield",
+    input: true,
+    weight: 90,
+    key: "decimalSymbol",
+    label: "Decimal Symbol",
+    defaultValue: "."
+  },
+  {
+    type: 'number',
+    input: true,
+    weight: 100,
     key: 'decimalLimit',
     label: 'Decimal Places',
     tooltip: 'The maximum number of decimal places.'
@@ -18,7 +45,7 @@ export default [
   {
     type: 'checkbox',
     input: true,
-    weight: 90,
+    weight: 110,
     key: 'requireDecimal',
     label: 'Require Decimal',
     tooltip: 'Always show decimals, even if trailing zeros.'


### PR DESCRIPTION
## Link to Jira Ticket

No ticket

## Description

**What changed?**

Added thousands separator and decimal symbol to number edit form

**Why have you chosen this solution?**

You use to need to manually set these in the edit json. Now you can set them in the edit form

## Dependencies

N/A

## How has this PR been tested?

manually tested

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
