### PR TITLE
FIO-9127 fixed saving empty values for Day component with hidden fields

### DIFF
--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -322,7 +322,7 @@ export default class DayComponent extends Field {
         if (!this.component.fields.day.hide && maxDay) {
           this.refs.day.max = maxDay;
         }
-        if (maxDay && day > maxDay) {
+        if (maxDay && day > maxDay && this.refs.day) {
           this.refs.day.value = this.refs.day.max;
         }
         updateValueAndSaveFocus(this.refs.month, 'month')();
@@ -556,37 +556,43 @@ export default class DayComponent extends Field {
       defaults = defaultValue.split('/').map(x => parseInt(x, 10));
     }
 
+    const isModalEditClosed = this.component.modalEdit && !this.componentModal.isOpened;
     if (this.showDay && this.refs.day) {
-      day = this.refs.day.value === '' ? '' : parseInt(this.refs.day.value, 10);
+      day = (this.refs.day.value === '' && !isModalEditClosed) ? '' : parseInt(this.refs.day.value, 10);
     }
-    if (day === undefined || _.isNaN(day)) {
-      day = (defaults.length !== 3 && value)
+    if (day === undefined || _.isNaN(day) || value) {
+      day = (defaults.length !== 3)
         ? this.getDayWithHiddenFields(defaults).day
         : (defaults[DAY] && !_.isNaN(defaults[DAY]) ? defaults[DAY] : 0);
     }
 
     if (this.showMonth && this.refs.month) {
       // Months are 0 indexed.
-      month = this.refs.month.value === '' ? '' : parseInt(this.refs.month.value, 10);
+      month = (this.refs.month.value === '' && !isModalEditClosed) ? '' : parseInt(this.refs.month.value, 10);
     }
-    if (month === undefined || _.isNaN(month)) {
-      month = (defaults.length !== 3 && value)
+    if (month === undefined || _.isNaN(month) || value) {
+      month = (defaults.length !== 3)
         ? this.getDayWithHiddenFields(defaults).month
         : (defaults[MONTH] && !_.isNaN(defaults[MONTH]) ? defaults[MONTH] : 0);
     }
 
     if (this.showYear && this.refs.year) {
-      year = this.refs.year.value === '' ? '' : parseInt(this.refs.year.value);
+      year = (this.refs.year.value === '' && !isModalEditClosed) ? '' : parseInt(this.refs.year.value);
     }
-    if (year === undefined || _.isNaN(year)) {
-      year = (defaults.length !== 3 && value)
+    if (year === undefined || _.isNaN(year) || value) {
+      year = (defaults.length !== 3)
         ? this.getDayWithHiddenFields(defaults).year
         : (defaults[YEAR] && !_.isNaN(defaults[YEAR]) ? defaults[YEAR] : 0);
     }
 
     let result;
     if (!day && !month && !year) {
-      this.dataValue = this.emptyValue;
+      if (!isModalEditClosed) {
+        this.dataValue = this.emptyValue;
+        if (this.options.building) {
+          this.triggerChange();
+        }
+      }
       return null;
     }
 

--- a/test/unit/Day.unit.js
+++ b/test/unit/Day.unit.js
@@ -437,6 +437,23 @@ describe('Day Component', () => {
     });
   });
 
+  it('Should save empty value after deleting the values if the day field is hidden', (done) => {
+    comp1.fields.day.hide = true;
+    Harness.testCreate(DayComponent, comp1).then((component) => {
+      component.setValue('10/2024');
+      assert.equal(component.getValue(), '10/2024');
+      component.refs.month.value = '';
+      component.refs.month.dispatchEvent(new Event('input'));
+      component.refs.year.value = '';
+      component.refs.year.dispatchEvent(new Event('input'));
+      setTimeout(() => {
+        assert.equal(component.getValue(), '');
+        done();
+      }, 100);
+    });
+    comp1.fields.day.hide = false;
+  });
+
   it('Should save empty value after deleting values from fields if default value is set', (done) => {
     comp1.defaultValue = '10/12/2024';
     Harness.testCreate(DayComponent, comp1).then((component) => {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9127
https://formio.atlassian.net/browse/FIO-9128

## Description

*Fixed saving empty values for Day component with hidden fields (day, month or year). Fixed saving empty values for Day component with Modal Edit. Now empty values are saved as empty string instead of zeros according to https://github.com/formio/formio.js/commit/fc34a5b697313bec5f4b8d20d9a89702db3f0860*
*Also fixed an issue where it was impossible to remove the default value for the Day component in the form builder*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*https://github.com/formio/formio.js/pull/5842*

## How has this PR been tested?

*Automated tests have been added. All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
