### PR TITLE
FIO-8948-8950: fixed an issue where radio and select boxes with url type do not display in PDF download

### DIFF
--- a/src/components/_classes/list/ListComponent.js
+++ b/src/components/_classes/list/ListComponent.js
@@ -25,6 +25,19 @@ export default class ListComponent extends Field {
     return _.get(selectData, this.path);
   }
 
+  get dataReady() {
+    // If the root submission has been set, and we are still not attached, then assume
+    // that our data is ready.
+    if (
+      this.root &&
+      this.root.submissionSet &&
+      !this.attached
+    ) {
+      return Promise.resolve();
+    }
+    return this.itemsLoaded;
+  }
+
   get shouldLoad() {
     if (this.loadingError) {
       return false;
@@ -125,6 +138,14 @@ export default class ListComponent extends Field {
     }
   }
 
+  get itemsLoaded() {
+    return this._itemsLoaded || Promise.resolve();
+  }
+
+  set itemsLoaded(promise) {
+    this._itemsLoaded = promise;
+  }
+  
   handleLoadingError(err) {
     this.loading = false;
     if (err.networkError) {

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -176,19 +176,6 @@ export default class SelectComponent extends ListComponent {
     this.getTemplateKeys();
   }
 
-  get dataReady() {
-    // If the root submission has been set, and we are still not attached, then assume
-    // that our data is ready.
-    if (
-      this.root &&
-      this.root.submissionSet &&
-      !this.attached
-    ) {
-      return Promise.resolve();
-    }
-    return this.itemsLoaded;
-  }
-
   get defaultSchema() {
     return SelectComponent.schema();
   }
@@ -1634,14 +1621,6 @@ export default class SelectComponent extends ListComponent {
         });
       }
     }
-  }
-
-  get itemsLoaded() {
-    return this._itemsLoaded || Promise.resolve();
-  }
-
-  set itemsLoaded(promise) {
-    this._itemsLoaded = promise;
   }
 
   validateValueAvailability(setting, value) {

--- a/test/unit/Radio.unit.js
+++ b/test/unit/Radio.unit.js
@@ -15,8 +15,10 @@ import {
   comp8,
   comp9,
   comp10,
-  comp11
+  comp11,
+  comp13
 } from './fixtures/radio';
+import { fastCloneDeep } from '@formio/core';
 
 describe('Radio Component', () => {
   it('Should build a radio component', () => {
@@ -392,6 +394,165 @@ describe('Radio Component', () => {
             done();
           }, 200);
         }, 200);
+      })
+      .catch(done);
+  });
+
+  it('Should wait for radio url options to load before submit', (done) => {
+    const element = document.createElement('div');
+    const originalMakeRequest = Formio.makeRequest;
+    const urlResponse = [
+      {
+        identifier: 'opt_a',
+        label: 'Option A',
+      },
+      {
+        identifier: 'opt_b',
+        label: 'Option B',
+      },
+      {
+        identifier: 'opt_c',
+        label: 'Option C',
+      },
+    ];
+    const listData = [
+      {
+        label: 'Option A',
+      },
+      {
+        label: 'Option B',
+      },
+      {
+        label: 'Option C',
+      },
+    ];
+    Formio.makeRequest = function() {
+      return new Promise((res, rej) => {
+        setTimeout(() => {
+          res(fastCloneDeep(urlResponse));
+        }, 400);
+      });
+    };
+
+    Formio.createForm(element, fastCloneDeep(comp13))
+      .then(instance => {
+        const radio = instance.getComponent('radio');
+        assert.equal(radio.optionsLoaded, false);
+        assert.equal(!!radio.element.querySelector('.loader'), true, 'Should show loader while options are loading.')
+        instance.submit().then((subm) => {
+          assert.equal(radio.loadedOptions.length, urlResponse.length);
+          assert.equal(radio.optionsLoaded, true);
+          assert.deepEqual(subm.metadata?.listData?.radio, listData);
+          Formio.makeRequest = originalMakeRequest;
+          done();
+        })
+      })
+      .catch(done);
+  });
+
+  it('Should render options from metadata in readOnly when radio value is empty in submission', (done) => {
+    const element = document.createElement('div');
+    const originalMakeRequest = Formio.makeRequest;
+    let optionsCalls = 0;
+    Formio.makeRequest = function() {
+      return new Promise((res, rej) => {
+        optionsCalls = optionsCalls + 1;
+        res([]);
+      });
+    };
+    const submission = {
+      form: '66ebe22841267c275a4cb34e',
+      metadata: {
+        listData: {
+          radio: [
+            {
+              label: 'Option A',
+            },
+            {
+              label: 'Option B',
+            },
+            {
+              label: 'Option C',
+            },
+          ],
+        }
+      },
+      data: {
+        radio: '',
+        submit: true,
+      },
+      _id: '66ebe85841267c275a4cbd4f',
+      state: 'submitted',
+    };
+
+    Formio.createForm(element, fastCloneDeep(comp13), { readOnly: true})
+      .then(instance => {
+        instance.setSubmission(submission).then(() => {
+          setTimeout(() => {
+            assert.equal(optionsCalls, 0);
+            const radio = instance.getComponent('radio');
+            assert.equal(radio.optionsLoaded, true);
+            assert.equal(radio.loadedOptions.length, 3);
+            Formio.makeRequest = originalMakeRequest;
+            done();
+          }, 100)
+        })
+      })
+      .catch(done);
+  });
+
+  it('Should render options from metadata in readOnly when radio has a value in submission', (done) => {
+    const element = document.createElement('div');
+    const originalMakeRequest = Formio.makeRequest;
+    let optionsCalls = 0;
+    Formio.makeRequest = function() {
+      return new Promise((res, rej) => {
+        optionsCalls = optionsCalls + 1;
+        res([]);
+      });
+    };
+    const submission = {
+      form: '66ebe22841267c275a4cb34e',
+      metadata: {
+        listData: {
+          radio: [
+            {
+              label: 'Option A',
+            },
+            {
+              label: 'Option B',
+            },
+            {
+              label: 'Option C',
+            },
+          ],
+        },
+        selectData: {
+          radio: {
+              label: 'Option B'
+          }
+      },
+      },
+      data: {
+        radio: 'opt_b',
+        submit: true,
+      },
+      _id: '66ebe85841267c275a4cbd4f',
+      state: 'submitted',
+    };
+
+    Formio.createForm(element, fastCloneDeep(comp13), { readOnly: true})
+      .then(instance => {
+        instance.setSubmission(submission).then(() => {
+          setTimeout(() => {
+            assert.equal(optionsCalls, 0);
+            const radio = instance.getComponent('radio');
+            assert.equal(radio.optionsLoaded, true);
+            assert.equal(radio.loadedOptions.length, 3);
+            Formio.makeRequest = originalMakeRequest;
+            done();
+          }, 100)
+        })
       })
       .catch(done);
   });

