### PR TITLE
FIO-8423: change default parent tag from p to div

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+
       - name: Installing dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         uses: borales/actions-yarn@v4
@@ -40,6 +41,11 @@ jobs:
         uses: borales/actions-yarn@v4
         with:
           cmd: lint
+
+      - name: dependencies
+        run: |
+          echo "Installing dependencies"
+          yarn list --depth=0
 
   ##################################################################
   ## Build
@@ -109,7 +115,7 @@ jobs:
           else
             echo "Merge successful."
           fi
-      
+
       - name: Set up Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
@@ -175,17 +181,17 @@ jobs:
           # Extract the pull request number and the short SHA of the commit
           PR_NUMBER=$(echo ${{ github.event.number }})
           COMMIT_SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
-          
+
           # Extract the current version from package.json
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          
+
           # If the current version includes '-rc.', remove it and everything after
           # This step ensures that we start with a base version like '3.0.0' even if it was a release candidate
           BASE_VERSION=$(echo "$CURRENT_VERSION" | cut -d'-' -f1)
-          
+
           # Construct the new version string
           NEW_VERSION="${BASE_VERSION}-dev.${PR_NUMBER}.${COMMIT_SHORT_SHA}"
-          
+
           # Output the new version for use in subsequent GitHub Actions steps
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 

--- a/src/components/html/HTML.js
+++ b/src/components/html/HTML.js
@@ -6,7 +6,7 @@ export default class HTMLComponent extends Component {
     return Component.schema({
       label: 'HTML',
       type: 'htmlelement',
-      tag: 'p',
+      tag: 'div',
       attrs: [],
       content: '',
       input: false,

--- a/test/renders/component-bootstrap-htmlelement-multiple.html
+++ b/test/renders/component-bootstrap-htmlelement-multiple.html
@@ -1,4 +1,4 @@
 <div id="" class="formio-component formio-component-htmlelement formio-component-multiple " ref="component">
-  <p class="formio-component-htmlelement " ref="html"></p>
+  <div class="formio-component-htmlelement " ref="html"></div>
   <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
 </div>

--- a/test/renders/component-bootstrap-htmlelement-readOnly.html
+++ b/test/renders/component-bootstrap-htmlelement-readOnly.html
@@ -1,4 +1,4 @@
 <div id="" class="formio-component formio-component-htmlelement " ref="component">
-  <p class="formio-component-htmlelement " ref="html"></p>
+  <div class="formio-component-htmlelement " ref="html"></div>
   <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
 </div>

--- a/test/renders/component-bootstrap-htmlelement-required.html
+++ b/test/renders/component-bootstrap-htmlelement-required.html
@@ -1,4 +1,4 @@
 <div id="" class="formio-component formio-component-htmlelement " ref="component">
-  <p class="formio-component-htmlelement " ref="html"></p>
+  <div class="formio-component-htmlelement " ref="html"></div>
   <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
 </div>

--- a/test/renders/component-bootstrap-htmlelement.html
+++ b/test/renders/component-bootstrap-htmlelement.html
@@ -1,4 +1,4 @@
 <div id="" class="formio-component formio-component-htmlelement " ref="component">
-  <p class="formio-component-htmlelement " ref="html"></p>
+  <div class="formio-component-htmlelement " ref="html"></div>
   <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
 </div>


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8423

## Description

The default parent tag for the HTML Component is `<p />`. However, the HTML spec [doesn't allow block-level elements](https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element) within a `<p />` tag, resulting in the browser closing the tag and the component's content, on first render, being rendered as a sibling (in other words, outside of the element's formio reference). 

After discussion, we decided that opting into the HTML Component means taking responsibility for valid HTML. I've changed the default parent tag to `<div />` for forms going forward, but this will be a 5.x change only (see below for backwards compatibility issues).

## Breaking Changes / Backwards Compatibility

Since we don't store the parent tag in the database (in other words, the previous default of `<p />` would change to `<div />` for every customer form), this is technically a breaking change that needs to be documented in the 5.x changelog. 

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
