### PR TITLE
FIO-7779: update pathing for nested container components and add test

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "fetch-ponyfill": "^7.1.0",
     "i18next": "22.4.12",
     "idb": "^7.1.1",
-    "inputmask": "^5.0.8",
+    "inputmask": "5.0.8",
     "ismobilejs": "^1.1.1",
     "json-logic-js": "^2.0.2",
     "jstimezonedetect": "^1.0.7",

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -298,7 +298,11 @@ export default class NestedComponent extends Field {
       while (thisPath && !thisPath.allowData && thisPath.parent) {
         thisPath = thisPath.parent;
       }
-      const rowIndex = component.row ? `[${Number.parseInt(component.row)}]` : '';
+      // any component that is nested in e.g. a Data Grid or an Edit Grid is going to receive a row prop; the problem
+      // is that options.row is passed to each further nested component, which results in erroneous paths like
+      // `editGrid[0].container[0].textField` rather than `editGrid[0].container.textField`. This should be adapted for other
+      // components with a tree-like data model
+      const rowIndex = component.row && !['container'].includes(thisPath.component.type) ? `[${Number.parseInt(component.row)}]` : '';
       path = thisPath.path ? `${thisPath.path}${rowIndex}.` : '';
       path += component._parentPath && component.component.shouldIncludeSubFormPath ? component._parentPath : '';
       path += component.component.key;

--- a/src/components/container/Container.unit.js
+++ b/src/components/container/Container.unit.js
@@ -8,6 +8,7 @@ import {
   comp2,
   comp3,
   comp4,
+  editGridWithChildContainer
 } from './fixtures';
 
 import Formio from '../../Formio';
@@ -96,5 +97,33 @@ describe('Container Component', () => {
         done();
       }, 200);
     }).catch(done);
+  });
+
+  it('Should not include an array index in any child component paths when child of a nested component', async() => {
+    const form = _.cloneDeep(editGridWithChildContainer);
+    const element = document.createElement('div');
+
+    const formInstance = await Formio.createForm(element, form);
+    formInstance.submission = {
+      data: {
+        editGrid: [
+          {
+            container: {
+              textField: 'a',
+            },
+          },
+        ],
+      },
+    };
+    await formInstance.submissionReady;
+    const editGrid = formInstance.getComponent(['editGrid']);
+    assert(editGrid, 'EditGrid component found');
+    assert.strictEqual(editGrid.path, 'editGrid');
+    const container = formInstance.getComponent('container');
+    assert(container, 'Container component found');
+    assert.strictEqual(container.path, 'editGrid[0].container');
+    const textField = formInstance.getComponent('textField');
+    assert(textField, 'TextField component found');
+    assert.strictEqual(textField.path, 'editGrid[0].container.textField');
   });
 });

--- a/src/components/container/fixtures/editGridWithChildContainer.js
+++ b/src/components/container/fixtures/editGridWithChildContainer.js
@@ -1,0 +1,48 @@
+export default {
+  title: 'Edit Grid With Child Container',
+  name: 'editGridWithChildContainer',
+  path: 'editgridwithchildcontainer',
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      label: 'Edit Grid',
+      tableView: false,
+      validateWhenHidden: false,
+      rowDrafts: false,
+      key: 'editGrid',
+      type: 'editgrid',
+      displayAsTable: false,
+      input: true,
+      components: [
+        {
+          label: 'Container',
+          tableView: false,
+          validateWhenHidden: false,
+          key: 'container',
+          type: 'container',
+          input: true,
+          components: [
+            {
+              label: 'Text Field',
+              applyMaskOn: 'change',
+              tableView: true,
+              validateWhenHidden: false,
+              key: 'textField',
+              type: 'textfield',
+              input: true,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+};

--- a/src/components/container/fixtures/index.js
+++ b/src/components/container/fixtures/index.js
@@ -1,4 +1,7 @@
-export comp1 from './comp1';
-export comp2 from './comp2';
-export comp3 from './comp3';
-export comp4 from './comp4';
+import comp1 from './comp1';
+import comp2 from './comp2';
+import comp3 from './comp3';
+import comp4 from './comp4';
+import editGridWithChildContainer from './editGridWithChildContainer';
+
+export { comp1, comp2, comp3, comp4, editGridWithChildContainer };

--- a/src/components/textfield/TextField.unit.js
+++ b/src/components/textfield/TextField.unit.js
@@ -835,7 +835,7 @@ describe('TextField Component', () => {
             if (_.isEqual(value, lastValue)) {
               done();
             }
-          }, 500);
+          }, 700);
         }).catch(done);
       });
     };