--- a/test/unit/fixtures/radio/comp13.js
+++ b/test/unit/fixtures/radio/comp13.js
@@ -1,0 +1,47 @@
+export default {
+  _id: '66ebe22841267c275a4cb34e',
+  title: 'test radio url 1',
+  name: 'testRadioUrl1',
+  path: 'testradiourl1',
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      label: 'Radio',
+      optionsLabelPosition: 'right',
+      inline: false,
+      tableView: false,
+      dataSrc: 'url',
+      values: [
+        {
+          label: '',
+          value: '',
+          shortcut: '',
+        },
+      ],
+      valueProperty: 'identifier',
+      validateWhenHidden: false,
+      key: 'radio',
+      type: 'radio',
+      data: {
+        url: 'https://test.test/options',
+        headers: [
+          {
+            key: '',
+            value: '',
+          },
+        ],
+      },
+      input: true,
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  project: '66e930e238963ab0230de6df',
+};

--- a/test/unit/fixtures/radio/index.js
+++ b/test/unit/fixtures/radio/index.js
@@ -10,4 +10,5 @@ import comp9 from './comp9';
 import comp10 from './comp10';
 import comp11 from './comp11';
 import comp12 from './comp12';
-export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12 };
+import comp13 from './comp13';
+export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13 };

--- a/test/unit/fixtures/selectboxes/comp8.js
+++ b/test/unit/fixtures/selectboxes/comp8.js
@@ -1,0 +1,47 @@
+export default {
+  _id: '66ebfb1141267c275a4cce11',
+  title: 'test selectboxes url',
+  name: 'testSelectboxesUrl',
+  path: 'testselectboxesurl',
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      label: 'Select Boxes',
+      optionsLabelPosition: 'right',
+      tableView: false,
+      dataSrc: 'url',
+      values: [
+        {
+          label: '',
+          value: '',
+          shortcut: '',
+        },
+      ],
+      valueProperty: 'identifier',
+      validateWhenHidden: false,
+      key: 'selectBoxes',
+      type: 'selectboxes',
+      data: {
+        url: 'https://test.test/options',
+        headers: [
+          {
+            key: '',
+            value: '',
+          },
+        ],
+      },
+      input: true,
+      inputType: 'checkbox',
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  project: '66e930e238963ab0230de6df',
+};

--- a/test/unit/fixtures/selectboxes/index.js
+++ b/test/unit/fixtures/selectboxes/index.js
@@ -5,4 +5,5 @@ import comp4 from './comp4';
 import comp5 from './comp5';
 import comp6 from './comp6';
 import comp7 from './comp7';
-export { comp1, comp2, comp3, comp4, comp5, comp6, comp7 };
+import comp8 from './comp8';
+export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8948
https://formio.atlassian.net/browse/FIO-8950

## Description

**What changed?**

Issues that this PR fixed:
- when it takes long time to load options for radio/selectboxes with url type, nothing indicates that the options are being loaded, the component displays just component label and not options. This PR adds the loader so that user could understand that it needs to wait.
- it was possible to submit the form even when radio/selectboxes options are not loaded. Because of it, the metadata related to the options was not included in the submission object. That caused issues with options display in  readOnly and pdf download. This PR adds the beforeSubmit handler that allows to submit the form only after the options are loaded.
- if the radio/selectboxes with url type had an empty value, the renderer did not take options from metadata but attempts to load it from url in readOnly. This caused options not to display in PDF download. This PR adds a check that forces to take options from metadata in this case.

## How has this PR been tested?

Manually + tests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
