### PR TITLE
FIO-7195/FIO-8234: Fixes an issue where Select renders value properties instead of labels in DataTable

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -1751,7 +1751,7 @@ export default class SelectComponent extends ListComponent {
   asString(value, options = {}) {
     value = value ?? this.getValue();
 
-    if (options.modalPreview) {
+    if (options.modalPreview || options.dataTablePreview) {
       const template = this.itemTemplate(value, value);
       return template;
     }


### PR DESCRIPTION

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8234
https://formio.atlassian.net/browse/FIO-7195

## Description

Passed on option from DataTable format function to tell the component it its being rendered inside DataTable to make it render  a label instead of unformatted value property.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
