### PR TITLE
FIO-8900-8899: made only 2 operators available for address component in conditionals ui and fixed setting an empty value for address

### DIFF
--- a/src/components/address/Address.js
+++ b/src/components/address/Address.js
@@ -100,6 +100,17 @@ export default class AddressComponent extends ContainerComponent {
     };
   }
 
+  static get serverConditionSettings() {
+    return AddressComponent.conditionOperatorsSettings;
+  }
+
+  static get conditionOperatorsSettings() {
+    return {
+      ...super.conditionOperatorsSettings,
+      operators: ['isEmpty', 'isNotEmpty'],
+    };
+  }
+
   mergeSchema(component = {}) {
     let { defaultSchema } = this;
 
@@ -222,7 +233,7 @@ export default class AddressComponent extends ContainerComponent {
   }
 
   set address(value) {
-    if (this.manualModeEnabled && !this.isMultiple) {
+    if (this.manualModeEnabled && !this.isMultiple && !_.isEqual(value, this.emptyValue)) {
       this.dataValue.address = value;
     }
     else {

--- a/src/components/address/Address.unit.js
+++ b/src/components/address/Address.unit.js
@@ -31,6 +31,7 @@ describe('Address Component', () => {
 
       setTimeout(() => {
         assert.equal(address.refs.searchInput[0].value, '');
+        assert.deepEqual(address.dataValue, address.emptyValue);
 
         document.innerHTML = '';
         done();


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8900
https://formio.atlassian.net/browse/FIO-8899

## Description

**What changed?**

- made only isEmpty and isNotEmpty operators available in simple conditionals for address component
- fixed an issue where address empty value set inside 'address' property of the dataValue that causes the isEmpty method to return false even when the value is empty.

## Dependencies

https://github.com/formio/formio/pull/1793
https://github.com/formio/premium/pull/328

## How has this PR been tested?

manually + test

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
