### PR TITLE
[4.21.x] FIO-9196: Fixed the issue with empty value in Day component

### DIFF
--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -413,6 +413,9 @@ export default class DayComponent extends Field {
    * @param value
    */
   setValueAt(index, value) {
+    if (value === '') {
+      value = this.emptyValue;
+    }
     // temporary solution to avoid input reset
     // on invalid date.
     if (!value || value === 'Invalid date') {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9196

## Description

**Issue**: The 5.x renderer changed the emptyValue for the day component. The formio-viewer wasn't updated to use the 5.x renderer and is still using the 4.x version. As a result, the PDF server, which relies on formio-viewer to generate PDFs, encounters a small inconsistency. When the 4.x renderer encounters a 5.x emptyValue, it cannot handle it and uses the default value. This causes the PDF server to generate a default value for the 5.x empty value.

**Solution**: Add a check for an empty string, which is the emptyValue for the 5.x renderer, and use the emptyValue from the 4.x renderer instead.


## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
