### PR TITLE
FIO-9072: required validation triggered on form load

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "dopublish": "npm run build && npm run tag && npm publish",
     "lint": "eslint ./src --fix",
     "serve": "jekyll serve --config _config.yml,_config.dev.yml",
-    "test": "mocha test/unit/*.unit.js",
+    "test": "nyc --reporter=lcov --reporter=text --reporter=text-summary mocha test/unit/*.unit.js",
     "test:updateRenders": "npm run lib && cross-env TZ=UTC node --require jsdom-global/register test/updateRenders.js",
     "test:e2e": "NODE_OPTIONS=\"--max-old-space-size=4096\" karma start --verbose --single-run",
     "show-coverage": "open coverage/lcov-report/index.html"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "dopublish": "npm run build && npm run tag && npm publish",
     "lint": "eslint ./src --fix",
     "serve": "jekyll serve --config _config.yml,_config.dev.yml",
-    "test": "nyc --reporter=lcov --reporter=text --reporter=text-summary mocha test/unit/*.unit.js",
+    "test": "mocha test/unit/*.unit.js",
     "test:updateRenders": "npm run lib && cross-env TZ=UTC node --require jsdom-global/register test/updateRenders.js",
     "test:e2e": "NODE_OPTIONS=\"--max-old-space-size=4096\" karma start --verbose --single-run",
     "show-coverage": "open coverage/lcov-report/index.html"

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -795,6 +795,7 @@ export default class Webform extends NestedDataComponent {
      */
     onSetSubmission(submission, flags = {}) {
       this.submissionSet = true;
+      flags.explicitSubmission = structuredClone(submission);
       this.triggerChange(flags);
       this.emit('beforeSetSubmission', submission);
       this.setValue(submission, flags);
@@ -952,7 +953,6 @@ export default class Webform extends NestedDataComponent {
         if (!flags.sanitize) {
             this.mergeData(this.data, submission.data);
         }
-
         submission.data = this.data;
         this._submission = submission;
         return changed;
@@ -1433,14 +1433,14 @@ export default class Webform extends NestedDataComponent {
         }
 
         this.checkData(value.data, flags);
-        const shouldValidate =
-            !flags.noValidate ||
+        let shouldValidate = flags.noValidate ? false :
+            _.isUndefined(flags.noValidate) ||
             flags.fromIframe ||
-            (flags.fromSubmission && this.rootPristine && this.pristine && flags.changed);
+            (flags.fromSubmission && this.rootPristine && this.pristine);
         const errors = shouldValidate
-            ? this.validate(value.data, { 
-                ...flags, 
-                noValidate: false, 
+            ? this.validate(value.data, {
+                ...flags,
+                noValidate: false,
                 process: 'change'
             })
             : [];

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -795,7 +795,7 @@ export default class Webform extends NestedDataComponent {
      */
     onSetSubmission(submission, flags = {}) {
       this.submissionSet = true;
-      flags.explicitSubmission = structuredClone(submission);
+      flags.submission = structuredClone(submission);
       this.triggerChange(flags);
       this.emit('beforeSetSubmission', submission);
       this.setValue(submission, flags);

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -3392,7 +3392,7 @@ export default class Component extends Element {
       dirty = true;
     }
     if (flags.fromSubmission && !_.isUndefined(_.get(flags?.submission?.data, this.key)) && !(this.pristine && this.protected)) {
-      dirty = this.pristine && this.component.protected ? false : true;
+      dirty = true;
     }
     this.setDirty(dirty);
     return this.setComponentValidity(errors, dirty, flags.silentCheck, flags.fromSubmission);

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2810,7 +2810,6 @@ export default class Component extends Element {
       return;
     }
     _.set(this._data, this.key, value);
-    return;
   }
 
   /**
@@ -3388,14 +3387,15 @@ export default class Component extends Element {
     if (flags.silentCheck) {
       return [];
     }
+    let dirty = this.dirty || flags.dirty
     if (this.options.alwaysDirty) {
-      flags.dirty = true;
+      dirty = true;
     }
-    if (flags.fromSubmission && this.hasValue(data) && !(this.pristine && this.protected)) {
-      flags.dirty = true;
+    if (flags.fromSubmission && !_.isUndefined(_.get(flags?.submission?.data, this.key)) && !(this.pristine && this.protected)) {
+      dirty = true;
     }
-    this.setDirty(flags.dirty);
-    return this.setComponentValidity(errors, flags.dirty, flags.silentCheck, flags.fromSubmission);
+    this.setDirty(dirty);
+    return this.setComponentValidity(errors, dirty, flags.silentCheck, flags.fromSubmission);
   }
 
   /**

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -927,22 +927,24 @@ export default class NestedComponent extends Field {
 
   setNestedValue(component, value, flags = {}) {
     component._data = this.componentContext(component);
+    let componentFlags = {...flags};
+
     if (component.type === 'button') {
       return false;
     }
     if (component.type === 'components') {
       if (component.tree && component.hasValue(value)) {
-        return component.setValue(_.get(value, component.key), flags);
+        return component.setValue(_.get(value, component.key), componentFlags);
       }
-      return component.setValue(value, flags);
+      return component.setValue(value, componentFlags);
     }
     else if (value && component.hasValue(value)) {
-      return component.setValue(_.get(value, component.key), flags);
+      return component.setValue(_.get(value, component.key), componentFlags);
     }
     else if ((!this.rootPristine || component.visible) && component.shouldAddDefaultValue) {
-      flags.noValidate = !flags.dirty;
-      flags.resetValue = true;
-      return component.setValue(component.defaultValue, flags);
+      componentFlags.noValidate = !componentFlags.dirty;
+      componentFlags.resetValue = true;
+      return component.setValue(component.defaultValue, componentFlags);
     }
   }
 

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -1162,6 +1162,7 @@ export default class EditGridComponent extends NestedArrayComponent {
       editRow.state === EditRowState.New ||
       editRow.state === EditRowState.Editing ||
       editRow.alerts ||
+      this.dirty ||
       dirty;
   }
 
@@ -1244,7 +1245,7 @@ export default class EditGridComponent extends NestedArrayComponent {
   }
 
   checkComponentValidity(data, dirty, row, options = {}, errors = []) {
-    const { silentCheck } = options;
+    const { silentCheck, fromSubmission } = options;
     const superValid = super.checkComponentValidity(data, dirty, row, options, errors);
 
     // If super tells us that component invalid and there is no need to update alerts, just return false
@@ -1256,7 +1257,7 @@ export default class EditGridComponent extends NestedArrayComponent {
     const allRowErrors = [];
     this.editRows.forEach((editRow, index) => {
       // Trigger all errors on the row.
-      const rowErrors = this.validateRow(editRow, dirty, silentCheck);
+      const rowErrors = this.validateRow(editRow, dirty, silentCheck, fromSubmission);
       errors.push(...rowErrors);
       allRowErrors.push(...rowErrors);
 

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -1245,7 +1245,7 @@ export default class EditGridComponent extends NestedArrayComponent {
   }
 
   checkComponentValidity(data, dirty, row, options = {}, errors = []) {
-    const { silentCheck, fromSubmission } = options;
+    const { silentCheck } = options;
     const superValid = super.checkComponentValidity(data, dirty, row, options, errors);
 
     // If super tells us that component invalid and there is no need to update alerts, just return false
@@ -1257,7 +1257,7 @@ export default class EditGridComponent extends NestedArrayComponent {
     const allRowErrors = [];
     this.editRows.forEach((editRow, index) => {
       // Trigger all errors on the row.
-      const rowErrors = this.validateRow(editRow, dirty, silentCheck, fromSubmission);
+      const rowErrors = this.validateRow(editRow, dirty, silentCheck);
       errors.push(...rowErrors);
       allRowErrors.push(...rowErrors);
 

--- a/test/unit/EditGrid.unit.js
+++ b/test/unit/EditGrid.unit.js
@@ -715,12 +715,12 @@ describe('EditGrid Component', () => {
                 assert(form.submitted, 'Form should be submitted');
                 const editRow = editGrid.editRows[0];
                 assert(editRow.alerts, 'Should add an error alert to the modal');
-                assert.equal(editRow.errors.length, 2, 'Should add errors to components inside draft row aftre it was submitted');
+                assert.equal(editRow.errors.length, 2, 'Should add errors to components inside draft row after it was submitted');
                 const textField = editRow.components[0].getComponent('textField');
 
                 const alert = editGrid.alert;
                 assert(alert, 'Should show an error alert when drafts are enabled and form is submitted');
-                assert(textField.element.className.includes('has-error'), 'Should add error class to component even when drafts enabled if the form was submitted');
+                assert(textField.element.className.includes('error'), 'Should add error class to component even when drafts enabled if the form was submitted');
 
                 // 4. Change the value of the text field
                 textField.setValue('new value', { modified: true });
@@ -736,7 +736,7 @@ describe('EditGrid Component', () => {
 
                   setTimeout(() => {
                     assert.equal(textField2.dataValue, 'test val');
-                    assert(!textField2.element.className.includes('has-error'), 'Should remove an error class from component when it was fixed');
+                    assert(!textField2.element.className.includes('error'), 'Should remove an error class from component when it was fixed');
 
                     editGrid.saveRow(0);
 

--- a/test/unit/Wizard.unit.js
+++ b/test/unit/Wizard.unit.js
@@ -637,7 +637,7 @@ describe('Wizard tests', () => {
         };
 
         clickWizardBtn('link[4]');
-        
+
         setTimeout(() => {
           checkPage(4);
           clickWizardBtn('submit');
@@ -664,7 +664,7 @@ describe('Wizard tests', () => {
     })
     .catch((err) => done(err));
   });
-  
+
 
   it('Should execute advanced logic for wizard pages', function(done) {
     const formElement = document.createElement('div');
@@ -1178,7 +1178,7 @@ describe('Wizard tests', () => {
 
             assert.equal(wizard.visibleErrors.length, 3, 'Should have page validation error');
             assert.equal(wizard.refs.errorRef.length, 3, 'Should keep alert with validation errors');
-            checkInvalidComp('textField');
+            checkInvalidComp('textField', true);
             clickWizardBtn('errorRef[1]', true);
 
             setTimeout(() => {
@@ -1186,7 +1186,7 @@ describe('Wizard tests', () => {
 
               assert.equal(wizard.visibleErrors.length, 3, 'Should have page validation error');
               assert.equal(wizard.refs.errorRef.length, 3, 'Should keep alert with validation errors');
-              checkInvalidComp('checkbox');
+              checkInvalidComp('checkbox', true);
               wizard.getComponent('checkbox').setValue(true);
 
               setTimeout(() => {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9072

## Description
### Webform.js
- Added explicit submission to flags so that it can be used to make a component dirty or not
- Made it so that if noValidate flag is set to true then the component will not validate. This was a problem because sometimes the noValidate flag was set to undefined causing shouldNotValidate to be true unexpectedly  

### Component.js
- Changed it so that when the dirty flag is set to true it doesn't propagate to sibling components
- Changed it so that the components dirty property is set to true when there is an explicit submission

### NestedComponent.js
- Component now uses a copy of flags so that a change in flags from one component does not propagate throughout other components

### Editgrid.js
- If the Editgrid is dirty then the row should be validated

**Why have you chosen this solution?**

This solution is probably the closest to what the best solution would be. Unfortunately it is not a small change to make it so that the required validation is not triggered on form init. There is a lot of assumptions made around the dirty flag and it seems as though we were just getting lucky that this hasn't appeared before. A lot of the changes made here fix these assumptions.

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

Added automated tests and manually tested. Also changed some tests which I will discuss in dev support

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
