### PR TITLE
FIO-8729: fixed an issue where the rollback to default templates does not work correctly and unknown template message is shown

### DIFF
--- a/src/templates/Templates.js
+++ b/src/templates/Templates.js
@@ -1,5 +1,5 @@
 import templates from './index';
 import { Template } from '@formio/core/experimental';
 Template.addTemplates(templates);
-Template.defaultTemplates = templates.bootstrap;
+Template.defaultTemplates = Template.templates.bootstrap;
 export default Template;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8729

## Description

**What changed?**

We use bootstrap templates as default templates. If someone does not use default framework and the template is missed in the used framework, we make a rollback to the default templates (bootstrap). But when a formio module (like premium, reporting, esignature) is included in the app, the bootstrap templates of those modules are not added to the default templates becouse default templates and bootstrap templates are referred to different objects. For that reason the fallback does not work for modules templates. This PR made it so that default templates refers and bootstrap templates refer to the same object.


## Dependencies

https://github.com/formio/pro.formview.io/pull/118
https://github.com/formio/vpat/pull/183
https://github.com/formio/uswds/pull/252

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
