### PR TITLE
FIO-8752: coerced keyboard actions to a boolean value

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1045,7 +1045,11 @@ export default class WebformBuilder extends Component {
       this.options.properties = form.properties;
     }
 
-    this.keyboardActionsEnabled = _.get(this.options, 'keyboardBuilder', false) || this.options.properties?.keyboardBuilder;
+    let keyboardActionsEnabled = _.get(this.options, 'keyboardBuilder', false) || this.options.properties?.keyboardBuilder;
+    if (typeof keyboardActionsEnabled === 'string') {
+      keyboardActionsEnabled = keyboardActionsEnabled === 'true';
+    }
+    this.keyboardActionsEnabled = keyboardActionsEnabled;
 
     const isShowSubmitButton = !this.options.noDefaultSubmitButton
       && (!form.components.length || !form.components.find(comp => comp.key === 'submit'));


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8752

## Description

**What changed?**

If the keyboard actions is given as a string then it needs to be coerced to a Boolean value else something like 
`this.options.properties?.keyboardBuilder = 'false'`
might evaluate to true in an expression like
`this.options.properties?.keyboardBuilder ? true : false => true`

## Dependencies

This PR depends on https://github.com/formio/bootstrap/pull/99

## How has this PR been tested?

manually tested

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
