### PR TITLE
FIO-9075: fixed an issue where the form cannot be resubmitted if it has server errors

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1444,7 +1444,7 @@ export default class Webform extends NestedDataComponent {
                 process: 'change'
             })
             : [];
-        value.isValid = errors.length === 0;
+        value.isValid = (errors || []).filter(err => !err.fromServer).length === 0;
 
         this.loading = false;
         if (this.submitted) {

--- a/test/forms/formWithUniqueValidation.js
+++ b/test/forms/formWithUniqueValidation.js
@@ -1,0 +1,66 @@
+export default {
+  form: {
+    _id: '66f276bb34ac6c4049cb91a5',
+    title: 'test unique',
+    name: 'testUnique',
+    path: 'testunique',
+    type: 'form',
+    display: 'form',
+    owner: '637b2e6b48c1227e60b1f910',
+    components: [
+      {
+        label: 'Text Field',
+        applyMaskOn: 'change',
+        tableView: true,
+        validate: {
+          required: true,
+        },
+        validateWhenHidden: false,
+        key: 'textField',
+        type: 'textfield',
+        input: true,
+      },
+      {
+        label: 'Text Field unique',
+        applyMaskOn: 'change',
+        tableView: true,
+        unique: true,
+        validateWhenHidden: false,
+        key: 'textFieldUnique',
+        type: 'textfield',
+        input: true,
+      },
+      {
+        type: 'button',
+        label: 'Submit',
+        key: 'submit',
+        disableOnInvalid: true,
+        input: true,
+        tableView: false,
+      },
+    ],
+    project: '66f27195e0c7ef9920ae787e',
+  },
+  submission: {
+    data: { textField: 'test', textFieldUnique: 'notUnique', submit: false },
+  },
+  serverErrors: {
+    name: 'ValidationError',
+    details: [
+      {
+        message: 'Text Field unique must be unique',
+        level: 'error',
+        path: ['textFieldUnique'],
+        context: {
+          validator: 'unique',
+          hasLabel: true,
+          key: 'textFieldUnique',
+          label: 'Text Field unique',
+          path: 'textFieldUnique',
+          value: 'notUnique',
+          index: 0,
+        },
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9075

## Description

**What changed?**

The issue: when the form has server errors, the submit btn is disabled and the form cannot be resubmitted.
When the form has only server errors, we should not consider it as invalid as we cannot know if the values become valid after changes until resubmit it.

## How has this PR been tested?

Tests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
