### PR TITLE
FIO-8914: fixed an issue where errors list doesnot appear when submitting a PDF form

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1431,10 +1431,14 @@ export default class Webform extends NestedDataComponent {
         this.checkData(value.data, flags);
         const shouldValidate =
             !flags.noValidate ||
-            flags.fromIFrame ||
+            flags.fromIframe ||
             (flags.fromSubmission && this.rootPristine && this.pristine && flags.changed);
         const errors = shouldValidate
-            ? this.validate(value.data, { ...flags, process: "change" })
+            ? this.validate(value.data, { 
+                ...flags, 
+                noValidate: flags.fromIframe && this.submitted ? false : flags.noValidate, 
+                process: 'change'
+            })
             : [];
         value.isValid = errors.length === 0;
 

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1436,7 +1436,7 @@ export default class Webform extends NestedDataComponent {
         const errors = shouldValidate
             ? this.validate(value.data, { 
                 ...flags, 
-                noValidate: flags.fromIframe && this.submitted ? false : flags.noValidate, 
+                noValidate: false, 
                 process: 'change'
             })
             : [];

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -3452,7 +3452,7 @@ export default class Component extends Element {
             this.parent.childErrors.push(...errors);
           }
           else {
-            _.remove(this.parent.childErrors, (err) => err.component.key === this.component.key);
+            _.remove(this.parent.childErrors, (err) => (err?.component?.key || err?.context?.key) === this.component.key);
           }
         }
         this.showValidationErrors(errors, data, row, flags);
@@ -3468,7 +3468,7 @@ export default class Component extends Element {
           this.parent.childErrors.push(...errors);
         }
         else {
-          _.remove(this.parent.childErrors, (err) => err.component.key === this.component.key);
+          _.remove(this.parent.childErrors, (err) => (err?.component?.key || err?.context?.key) === this.component.key);
         }
       }
       return errors.length === 0;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8914

## Description

**What changed?**

We should always validate the submission that comes from the iframe, when the form  is submitted, to control the validation errors (add/remove them from the errors list).
Also this PR fixes the portal console error when editing the form with errors list as not all errors have component prop.

## How has this PR been tested?

Manually with PDF forms

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
