### PR TITLE
FIO-9056: Fix enabling multiple values for address component

### DIFF
--- a/src/components/address/Address.js
+++ b/src/components/address/Address.js
@@ -259,6 +259,18 @@ export default class AddressComponent extends ContainerComponent {
     return value && !value.mode;
   }
 
+  set dataValue(value) {
+    super.dataValue = value
+  }
+
+  get dataValue() {
+    const resultValue = _.get(this._data, this.component.path);
+    if (!_.isArray(resultValue) && this.component.multiple) {
+      return [resultValue]
+    }
+    return super.dataValue;
+  }
+
   normalizeValue(value) {
     return (this.manualModeEnabled && this.isValueInLegacyFormat(value))
       ? {

--- a/test/unit/WebformBuilder.unit.js
+++ b/test/unit/WebformBuilder.unit.js
@@ -25,6 +25,31 @@ describe('WebformBuilder tests', function() {
     done();
   });
 
+  it("Should not show errors with default array values", (done) => {
+    const builder = Harness.getBuilder();
+    builder
+      .setForm({})
+      .then(() => {
+        Harness.buildComponent("address");
+        setTimeout(() => {
+          const multipleValues = builder.editForm.getComponent("multiple");
+          const provider = builder.editForm.getComponent("provider");
+          provider.setValue("nominatim");
+          setTimeout(() => {
+            multipleValues.setValue(true);
+            setTimeout(() => {
+              Harness.saveComponent();
+              setTimeout(() => {
+                assert.equal(builder.editForm.errors.length, 0);
+                done();
+              }, 350);
+            }, 250);
+          }, 250);
+        }, 250);
+      })
+      .catch(done);
+  });
+
   it('Should execute form controller', (done) => {
     const builder = Harness.getBuilder();
     builder.webform.form = formWithFormController;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9056

## Description

**What changed?**

Added sttter and getter for dataValue in Address component, since when enabling multiple values, the data structure wasn't changing to array, causing validation error to appear when trying to save the component.

## Dependencies

None

## How has this PR been tested?

Automated test was added

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
