### PR TITLE
FIO-9080 checkbox radio validation error

### DIFF
--- a/src/components/Components.js
+++ b/src/components/Components.js
@@ -1,6 +1,7 @@
 import Component from './_classes/component/Component';
 import EditFormUtils from './_classes/component/editForm/utils';
 import BaseEditForm from './_classes/component/Component.form';
+import { getComponentKey } from '../utils/utils';
 import _ from 'lodash';
 export default class Components {
   static _editFormUtils = EditFormUtils;
@@ -63,7 +64,8 @@ export default class Components {
    */
   static getComponentPath(component) {
     let path = '';
-    if (component.component.key) {
+    const componentKey = getComponentKey(component.component);
+    if (componentKey) {
       let thisPath = component.options?.parent || component;
       while (thisPath && !thisPath.allowData && thisPath.parent) {
         thisPath = thisPath.parent;
@@ -75,7 +77,7 @@ export default class Components {
       const rowIndex = component.row;
       const rowIndexPath = rowIndex && !['container'].includes(thisPath.component.type) ? `[${Number.parseInt(rowIndex)}]` : '';
       path = `${thisPath.path}${rowIndexPath}.`;
-      path += component.component.key;
+      path += componentKey;
       return _.trim(path, '.');
     }
     return path;

--- a/test/forms/formWithCheckboxRadioTypeAndValidation.js
+++ b/test/forms/formWithCheckboxRadioTypeAndValidation.js
@@ -1,0 +1,35 @@
+export default {
+    title: 'test checkbox',
+    name: 'testCheckbox',
+    path: 'testcheckbox',
+    type: 'form',
+    display: 'form',
+    components: [
+      {
+        label: 'Checkbox 1',
+        inputType: 'radio',
+        tableView: false,
+        defaultValue: false,
+        key: 'checkbox1',
+        type: 'checkbox',
+        name: 'radio',
+        value: 'value1',
+        input: true,
+        radio: false,
+        validate: {
+            required: true
+        },
+      },
+      {
+        input: true,
+        label: 'Submit',
+        tableView: false,
+        key: 'submit',
+        type: 'button',
+        disableOnInvalid: true,
+      }
+    ],
+    created: '2022-09-01T09:12:45.581Z',
+    modified: '2022-09-05T08:51:16.048Z',
+    machineName: 'uubnbosxacwjzbk:testCheckbox',
+  };

--- a/test/unit/NestedComponent.unit.js
+++ b/test/unit/NestedComponent.unit.js
@@ -4,7 +4,7 @@ import Harness from '../harness';
 import assert from 'power-assert';
 import each from 'lodash/each';
 import { expect } from 'chai';
-import { comp1, comp2, comp3 } from './fixtures/nested';
+import { comp1, comp2, comp3, comp4 } from './fixtures/nested';
 import { nestedForm } from '../fixtures';
 import _map from 'lodash/map';
 import Webform from '../../src/Webform';
@@ -253,6 +253,18 @@ describe('NestedComponent class', () => {
           assert(dataGrid.components[0].path === 'dataGrid[0].textField');
           assert(tabs.path === 'tabs');
           assert(tabs.tabs[0][0].path === 'tabsTextfield');
+          done();
+        })
+        .catch(done);
+    });
+    // see these functions in core to see how component path is derived for checkbox components of inputType radio
+    // - https://github.com/formio/core/blob/master/src/utils/formUtil.ts#L228-L240
+    // - https://github.com/formio/core/blob/master/src/utils/formUtil.ts#L418-L427
+    it('returns the right path (i.e. name) for checkbox components with an inputType of radio', (done) => {
+      Harness.testCreate(NestedComponent, comp4)
+        .then((nested) => {
+          assert(nested.components[0].path === 'radio');
+          assert(nested.components[1].path === 'radio');
           done();
         })
         .catch(done);

--- a/test/unit/Webform.unit.js
+++ b/test/unit/Webform.unit.js
@@ -71,6 +71,7 @@ import optionalSanitize from '../forms/optionalSanitize.js';
 import formsWithNewSimpleConditions from '../forms/formsWithNewSimpleConditions.js';
 import formWithRadioInsideDataGrid from '../forms/formWithRadioInsideDataGrid.js';
 import formWithCheckboxRadioType from '../forms/formWithCheckboxRadioType.js';
+import formWithCheckboxRadioTypeAndValidation from '../forms/formWithCheckboxRadioTypeAndValidation.js';
 import formWithFormController from '../forms/formWithFormController.js';
 import calculateValueOnServerForEditGrid from '../forms/calculateValueOnServerForEditGrid.js';
 import formsWithAllowOverride from '../forms/formsWithAllowOverrideComps.js';
@@ -5147,6 +5148,20 @@ describe('Webform tests', function() {
       }, 300);
     })
       .catch((err) => done(err));
+  });
+
+  it('Should show validation errors for checkbox component with inputType of radio', (done) => {
+    const formElement = document.createElement('div');
+    const form = new Webform(formElement);
+    form.setForm(formWithCheckboxRadioTypeAndValidation).then(() => {
+      const submitButton = form.getComponent('submit');
+      assert.ok(submitButton.disabled, 'Submit button should be disabled');
+      const errors = form.validate(); 
+      assert.strictEqual(errors.length, 1, 'Should return 1 error for the checkbox');
+      assert.strictEqual(errors[0].component.label, 'Checkbox 1', 'The error should be for the checkbox component');
+      assert.strictEqual(errors[0].errorKeyOrMessage, 'required', 'Should show required validation error');
+      done();
+    }).catch(done);
   });
 
   for (const formTest of FormTests) {

--- a/test/unit/fixtures/nested/comp4.js
+++ b/test/unit/fixtures/nested/comp4.js
@@ -1,0 +1,8 @@
+import comp from '../checkbox/comp2';
+
+export default {
+    components: [
+        { ...comp },
+        { ...comp, value: 'false' }
+    ]
+};

--- a/test/unit/fixtures/nested/index.js
+++ b/test/unit/fixtures/nested/index.js
@@ -1,3 +1,4 @@
 export { default as comp1 } from './comp1';
 export { default as comp2 } from './comp2';
 export { default as comp3 } from './comp3';
+export { default as comp4 } from './comp4';


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9080

## Description

**What changed?**

A while back, core was updated to use the component `name` property as the `key` for checkbox components with an `inputType` of `'radio'`. `name`, in turn, was then used instead of `key` to generate the component `path`. formio.js was never updated to use `name` instead of `key`, so checkbox–radio components could not be validated. 

This change updates formio.js to use the same helper function that core uses to get the component `key`.

**Why have you chosen this solution?**

It made sense to plug into core's functionality instead of duplicating the logic; the helper function from core was already imported into formio.js. This also aligns with the desire to move business logic from formio.js to core.

## Breaking Changes / Backwards Compatibility

I'm not sure–– are the versions of core and formio.js always synced? If someone was using an older version of core from before the calculation changed with this update from formio.js it would break things.

## Dependencies

n/a

## How has this PR been tested?
  - One test to assert that `Components.getComponentPath()` returns the correct component path for a checkbox–radio 
     component.
  - One test to assert that a web form renders a checkbox–radio component error correctly when `validation: required` is 
     true for that component.
## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
