### PR TITLE
FIO-8962 Fixed screen shifting when validation errors pop up in an em…

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -818,7 +818,7 @@ export default class Wizard extends Webform {
     }
     else {
       this.currentPage.components.forEach((comp) => comp.setPristine(false));
-      this.scrollIntoView(this.element);
+      this.scrollIntoView(this.element, true);
       return Promise.reject(this.showErrors(errors, true));
     }
   }

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -3938,12 +3938,12 @@ export default class Component extends Element {
     }
   }
 
-  scrollIntoView(element = this.element) {
+  scrollIntoView(element = this.element, verticalOnly) {
     if (!element) {
       return;
     }
     const { left, top } = element.getBoundingClientRect();
-    window.scrollTo(left + window.scrollX, top + window.scrollY);
+    window.scrollTo(verticalOnly ? window.scrollX : left + window.scrollX, top + window.scrollY);
   }
 
   focus(index) {


### PR DESCRIPTION
…bedded Wizard form

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8962

## Description

Previously, scrollIntoView function was triggered on failed validation in Wizard forms, and the scroll was performed by X axis as well as Y, which created issues in the case of Wizard form being embedded. It was changed so that the form is scrolled into view only by Y axis, so there is no layout shifts.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

Tested locally. Unable to add tests due to the fact JSDOM doesn't support scroll functions. scrollTop property is always 0.

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
