### PR TITLE
FIO-9120: Fix issue with unchecking radio default value

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -93,6 +93,15 @@ export default class RadioComponent extends ListComponent {
     return defaultValue;
   }
 
+  resetValue() {
+    this.unset();
+    this.setValue(this.emptyValue, {
+      noUpdateEvent: true,
+      noValidate: true,
+      resetValue: true
+    });
+  }
+
   get inputInfo() {
     const info = super.elementInfo();
     info.type = 'input';
@@ -149,7 +158,7 @@ export default class RadioComponent extends ListComponent {
     this.loadedOptions = [];
 
     if (!this.visible) {
-      this.itemsLoadedResolve(); 
+      this.itemsLoadedResolve();
     }
 
     // Get the template keys for this radio component.
@@ -157,7 +166,7 @@ export default class RadioComponent extends ListComponent {
   }
 
   beforeSubmit() {
-    return new Promise(res => { 
+    return new Promise(res => {
       this.dataReady.then(() => res(true));
     });
   }

--- a/test/unit/Radio.unit.js
+++ b/test/unit/Radio.unit.js
@@ -28,6 +28,38 @@ describe('Radio Component', () => {
     });
   });
 
+  it("Should allow to uncheck default radio value and set correct submission data", function (done) {
+    const formElement = document.createElement("div");
+    const comp5Cloned = _.cloneDeep(comp5);
+    comp5Cloned.components[0].defaultValue = "one";
+
+    Formio.createForm(formElement, comp5Cloned)
+      .then((form) => {
+        const submit = form.getComponent("submit");
+        const submitBtn = submit.refs.button;
+        const clickEvent = new Event("click");
+        const component = form.getComponent("radio");
+        const radioFirstInput = component.refs.input[0];
+        setTimeout(() => {
+          submitBtn.dispatchEvent(clickEvent);
+          setTimeout(() => {
+            assert.equal(form.submission.data.radio, 'one');
+            assert.equal(component.refs.input[0].checked, true);
+            radioFirstInput.click();
+            setTimeout(() => {
+              submitBtn.dispatchEvent(clickEvent);
+              setTimeout(() => {
+                assert.equal(form.submission.data.radio, '');
+                assert.equal(component.refs.input[0].checked, false);
+                done();
+              }, 200);
+            }, 200);
+          }, 200);
+        }, 200);
+      })
+      .catch(done);
+  });
+
   it('Should return correct string values if storage type is Number', () => {
     return Harness.testCreate(RadioComponent, comp2).then((component) => {
       assert.equal(component.getValueAsString(1), 'one');


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9120

## Description

**What changed?**

Added own version of `resetValue` method to the Radio component, since the inherited one was setting `defaultValue` instead of `emptyValue`, this made impossible unchecking all Radio values

## Dependencies

None

## How has this PR been tested?

Automated test is added

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
