### PR TITLE
FIO-8423 Fixed duplicating HTML when using 'p' tag

### DIFF
--- a/src/components/html/HTML.js
+++ b/src/components/html/HTML.js
@@ -101,8 +101,8 @@ export default class HTMLComponent extends Component {
   attach(element) {
     this.loadRefs(element, { html: 'single' });
     this.dataReady.then(() => {
-      if (this.refs.html) {
-        this.setContent(this.refs.html, this.content);
+      if (this.element) {
+        this.setContent(this.element, this.renderContent());
       }
     });
     return super.attach(element);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8423

## Description

Changed the way content was set after attach, due to the way innerHTML function interacts with 'p' tag if it contains other HTML tags inside.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

Tested locally

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
