### PR TITLE
FIO-9158: fixed an issue where Password component error message persists to displayed in Edit page

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -3391,7 +3391,7 @@ export default class Component extends Element {
     if (this.options.alwaysDirty) {
       flags.dirty = true;
     }
-    if (flags.fromSubmission && this.hasValue(data)) {
+    if (flags.fromSubmission && this.hasValue(data) && !(this.pristine && this.protected)) {
       flags.dirty = true;
     }
     this.setDirty(flags.dirty);

--- a/test/unit/Password.unit.js
+++ b/test/unit/Password.unit.js
@@ -144,4 +144,22 @@ describe('Password Component', () => {
     testValidity(validValues, true);
     testValidity(invalidValues, false, 'Password does not match the pattern \\D+', invalidValues[invalidValues.length-1]);
   });
+
+  it('Should not show required validation error message in edit page before editing', (done) => {
+    const form = _.cloneDeep(comp2);
+    form.components[0].validate = { required: true };
+    const element = document.createElement('div');
+    
+    Formio.createForm(element, form).then(form => {
+      const component = form.getComponent('password');
+      component.setValue('');
+      form.root.editing = true;
+      form.setPristine(true);
+      setTimeout(() => {
+        assert.equal(component.visibleErrors.length, 0);
+        assert.equal(component.errors.length, 1);
+        done();
+      }, 300);
+    }).catch(done);
+  });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9158

## Description

Password component is protected, so in edit submission page it shows as "" that triggers validation error. Added condition to make sure error isn't shown if this component wasn't changed in edit page.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

tested manually, added automated test

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
