### PR TITLE
FIO-9105: trigger error in test

### DIFF
--- a/src/components/selectboxes/SelectBoxes.unit.js
+++ b/src/components/selectboxes/SelectBoxes.unit.js
@@ -391,7 +391,7 @@ describe('SelectBoxes Component', () => {
     });
   });
 
-  it('Should show validation errors when the value property is set', () => {
+  it('Should show validation errors when the value property is set', (done) => {
     const originalMakeRequest = Formio.makeRequest;
     Formio.makeRequest = async() => {
       return [
@@ -417,9 +417,14 @@ describe('SelectBoxes Component', () => {
     };
     const newComp12 = _.cloneDeep(comp12);
     _.set(newComp12.components[0], 'validate.required', true);
-    return Formio.createForm(document.createElement('div'), newComp12, {}).then((form) => {
+    Formio.createForm(document.createElement('div'), newComp12, {}).then((form) => {
       const selectBoxesComponent = form.getComponent('selectBoxes');
-      assert.equal(selectBoxesComponent.errors.length, 1);
+      const buttonComponent = form.getComponent('submit');
+      buttonComponent.refs.button.click();
+      setTimeout(() => {
+        assert.equal(selectBoxesComponent.errors.length, 1);
+        done();
+      },200);
       Formio.makeRequest = originalMakeRequest;
     });
   });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9105

## Description

**What changed?**

Test now includes a submit click so that the selectboxes error array is pushed with the required error

**Why have you chosen this solution?**

On the 5.x branch the required error is already set within the selectboxes error array without a submit click. The 4.x branch needs a submit button click in order to add the error to the selectboxes error array

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

The PR is a test

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
