### PR TITLE
FIO-8684: Fixes cannot attach more than one component to the PDF form

### DIFF
--- a/src/PDF.js
+++ b/src/PDF.js
@@ -76,7 +76,7 @@ export default class PDF extends Webform {
   }
 
   rebuild() {
-    if (this.attached && this.builderMode && this.component.components) {
+    if (this.builderMode && this.component.components) {
       this.destroyComponents();
       this.addComponents();
       return Promise.resolve();


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8684

## Description

**What changed?**

Fixed the issue when PDF form was fully remounted to DOM on every component add. This caused a behavior when iframe ref was lost and only one component could be added to the PDF form.

**Why have you chosen this solution?**

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

Manually. Tried different approaches on writing an automated test for it, but ran into many issues and wasn't been able to complete it.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
