### PR TITLE
Bugfix: fix runtime error in setForm when passing string argument to Formio.builder

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -286,7 +286,7 @@ export default class Form extends Element {
 
   /**
    * Sets the form to the JSON schema of a form.
-   * @param {import('@formio/core').Form} formParam - The form JSON to set this form to.
+   * @param {import('@formio/core').Form | string} formParam - The form JSON to set this form to.
    * @returns {Promise<Webform|Wizard|PDF>} - The webform instance that was created.
    */
   setForm(formParam) {
@@ -313,8 +313,15 @@ export default class Form extends Element {
               }
               this.loading = false;
               this.instance = this.instance || this.create(form.display);
-              const options = this.getFormInitOptions(formParam, form);
-              this.instance.setUrl(formParam, options);
+
+              // If we're in builder mode, instance.setUrl is not a function, so just manually set the URL.
+              if (this.instance.setUrl) {
+                const options = this.getFormInitOptions(formParam, form);
+                this.instance.setUrl(formParam, options);
+              } else {
+                this.instance.url = formParam;
+              }
+              
               this.instance.nosubmit = false;
               this._form = this.instance.form = form;
               if (submission) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8809

## Description

`setUrl` is a Webform method, so it won't exist when rendering a builder with a string form argument (e.g. `Formio.builder(element, 'https://examples.form.io/example');` and will result in a runtime error.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
