### PR TITLE
FIO-9010: tighten up multivalue normalization by covering 'any' type models

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -3029,9 +3029,6 @@ export default class Component extends Element {
    * @returns {*} - The normalized value.
    */
   normalizeValue(value) {
-    if (this.component.multiple && !Array.isArray(value)) {
-      value = value ? [value] : [];
-    }
     return value;
   }
 

--- a/src/components/_classes/multivalue/Multivalue.js
+++ b/src/components/_classes/multivalue/Multivalue.js
@@ -29,11 +29,11 @@ export default class Multivalue extends Field {
       }
     } else {
       if (Array.isArray(value) && !underlyingValueShouldBeArray) {
+        if (Utils.getModelType(this.component) === 'any') {
+          return super.normalizeValue(value, flags);
+        }
         if (this.component.storeas === 'string') {
           return super.normalizeValue(value.join(this.delimiter || ''), flags);
-        }
-        if (this.component.type === 'hidden' && value.length > 1) {
-          return super.normalizeValue(value, flags);
         }
         return super.normalizeValue(value[0] || emptyValue, flags);
       } else {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9010

## Description

This PR further utilizes @formio/core's model types to cover the case of "any" - so hidden components, custom components, and anything else with an unknown data model type at runtime. It also removes redundant `multiple` normalization from the base Component class.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

The tests written for the original solution pass!

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
