### PR TITLE
FIO-5748 Fixed preview not working correctly after hiding/showing it

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1442,6 +1442,7 @@ export default class WebformBuilder extends Component {
           helplinks: this.helplinks,
         }));
         this.editForm.attach(this.componentEdit.querySelector(`[${this._referenceAttributeName}="editForm"]`));
+        this.updateComponent(this.editForm.submission.data ?? component);
         this.attachEditComponentControls(component, parent, isNew, original, ComponentClass);
       });
     });

--- a/src/components/panel/Panel.js
+++ b/src/components/panel/Panel.js
@@ -24,6 +24,7 @@ export default class PanelComponent extends NestedComponent {
       icon: 'list-alt',
       group: 'layout',
       documentation: '/userguide/form-building/layout-components#panel',
+      showPreview: false,
       weight: 30,
       schema: PanelComponent.schema()
     };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-5748

## Description

Previously, after hiding/showing preview in Component settings modal window, current data of the preview form wasn't persisted/updated after the changes to the Component settings, which is crucial to the behavior of Component preview. Added the code to update the state of the preview each time it is closed/opened.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

Tested locally

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
