### PR TITLE
FIO-9127 fixed saving an empty value for day component after deleting values

### DIFF
--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -557,7 +557,7 @@ export default class DayComponent extends Field {
     }
 
     if (this.showDay && this.refs.day) {
-      day = parseInt(this.refs.day.value, 10);
+      day = this.refs.day.value === '' ? '' : parseInt(this.refs.day.value, 10);
     }
     if (day === undefined || _.isNaN(day)) {
       day = defaults[DAY] && !_.isNaN(defaults[DAY]) ? defaults[DAY] : 0;
@@ -565,14 +565,14 @@ export default class DayComponent extends Field {
 
     if (this.showMonth && this.refs.month) {
       // Months are 0 indexed.
-      month = parseInt(this.refs.month.value, 10);
+      month = this.refs.month.value === '' ? '' : parseInt(this.refs.month.value, 10);
     }
     if (month === undefined || _.isNaN(month)) {
       month = defaults[MONTH] && !_.isNaN(defaults[MONTH]) ? defaults[MONTH] : 0;
     }
 
     if (this.showYear && this.refs.year) {
-      year = parseInt(this.refs.year.value);
+      year = this.refs.year.value === '' ? '' : parseInt(this.refs.year.value);
     }
     if (year === undefined || _.isNaN(year)) {
       year = defaults[YEAR] && !_.isNaN(defaults[YEAR]) ? defaults[YEAR] : 0;
@@ -580,6 +580,7 @@ export default class DayComponent extends Field {
 
     let result;
     if (!day && !month && !year) {
+      this.dataValue = this.emptyValue;
       return null;
     }
 

--- a/test/forms/helpers/testBasicComponentSettings/form.js
+++ b/test/forms/helpers/testBasicComponentSettings/form.js
@@ -305,7 +305,6 @@ export default {
       "key": "day",
       "type": "day",
       "input": true,
-      "defaultValue": "00/00/0000"
     }, {
       "label": "Time",
       "tableView": true,

--- a/test/unit/Day.unit.js
+++ b/test/unit/Day.unit.js
@@ -387,4 +387,40 @@ describe('Day Component', () => {
       },200);
     });
   });
+
+  it('Should save empty value after deleting the values', (done) => {
+    delete comp1.defaultValue;
+    Harness.testCreate(DayComponent, comp1).then((component) => {
+      component.setValue('10/12/2024');
+      assert.equal(component.getValue(), '10/12/2024');
+      component.refs.month.value = '';
+      component.refs.month.dispatchEvent(new Event('input'));
+      component.refs.day.value = '';
+      component.refs.day.dispatchEvent(new Event('input'));
+      component.refs.year.value = '';
+      component.refs.year.dispatchEvent(new Event('input'));
+      setTimeout(() => {
+        assert.equal(component.getValue(), '');
+        done();
+      }, 100);
+    });
+  });
+
+  it('Should save empty value after deleting values from fields if default value is set', (done) => {
+    comp1.defaultValue = '10/12/2024';
+    Harness.testCreate(DayComponent, comp1).then((component) => {
+      assert.equal(component.getValue(), '10/12/2024');
+      component.refs.month.value = '';
+      component.refs.month.dispatchEvent(new Event('input'));
+      component.refs.day.value = '';
+      component.refs.day.dispatchEvent(new Event('input'));
+      component.refs.year.value = '';
+      component.refs.year.dispatchEvent(new Event('input'));
+      setTimeout(() => {
+        assert.equal(component.getValue(), '');
+        done();
+      }, 100);
+    });
+    delete comp1.defaultValue;
+  });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9127

## Description

*Fixed the issue of saving an empty value for the Day component after deleting values from each of the fields (month, day and year). Previously, the last deleted field was not left empty, so after editing it was impossible to set an empty value for the day component. The issue of setting an empty value for the Day component with the default value has also been fixed*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated test have been added. Al test pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
