### PR TITLE
[4.x] FIO-8660: Fixed email component re-rendering with unique setting option

### DIFF
--- a/src/validator/Validator.js
+++ b/src/validator/Validator.js
@@ -989,6 +989,7 @@ class ValidationChecker {
     }
   }
 
+  // eslint-disable-next-line max-statements
   checkComponent(component, data, row, includeWarnings = false, async = false) {
     const isServerSidePersistent = typeof process !== 'undefined'
       && _.get(process, 'release.name') === 'node'
@@ -1107,8 +1108,11 @@ class ValidationChecker {
 
     // Run the "unique" pseudo-validator
     component.component.validate = component.component.validate || {};
+    const originalUnique = component.component.validate.unique;
     component.component.validate.unique = component.component.unique;
     resultsOrPromises.push(this.validate(component, 'unique', component.validationValue, data, 0, data, async, conditionallyVisible));
+    // restore the original value to prevent component re-rendering
+    component.component.validate.unique = originalUnique;
 
     // Run the "multiple" pseudo-validator
     component.component.validate.multiple = component.component.multiple;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8660

## Description

**Note:** The issue is not reproducible on the 5.x version of the renderer because the 5.x renderer uses the core validator. However, as decided, the fix should be added to the 4.x renderer as well.

**Issue:** When the component has the `unique` setting, it causes the validator [to assign](https://github.com/formio/formio.js/blob/v4.21.0/src/validator/Validator.js#L1110) a `unique` value to the `validate` object of the component before running the `checkValidity` method. On the next change, the component [will check](https://github.com/formio/formio.js/blob/v4.21.0/src/components/_classes/component/Component.js#L1924) both the current and original components and will find a unique change, triggering a redraw of the component. This redraw attaches the default validate object and the validator reassigns the `validate.unique` value. This cycle repeats with every change of the component. The issue is reproducible for the email component because, before the redraw, we save the cursor position using `HTMLInputElement.selectionStart`. According to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/selectionStart), this property is not available for inputs with the email type, which causes the cursor to always move to the beginning of the input after redrawing.

**Solution:** Save the original `unique` setting value and restore it after validation. This prevents the component with the `unique` setting from re-rendering on every change.
## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
