### PR TITLE
FIO-8938 fixed label display for multiple select with dataSrc resource

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -302,7 +302,8 @@ export default class SelectComponent extends ListComponent {
       return this.sanitize(value, this.shouldSanitizeValue);
     }
 
-    if (this.component.multiple && _.isArray(this.dataValue) ? this.dataValue.find((val) => value === val) : (this.dataValue === value)) {
+    if (this.component.multiple
+      && _.isArray(this.dataValue) ? this.dataValue.find((val) => this.normalizeSingleValue(value) === val) : (this.dataValue === value)) {
       const selectData = this.selectData;
       if (selectData) {
         const templateValue = this.component.reference && value?._id ? value._id.toString() : value;

--- a/src/components/select/Select.unit.js
+++ b/src/components/select/Select.unit.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-statements */
 import assert from 'power-assert';
 import cloneDeep from 'lodash/cloneDeep';
+import set from 'lodash/set'
 import sinon from 'sinon';
 import Harness from '../../../test/harness';
 import SelectComponent from './Select';
@@ -1218,6 +1219,46 @@ describe('Select Component', () => {
     });
   });
 
+  
+  it('Should render label for multiple Select when Data Source is Resource in read only mode', (done) => {
+    const element = document.createElement('div');
+    const form = cloneDeep(comp24);
+    set(form, 'components[0].multiple', true);
+    Formio.createForm(element, form, { readOnly: true }).then((form) => {
+      form.setSubmission({
+        metadata: {
+          selectData: {
+            select: {
+              1: {
+                data: {
+                  textField1: 'One'
+                }
+              },
+              olivia: {
+                data: {
+                  textField1: 'Olivia Miller'
+                }
+              }
+            },
+          },
+        },
+        data: {
+          select: [1, 'olivia'],
+          submit: true,
+        },
+        state: 'submitted',
+      });
+
+      setTimeout(() => {
+        const select = form.getComponent('select');
+        const selectedItems = select.element.querySelectorAll('[aria-selected="true"] span');
+        assert.equal(selectedItems[0].innerHTML, 'One', 'Should show correct label for numeric values');
+        assert.equal(selectedItems[1].innerHTML, 'Olivia Miller', 'Should show correct label for string values');;
+        done();
+      }, 700);
+    })
+    .catch((err) => done(err));
+  });
   // it('should reset input value when called with empty value', () => {
   //   const comp = Object.assign({}, comp1);
   //   delete comp.placeholder;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8938

## Description

*Previously  the label of an item of a multiple Select component with dataSrc as resource could be displayed as undefined if the item value has type number or boolean. It has been fixed by adding normalizeSingleValue method*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated tests have been added. All test pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
