### PR TITLE
FIO-9097 fixed navigation through the errors list

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -1073,6 +1073,17 @@ export default class Wizard extends Webform {
     return super.errors;
   }
 
+  showErrors(errors, triggerEvent) {
+    if (this.hasExtraPages) {
+      this.subWizards.forEach((subWizard) => {
+        if(Array.isArray(subWizard.errors)) {
+          errors = [...errors, ...subWizard.errors]
+        }
+      })
+    };
+    return super.showErrors(errors, triggerEvent)
+  }
+
   focusOnComponent(key) {
     const component = this.getComponent(key);
     if (component) {
@@ -1080,7 +1091,7 @@ export default class Wizard extends Webform {
       while (!(topPanel.parent instanceof Wizard)) {
         topPanel = topPanel.parent;
       }
-      const pageIndex = this.pages.findIndex(page => page === topPanel);
+      const pageIndex = this.pages.findIndex(page => page.id === topPanel.id);
       if (pageIndex >= 0) {
         const page = this.pages[pageIndex];
         if (page && page !== this.currentPage) {

--- a/test/unit/Wizard.unit.js
+++ b/test/unit/Wizard.unit.js
@@ -596,6 +596,76 @@ describe('Wizard tests', () => {
     .catch((err) => done(err));
   });
 
+  it('Should redirect to the correct nested wizard page from the Error list', function(done) {
+    const formElement = document.createElement('div');
+    const wizard = new Wizard(formElement);
+    const nestedWizard = _.cloneDeep(wizardTestForm.form);
+    const parentWizardForm = _.cloneDeep(formWithNestedWizard);
+    parentWizardForm.components[0].components.push({
+      label: 'Parent Text',
+      applyMaskOn: 'change',
+      tableView: true,
+      validate: {
+        required: true
+      },
+      validateWhenHidden: false,
+      key: 'parentText',
+      type: 'textfield',
+      input: true
+    })
+    const clickEvent = new Event('click');
+
+    wizard.setForm(parentWizardForm).then(() => {
+      const nestedFormComp = wizard.getComponent('formNested');
+
+      nestedFormComp.loadSubForm = ()=> {
+        nestedFormComp.formObj = nestedWizard;
+        nestedFormComp.subFormLoading = false;
+        return new Promise((resolve) => resolve(nestedWizard));
+      };
+
+      nestedFormComp.createSubForm();
+
+      setTimeout(() => {
+        const clickWizardBtn = (pathPart) => {
+          const btn = _.get(wizard.refs, `${wizard.wizardKey}-${pathPart}`);
+          btn.dispatchEvent(clickEvent);
+        };
+
+        const checkPage = (pageNumber) => {
+          assert.equal(wizard.page, pageNumber, `Should open wizard page ${pageNumber + 1}`);
+        };
+
+        clickWizardBtn('link[4]');
+        
+        setTimeout(() => {
+          checkPage(4);
+          clickWizardBtn('submit');
+          setTimeout(() => {
+            assert.equal(wizard.refs.errorRef.length, 4, 'Should have errors');
+            wizard.refs.errorRef[0].dispatchEvent(clickEvent);
+            setTimeout(() => {
+              checkPage(0);
+              assert.equal(wizard.refs.errorRef.length, 4, 'Should have errors');
+              wizard.refs.errorRef[1].dispatchEvent(clickEvent);
+                setTimeout(() => {
+                  checkPage(2);
+                  assert.equal(wizard.refs.errorRef.length, 4, 'Should have errors');
+                  wizard.refs.errorRef[2].dispatchEvent(clickEvent);
+                  setTimeout(() => {
+                    checkPage(3);
+                    done();
+                  }, 200);
+                }, 200);
+            }, 200);
+          }, 200);
+        }, 200);
+      }, 200)
+    })
+    .catch((err) => done(err));
+  });
+  
+
   it('Should execute advanced logic for wizard pages', function(done) {
     const formElement = document.createElement('div');
     const wizard = new Wizard(formElement);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9097

## Description

*Previously, when clicking on the error list links for a wizard form that includes a child wizard forum, focusing did not work for components of the parent form; and for components from the child form, after going to the corresponding page, some of the errors from the list disappeared. This has been fixed, now navigation via links from the error list works for both components from the parent wizard form and from the child wizard form.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated tests have been added. All test pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
