### PR TITLE
FIO-9010 fixed disappearance of components inside Columns after editing

### DIFF
--- a/src/components/_classes/multivalue/Multivalue.js
+++ b/src/components/_classes/multivalue/Multivalue.js
@@ -32,6 +32,9 @@ export default class Multivalue extends Field {
         if (this.component.storeas === 'string') {
           return super.normalizeValue(value.join(this.delimiter || ''), flags);
         }
+        if (this.component.type === 'hidden' && value.length > 1) {
+          return super.normalizeValue(value, flags);
+        }
         return super.normalizeValue(value[0] || emptyValue, flags);
       } else {
         return super.normalizeValue(value, flags);

--- a/src/components/hidden/Hidden.unit.js
+++ b/src/components/hidden/Hidden.unit.js
@@ -29,4 +29,16 @@ describe('Hidden Component', () => {
       assert(component.checkValidity(), 'Item should be valid after setting value');
     });
   });
+
+  it('Should set correct array data for Hidden component', () => {
+    return Harness.testCreate(HiddenComponent, comp1).then((component) => {
+      const value = [
+        [ 1, 2, 3],
+        ['a','b','c']
+      ]
+      component.setValue(value);
+      assert(Array.isArray(component.dataValue), 'Value should be an Array');
+      assert.deepEqual(component.dataValue, value, 'Value should be be equal to the set value');
+    });
+  });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9010

## Description

*The root of the issue with disappearance components inside the Column component is the incorrect setting of the value for the Hidden component. Previously, if the value of the Hidden Component was an array with nested arrays inside, then after normalization of the value, the first element of the array became the value. This was fixed by an additional check in the normalizeValue method*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated tests have been added. All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
