### PR TITLE
FIO-7524 Added back aspect ratio option to Signature

### DIFF
--- a/src/components/signature/editForm/Signature.edit.display.js
+++ b/src/components/signature/editForm/Signature.edit.display.js
@@ -37,7 +37,6 @@ export default [
     label: 'Keep Overlay Aspect Ratio',
     tooltip: 'If checked, the field will have the same aspect ratio as its preview.',
     key: 'keepOverlayRatio',
-    customConditional: ({ options }) => (options?.editForm?.display === 'pdf'),
     input: true
   },
   {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7524

## Description

Returned aspect ratio option to Signature so the Signature field size can be configured manually.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

Tested locally.

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
