### PR TITLE
FIO-8234/FIO-7195: Fixes an issue where value properties are shown instead of labels for Select component with Resource/URL data sources in read only mode and for modal preview

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -279,7 +279,6 @@ export default class SelectComponent extends ListComponent {
 
   selectValueAndLabel(data) {
     const value = this.getOptionValue((this.isEntireObjectDisplay() && !this.itemValue(data)) ? data : this.itemValue(data));
-    // const templateData = this.options.readOnly && (this.isSelectResource || this.isSelectURL) && this.selectData ? this.selectData : data;
     return {
       value,
       label: this.itemTemplate((this.isEntireObjectDisplay() && !_.isObject(data.data)) ? { data: data } : data, value)

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -302,15 +302,7 @@ export default class SelectComponent extends ListComponent {
       return this.sanitize(value, this.shouldSanitizeValue);
     }
 
-<<<<<<< Updated upstream
-    if (this.component.multiple
-      && _.isArray(this.dataValue) ? this.dataValue.find((val) => this.normalizeSingleValue(value) === val) : (this.dataValue === value)) {
-=======
-    const dataValue = this.undoValueTyping(this.dataValue);
-    const untypedValue = this.undoValueTyping(value);
-
-    if (this.component.multiple && _.isArray(dataValue) ? dataValue.find((val) => untypedValue === val) : (dataValue === untypedValue)) {
->>>>>>> Stashed changes
+    if (this.component.multiple && _.isArray(this.dataValue) ? this.dataValue.find((val) => this.normalizeSingleValue(value) === val) : (this.dataValue === this.normalizeSingleValue(value))) {
       const selectData = this.selectData;
       if (selectData) {
         const templateValue = this.component.reference && value?._id ? value._id.toString() : value;

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -279,10 +279,10 @@ export default class SelectComponent extends ListComponent {
 
   selectValueAndLabel(data) {
     const value = this.getOptionValue((this.isEntireObjectDisplay() && !this.itemValue(data)) ? data : this.itemValue(data));
-    const readOnlyResourceLabelData = this.options.readOnly && (this.component.dataSrc === 'resource' || this.component.dataSrc === 'url') && this.selectData;
+    // const templateData = this.options.readOnly && (this.isSelectResource || this.isSelectURL) && this.selectData ? this.selectData : data;
     return {
       value,
-      label: this.itemTemplate((this.isEntireObjectDisplay() && !_.isObject(data.data)) ? { data: data } : readOnlyResourceLabelData || data, value)
+      label: this.itemTemplate((this.isEntireObjectDisplay() && !_.isObject(data.data)) ? { data: data } : data, value)
     };
   }
 
@@ -302,8 +302,15 @@ export default class SelectComponent extends ListComponent {
       return this.sanitize(value, this.shouldSanitizeValue);
     }
 
+<<<<<<< Updated upstream
     if (this.component.multiple
       && _.isArray(this.dataValue) ? this.dataValue.find((val) => this.normalizeSingleValue(value) === val) : (this.dataValue === value)) {
+=======
+    const dataValue = this.undoValueTyping(this.dataValue);
+    const untypedValue = this.undoValueTyping(value);
+
+    if (this.component.multiple && _.isArray(dataValue) ? dataValue.find((val) => untypedValue === val) : (dataValue === untypedValue)) {
+>>>>>>> Stashed changes
       const selectData = this.selectData;
       if (selectData) {
         const templateValue = this.component.reference && value?._id ? value._id.toString() : value;
@@ -1515,6 +1522,25 @@ export default class SelectComponent extends ListComponent {
     return changed;
   }
 
+  undoValueTyping(value) {
+    let untypedValue = value;
+    if (this.component.multiple && Array.isArray(value)) {
+      untypedValue = value.map(v => {
+        if (typeof v === 'boolean' || typeof v === 'number') {
+          return v.toString();
+        }
+        return v;
+      });
+    }
+    else {
+      if (typeof value === 'boolean' || typeof value === 'number') {
+        untypedValue = value.toString();
+      }
+    }
+
+    return untypedValue;
+  }
+
   setValue(value, flags = {}) {
     const previousValue = this.dataValue;
     const changed = this.updateValue(value, flags);
@@ -1526,19 +1552,7 @@ export default class SelectComponent extends ListComponent {
     const hasValue = !this.isEmpty(value);
 
     // Undo typing when searching to set the value.
-    if (this.component.multiple && Array.isArray(value)) {
-      value = value.map(value => {
-        if (typeof value === 'boolean' || typeof value === 'number') {
-          return value.toString();
-        }
-        return value;
-      });
-    }
-    else {
-      if (typeof value === 'boolean' || typeof value === 'number') {
-        value = value.toString();
-      }
-    }
+    value = this.undoValueTyping(value);
 
     if (this.isHtmlRenderMode() && flags && flags.fromSubmission && changed) {
       this.itemsLoaded.then(() => {
@@ -1767,9 +1781,9 @@ export default class SelectComponent extends ListComponent {
   asString(value, options = {}) {
     value = value ?? this.getValue();
 
-    if (options.modalPreview && this.selectData) {
-      const { label } = this.selectValueAndLabel(value);
-      return label;
+    if (options.modalPreview) {
+      const template = this.itemTemplate(value, value);
+      return template;
     }
     //need to convert values to strings to be able to compare values with available options that are strings
     const convertToString = (data, valueProperty) => {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -163,6 +163,11 @@ export function checkCalculated(component, submission, rowData) {
  * @returns {boolean} - TRUE if the condition is true; FALSE otherwise.
  */
 
+/**
+ *
+ * @param conditionPaths
+ * @param data
+ */
 function getConditionalPathsRecursive(conditionPaths, data) {
   let currentGlobalIndex = 0;
   const conditionalPathsArray = [];
@@ -208,6 +213,14 @@ function getConditionalPathsRecursive(conditionPaths, data) {
   return conditionalPathsArray;
 }
 
+ /**
+  *
+  * @param component
+  * @param condition
+  * @param row
+  * @param data
+  * @param instance
+  */
  export function checkSimpleConditional(component, condition, row, data, instance) {
   if (condition.when) {
     const value = getComponentActualValue(condition.when, data, row);

--- a/test/unit/Select.unit.js
+++ b/test/unit/Select.unit.js
@@ -1230,7 +1230,7 @@ describe('Select Component', () => {
     });
   });
 
-  
+
   it('Should render label for multiple Select when Data Source is Resource in read only mode', (done) => {
     const element = document.createElement('div');
     const form = cloneDeep(comp24);
@@ -1490,6 +1490,45 @@ describe('Select Component with Entire Object Value Property', () => {
             referer: 'http://localhost:3001/',
             'accept-encoding': 'gzip, deflate, br, zstd',
             'accept-language': 'en-US,en;q=0.9,ru-RU;q=0.8,ru;q=0.7',
+          },
+        },
+        data: {
+          select: 1,
+          select1: {
+            textField1: 'A',
+            textField2: '1',
+            submit: true,
+          },
+          submit: true,
+        },
+        state: 'submitted',
+      });
+
+      setTimeout(() => {
+        const previewSelect = select.element.querySelector('[aria-selected="true"] span');
+
+        assert.equal(previewSelect.innerHTML, 'A', 'Should show label as a selected value' +
+          ' for Select component');
+
+        done();
+      }, 300);
+    })
+      .catch((err) => done(err));
+  });
+
+  it('Should render label for Select components when Data Source is Resource for modal preview', (done) => {
+    const element = document.createElement('div');
+    const comp = { ...comp24, modalEdit: true };
+    Formio.createForm(element, comp).then((form) => {
+      const select = form.getComponent('select');
+      form.setSubmission({
+        metadata: {
+          selectData: {
+            select: {
+              data: {
+                textField1: 'A',
+              },
+            },
           },
         },
         data: {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7195
https://formio.atlassian.net/browse/FIO-8234

## Description

Issue was caused by changes made for selectMetadata feature The issue happened bacause in scenarios where its a modal preview or read only mode the metadata was not used to render value of resource/url select component. Added it to the asString method 
Also there was an issue where "value" passed to the itemTemplate method was number/boolean type or string because inside setValue method we convert numbers/booleans to string, so comparing it to this.dataValue was not always true because they had diffewrent types, but that was fixed on the latest master with normalizeSingleValue
## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
