### PR TITLE
FIO-8986 fixed setting default value for day ,component with hidden day and month

### DIFF
--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -473,7 +473,9 @@ export default class DayComponent extends Field {
       DAY = null;
     }
     if (!this.showMonth) {
-      DAY = DAY === 0 ? 0 : DAY - 1;
+      if (!_.isNull(DAY)) {
+        DAY = DAY === 0 ? 0 : DAY - 1;
+      }
       YEAR = YEAR - 1;
       MONTH = null;
     }

--- a/test/unit/Day.unit.js
+++ b/test/unit/Day.unit.js
@@ -298,6 +298,18 @@ describe('Day Component', () => {
     comp1.fields.year.hide = false;
   });
 
+  it('Should set correct default value if the day and month fields are hidden', (done) => {
+    comp1.defaultValue = '2024';
+    comp1.fields.day.hide = true;
+    comp1.fields.month.hide = true;
+    Harness.testCreate(DayComponent, comp1).then((component) => {
+      assert.equal(component.data.date, '2024');
+      done();
+    }).catch(done);
+    comp1.fields.day.hide = false;
+    comp1.fields.month.hide = false;
+  });
+
   it('OnBlur validation should work properly with Day component', (done) => {
     const element = document.createElement('div');
 


### PR DESCRIPTION

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8986

## Description

*Fixed a behavior where it was impossible to set the default value for the Day component if the day and month fields are hidden*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

- *https://github.com/formio/formio.js/pull/5797*
- *https://github.com/formio/core/pull/149*
- *https://github.com/formio/core/pull/151*

## How has this PR been tested?

*Automated test has been added/ All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