--- a/src/components/textfield/TextField.unit.js
+++ b/src/components/textfield/TextField.unit.js
@@ -364,13 +364,13 @@ describe('TextField Component', () => {
             if (_.isEqual(value, lastValue)) {
               done();
             }
-          }, 300);
+          }, 500);
         }).catch(done);
       });
     };
 
     testValidity(validValues, true);
-    testValidity(invalidValues, false, invalidValues[invalidValues.length-1]);
+    testValidity(invalidValues, false, invalidValues[invalidValues.length - 1]);
   });
 
   it('Should allow inputing only numbers and format input according to input mask', (done) => {

--- a/src/components/textfield/TextField.unit.js
+++ b/src/components/textfield/TextField.unit.js
@@ -835,7 +835,7 @@ describe('TextField Component', () => {
             if (_.isEqual(value, lastValue)) {
               done();
             }
-          }, 300);
+          }, 500);
         }).catch(done);
       });
     };

--- a/src/components/textfield/TextField.unit.js
+++ b/src/components/textfield/TextField.unit.js
@@ -364,13 +364,13 @@ describe('TextField Component', () => {
             if (_.isEqual(value, lastValue)) {
               done();
             }
-          }, 500);
+          }, 300);
         }).catch(done);
       });
     };
 
     testValidity(validValues, true);
-    testValidity(invalidValues, false, invalidValues[invalidValues.length - 1]);
+    testValidity(invalidValues, false, invalidValues[invalidValues.length-1]);
   });
 
   it('Should allow inputing only numbers and format input according to input mask', (done) => {
@@ -835,7 +835,7 @@ describe('TextField Component', () => {
             if (_.isEqual(value, lastValue)) {
               done();
             }
-          }, 700);
+          }, 300);
         }).catch(done);
       });
     };

--- a/src/components/textfield/TextField.unit.js
+++ b/src/components/textfield/TextField.unit.js
@@ -364,13 +364,13 @@ describe('TextField Component', () => {
             if (_.isEqual(value, lastValue)) {
               done();
             }
-          }, 300);
+          }, 500);
         }).catch(done);
       });
     };
 
     testValidity(validValues, true);
-    testValidity(invalidValues, false, invalidValues[invalidValues.length-1]);
+    testValidity(invalidValues, false, invalidValues[invalidValues.length - 1]);
   });
 
   it('Should allow inputing only numbers and format input according to input mask', (done) => {
@@ -835,7 +835,7 @@ describe('TextField Component', () => {
             if (_.isEqual(value, lastValue)) {
               done();
             }
-          }, 300);
+          }, 700);
         }).catch(done);
       });
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5302,7 +5302,7 @@ ini@^1.3.4:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-inputmask@^5.0.8:
+inputmask@5.0.8:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/inputmask/-/inputmask-5.0.8.tgz#cd0f70b058c3291a0d4f27de25dbfc179c998bb4"
   integrity sha512-1WcbyudPTXP1B28ozWWyFa6QRIUG4KiLoyR6LFHlpT4OfTzRqFfWgHFadNvRuMN1S9XNVz9CdNvCGjJi+uAMqQ==


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7779

## Description

**What changed?**

When a nested component is created, the parent's options are passed down with it. For example, an edit grid component that contains a child container component will have a `options.row` parameter passed down and added to the child container component. This causes a problem with pathing - we previously didn't account for container components and naively added a row index to the pathing parameter (via the function `calculateComponentPath`) if the component had a row parameter. This means that the path for any resulting child components of the container would be pathed as 

```editGrid[0].container[0].textField```

rather than

```editGrid[0].container.textField```.

This PR updates the `calculateComponentPath` function to account for container components.

This pathing behavior has been overhauled in the 5.x version of the renderer, so this should be thought of as exclusively a 4.x patch.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Manually, and added an automated test for the root cause

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
