### PR TITLE
FIO-8797: set empty day component value to the empty string

### DIFF
--- a/src/WebformBuilder.unit.js
+++ b/src/WebformBuilder.unit.js
@@ -252,7 +252,7 @@ describe('WebformBuilder tests', function() {
             done();
           }, 200);
         }, 200);
-      }, 150);
+      }, 300);
     }).catch(done);
   });
 

--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -69,10 +69,10 @@ export default class DayComponent extends Field {
 
   /**
    * The empty value for day component.
-   * @returns {'00/00/0000'} - The empty value of the day component.
+   * @returns {''} - The empty value of the day component.
    */
   get emptyValue() {
-    return '00/00/0000';
+    return '';
   }
 
   get valueMask() {
@@ -413,7 +413,7 @@ export default class DayComponent extends Field {
   setValueAt(index, value) {
     // temporary solution to avoid input reset
     // on invalid date.
-    if (!value || value === 'Invalid date') {
+    if (value === 'Invalid date') {
       return null;
     }
     const parts = value.split('/');

--- a/src/components/day/Day.unit.js
+++ b/src/components/day/Day.unit.js
@@ -24,6 +24,17 @@ describe('Day Component', () => {
     });
   });
 
+  it('Should handle blank data correctly', (done) => {
+    Harness.testCreate(DayComponent, comp1).then((component) => {
+      component.setValue();
+      assert.equal(component.getValue(), '');
+      component.checkValidity();
+      assert.equal(component.errors.length, 0, 'Component should be valid with blank data');
+
+      done();
+    });
+  });
+
   it('Should change the max day when the month changes', (done) => {
     Harness.testCreate(DayComponent, comp1).then((component) => {
       Harness.testElements(component, 'option', 13);
@@ -286,7 +297,7 @@ describe('Day Component', () => {
     })
   });
 
-  it('Should translate requiredDayField to {{ field }} is required', (done) => {
+  it('Should translate requiredDayEmpty to {{ field }} is required', (done) => {
     Formio.createForm(document.createElement('div'), comp8, {}).then((form) => {
       const dayComponent = form.getComponent('dayTable');
       const buttonComponent = form.getComponent('submit');

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -75,6 +75,7 @@ export default {
   typeRemaining: '{{ remaining }} {{ type }} remaining.',
   typeCount: '{{ count }} {{ type }}',
   requiredDayField: '{{ field }} is required',
+  requiredDayEmpty: '{{ field }} is required',
   requiredMonthField: '{{ field }} is required',
   requiredYearField: '{{ field }} is required'
 };

--- a/test/renders/component-bootstrap-day-html-value0.html
+++ b/test/renders/component-bootstrap-day-html-value0.html
@@ -2,6 +2,6 @@
   <label ref="label" class="col-form-label " for="day-day" id="l-day-day">
     Day
   </label>
-  <div ref="value">00/00/0000</div>
+  <div ref="value">-</div>
   <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
 </div>


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8797

## Description

The empty value for the day component has been changed from '00/00/0000' to empty string ('').
The changes were made because the previous empty day value violated the logic of the form actions.

## Breaking Changes / Backwards Compatibility

The empty value for the day component has been changed from '00/00/0000' to empty string ('').

## How has this PR been tested?
auto tests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
