### PR TITLE
FIO-9196: Fixed issue with getting default value instead of requested value in Day component

### DIFF
--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -655,6 +655,9 @@ export default class DayComponent extends Field {
    * @returns {string|null} - The string value of the date.
    */
   getValueAsString(value) {
+    if (!value) {
+      return '';
+    }
     return this.getDate(value) || '';
   }
 

--- a/test/unit/Day.unit.js
+++ b/test/unit/Day.unit.js
@@ -416,7 +416,7 @@ describe('Day Component', () => {
         assert.equal(dayComponent.errors[0].message, 'Day - Table is required');
         done();
       },200);
-    });
+    }).catch(done);
   });
 
   it('Should save empty value after deleting the values', (done) => {
@@ -434,7 +434,7 @@ describe('Day Component', () => {
         assert.equal(component.getValue(), '');
         done();
       }, 100);
-    });
+    }).catch(done);
   });
 
   it('Should save empty value after deleting the values if the day field is hidden', (done) => {
@@ -450,7 +450,7 @@ describe('Day Component', () => {
         assert.equal(component.getValue(), '');
         done();
       }, 100);
-    });
+    }).catch(done);
     comp1.fields.day.hide = false;
   });
 
@@ -468,7 +468,22 @@ describe('Day Component', () => {
         assert.equal(component.getValue(), '');
         done();
       }, 100);
-    });
+    }).catch(done);
+    delete comp1.defaultValue;
+  });
+
+  it('Should return correct values from getValueAsString without using default value', (done) => {
+    comp1.defaultValue = '10/12/2024';
+    Harness.testCreate(DayComponent, comp1)
+      .then((component) => {
+        assert.equal(component.getValue(), '10/12/2024');
+        assert.equal(component.getValueAsString('11/12/2024'), '11/12/2024');
+        assert.equal(component.getValueAsString(''), '');
+        assert.equal(component.getValueAsString(null), '');
+        assert.equal(component.getValueAsString(), '');
+        done();
+      })
+      .catch(done);
     delete comp1.defaultValue;
   });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9196

## Description

**Issue**: The DataTable is calling the method `getValueAsString` to get the string representation of a value from the submission. The `getValueAsString` method internally calls the `getDate` method, which uses the default value of the component if the value is empty. This results in the DataTable showing the default value instead of a blank.

**Solution**: Add a check to see if the value is not set. If the value is not set, return an empty string without calling the internal method getDate.

## How has this PR been tested?

Unit tests and manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
