### PR TITLE
Explicitly sets type to commonjs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "formiojs",
   "version": "4.19.5",
   "description": "JavaScript powered Forms with JSON Form Builder",
-  "main": "./dist/formio.full.min.js",
+  "type": "commonjs",
+  "main": "index.js",
   "types": "index.d.ts",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "formiojs",
   "version": "4.19.5",
   "description": "JavaScript powered Forms with JSON Form Builder",
+  "type": "commonjs",
   "main": "index.js",
   "types": "index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "formiojs",
   "version": "4.19.5",
   "description": "JavaScript powered Forms with JSON Form Builder",
-  "type": "commonjs",
-  "main": "index.js",
+  "main": "./dist/formio.full.min.js",
   "types": "index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
This PR explicitly sets type to commonjs in package.json. This makes sure that bundlers such as Vite recongnize that this dependency only supports commonjs format