### PR TITLE
FIO-9153: fixed an issue where tagpad components skip front-end validation before submission

### DIFF
--- a/src/components/Components.js
+++ b/src/components/Components.js
@@ -1,7 +1,7 @@
 import Component from './_classes/component/Component';
 import EditFormUtils from './_classes/component/editForm/utils';
 import BaseEditForm from './_classes/component/Component.form';
-import { getComponentKey } from '../utils/utils';
+import { getComponentKey, getModelType } from '../utils/utils';
 import _ from 'lodash';
 export default class Components {
   static _editFormUtils = EditFormUtils;
@@ -77,6 +77,9 @@ export default class Components {
       const rowIndex = component.row;
       const rowIndexPath = rowIndex && !['container'].includes(thisPath.component.type) ? `[${Number.parseInt(rowIndex)}]` : '';
       path = `${thisPath.path}${rowIndexPath}.`;
+      if (rowIndexPath && getModelType(thisPath) === 'nestedDataArray') {
+        path = `${path}data.`;
+      }
       path += componentKey;
       return _.trim(path, '.');
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9153

## Description

**What changed?**

After changes made in core by https://github.com/formio/core/pull/157, there was inconsistency in path calculation for tagpad that causes the validation for tagpad child components to be skipped. This PR fixes the path calculation.

## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
