### PR TITLE
FIO-8914: fixed an issue where select url does not work properly when url value has whitespaces at the end

### DIFF
--- a/src/components/_classes/list/ListComponent.js
+++ b/src/components/_classes/list/ListComponent.js
@@ -192,6 +192,7 @@ export default class ListComponent extends Field {
           return;
         }
         let { url } = this.component.data;
+        url = _.trim(url);
         let method;
         let body;
         if (url.startsWith('/')) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8914

## Description

**What changed?**

need to trim url that comes from the component settings before to add query parameters to it, so that url works as expected.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
