### PR TITLE
Bugfix/submission metadata nullish

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -933,7 +933,6 @@ export default class Webform extends NestedDataComponent {
         if (!submission || !submission.data) {
             submission = {
                 data: {},
-                metadata: submission.metadata,
             };
         }
         // Metadata needs to be available before setValue


### PR DESCRIPTION
https://formio.atlassian.net/browse/FIO-8801

resolves #5724 

## Link to Jira Ticket

n/a

## Description

If a nullish submission value is passed to Webform#setValue, it will no longer try to set the metadata property with the nullish value's metadata property.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Tests pass, submission payloads still include metadata

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
