### PR TITLE
FIO-8874: fixed conditional value field for time component

### DIFF
--- a/src/components/time/Time.js
+++ b/src/components/time/Time.js
@@ -16,18 +16,6 @@ export default class TimeComponent extends TextFieldComponent {
     }, ...extend);
   }
 
-  static get serverConditionSettings() {
-    return {
-      ...super.serverConditionSettings,
-      valueComponent(classComp) {
-        return {
-          ...classComp,
-          type: 'time',
-        };
-      },
-    };
-  }
-
   constructor(component, options, data) {
     super(component, options, data);
     const { edge: isEdgeBrowser, version: edgeVersion } = getBrowserInfo();


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8874

## Description

**What changed?**

Before time field was used a value field for time component in the simple conditional UI. But time field has required input mask and does not allow to enter partial time value. I have changed it so that textfield is used as a value field in condition with time.

## Dependencies

https://github.com/formio/premium/pull/323
https://github.com/formio/formio/pull/1788

## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
