### PR TITLE
FIO-9197: Fix Day component triggered required validation when loading form

### DIFF
--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -54,6 +54,9 @@ export default class DayComponent extends Field {
     return getComponentSavedTypes(schema) || [componentValueTypes.string];
   }
 
+  // Empty value used before 9.3.x
+  static oldEmptyValue = '00/00/0000';
+
   constructor(component, options, data) {
     if (component.maxDate && component.maxDate.indexOf('moment(') === -1) {
       component.maxDate = moment(component.maxDate, 'YYYY-MM-DD').toISOString();
@@ -118,6 +121,13 @@ export default class DayComponent extends Field {
     info.attr.type = 'hidden';
     info.changeEvent = 'input';
     return info;
+  }
+
+  isEmpty(value = this.dataValue) {
+    if (value === DayComponent.oldEmptyValue) {
+      return true
+    }
+    return super.isEmpty(value);
   }
 
   inputDefinition(name) {
@@ -379,6 +389,11 @@ export default class DayComponent extends Field {
   }
 
   normalizeValue(value) {
+    // Adjust the value from old to new format
+    if (value === DayComponent.oldEmptyValue) {
+      value = '';
+    }
+
     if (!value || this.valueMask.test(value)) {
       return value;
     }
@@ -390,7 +405,6 @@ export default class DayComponent extends Field {
     let defaultDay = '';
     let defaultMonth = '';
     let defaultYear = '';
-    
     if(defaultValue) {
       const hasHiddenFields = defaultValue.length !==3;
       defaultDay = hasHiddenFields ? this.getDayWithHiddenFields(defaultValue).day : defaultValue[DAY];

--- a/test/unit/Day.unit.js
+++ b/test/unit/Day.unit.js
@@ -33,6 +33,21 @@ describe('Day Component', () => {
     });
   });
 
+  it('Should not show error when form loaded with defaultValue = "00/00/0000"', (done) => {
+      Formio.createForm(document.createElement('div'), comp5, {}).then((form) => {
+        const dayComponent = form.getComponent('day');
+        assert.equal(dayComponent.visibleErrors.length, 0);
+        assert.equal(form.data.day, '');
+        const buttonComponent = form.getComponent('submit');
+        buttonComponent.refs.button.click();
+        setTimeout(()=>{
+          assert.equal(dayComponent.visibleErrors.length, 1);
+          assert.equal(dayComponent.visibleErrors[0].message, 'Day is required');
+          done();
+        },200);
+      });
+  });
+
   it('Should change the max day when the month changes', (done) => {
     Harness.testCreate(DayComponent, comp1).then((component) => {
       Harness.testElements(component, 'option', 13);

--- a/test/unit/fixtures/day/comp5.js
+++ b/test/unit/fixtures/day/comp5.js
@@ -26,5 +26,11 @@ export default {
       input: true,
       defaultValue: '00/00/0000'
     },
+    {
+      type: 'button',
+      action: 'submit',
+      label: 'Submit',
+      theme: 'primary'
+    }
   ]
 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9197

## Description

**What changed?**

Made a check to count before 9.3.x '00/00/0000' value as empty. Added convertion to an empty string if this value is met.

**Why have you chosen this solution?**

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

Checked against such scenarios, haven't noticed any issues

1) application that uses 4.x renderer works with 9.3.x server validations.

2) application that uses 5.x renderer works with 8.x server validations.

3) application that uses 5.x renderer works with 9.2.x server validations.

4) application that uses 5.x renderer works with 9.3.x server validations.

## Dependencies

None

## How has this PR been tested?

Automated test added

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
