### PR TITLE
FIO-8990: fixed incorrect moment export

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -31,9 +31,7 @@ jsonLogic.add_operation('relativeMaxDate', (relativeMaxDate) => {
   return moment().add(relativeMaxDate, 'days').toISOString();
 });
 
-export { jsonLogic, ConditionOperators };
-export * as moment from 'moment-timezone/moment-timezone';
-
+export { jsonLogic, ConditionOperators, moment };
 /**
  * Sets the path to the component and parent schema.
  * @param {import('@formio/core').Component} component - The component to set the path for.


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8990

## Description

**What changed?**

We exported the moment lib from utils like this: 
_export * as moment from 'moment-timezone/moment-timezone'._
The asterisk imports ALL exports from the package and the default export (that is the main moment instance) is available only when calling Utils.moment.default('someDate'). But the reporting module (maybe also some other our libraries ) expects that moment instance is available directly from Utils (Utils.moment('someDate')) like it was before (in 4.x).
This PR exports the moment library that was imported on the top of the file like:
_import moment from 'moment-timezone/moment-timezone';_
This type of import imports only default export and the moment instance becomes available directly from the Utils.


## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
