### PR TITLE
FIO-8921: fixed an issue where newly created PDF-form cannot be saved in builder after adding some components in it

### DIFF
--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -478,7 +478,7 @@ export default class PDFBuilder extends WebformBuilder {
     }
 
     // Set a unique key for this component.
-    BuilderUtils.uniquify([this.webform._form], schema);
+    BuilderUtils.uniquify(this.webform._form?.components || [], schema);
     this.webform._form.components.push(schema);
 
     schema.overlay = {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8921

## Description

**What changed?**

When any component is dropped in the new PDF form (not saved), we uniquify the component API key. The uniquify method calls eachComponent function inside that assigns the **not enumerable** 'path' property to each component. 
Before, in pdf builder, we passed the array with a form as a first arg to the uniquify method and the eachComponent method made the form 'path' property not enumerable. That means that 'path' property can not be copied or spread like { ... form}. So, on saveForm, the server got the form without path and returned the validation error. This PR passes form components (this is what the uniquify method expects) as an arg for the uniquify method.

## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
