### PR TITLE
FIO-9176: fix rewriting of component path in eachComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@formio/bootstrap": "3.0.0-dev.98.17ba6ea",
     "@formio/choices.js": "^10.2.1",
-    "@formio/core": "2.3.0-dev.160.cabaa43",
+    "@formio/core": "v2.1.0-dev.170.9d1e8b7",
     "@formio/text-mask-addons": "^3.8.0-formio.2",
     "@formio/vanilla-text-mask": "^5.1.1-formio.1",
     "abortcontroller-polyfill": "^1.7.5",

--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1777,7 +1777,7 @@ export default class Webform extends NestedDataComponent {
             return;
         }
         const captchaComponent = [];
-        eachComponent(this.components, (component) => {
+        this.eachComponent((component) => {
             if (/^(re)?captcha$/.test(component.type) && component.component.eventType === 'formLoad') {
                 captchaComponent.push(component);
             }

--- a/test/unit/EditGrid.unit.js
+++ b/test/unit/EditGrid.unit.js
@@ -33,6 +33,7 @@ import Webform from '../../src/Webform'
 import { displayAsModalEditGrid } from '../formtest';
 import { Formio } from '../../src/Formio';
 import { fastCloneDeep } from '@formio/core';
+import comp20 from './fixtures/editgrid/comp20';
 
 describe('EditGrid Component', () => {
   it('Should set correct values in dataMap inside editGrid and allow aditing them', (done) => {
@@ -1479,6 +1480,31 @@ describe('EditGrid Component', () => {
 
     }).catch(done);
   });
+
+  it('Validation error should contain the correct path to the component inside editGrid without openWhenEmpty', async() => {
+    let form = _.cloneDeep(comp20);
+    const element = document.createElement('div');
+    try {
+      form = await Formio.createForm(element, form);
+    }
+    catch(validationError) {
+      assert.equal(validationError.length, 1, 'Should have 1 validation error');
+      assert.equal(validationError[0].context.path, 'editGrid[0].textField', 'Should have correct path to insure that component can be accessed via link from error message ' );
+    }
+  }).timeout(3000);
+
+  it('Validation error should contain the correct path to the component inside editGrid with openWhenEmpty', async () => {
+    let form = _.cloneDeep(comp20);
+    const element = document.createElement('div');
+    form.components[0].openWhenEmpty = true;
+    try {
+      form = await Formio.createForm(element, form);
+    }
+    catch(validationError) {
+      assert.equal(validationError.length, 1, 'Should have 1 validation error');
+      assert.equal(validationError[0].context.path, 'editGrid[0].textField', 'Should have correct path to insure that component can be accessed via link from error message ' );
+    }
+  }).timeout(3000);
 });
 
 describe('EditGrid Open when Empty', () => {

--- a/test/unit/fixtures/editgrid/comp20.js
+++ b/test/unit/fixtures/editgrid/comp20.js
@@ -1,0 +1,37 @@
+export default {
+	type: 'form',
+	components: [
+		{
+			label: 'Edit Grid',
+			tableView: false,
+			rowDrafts: false,
+			key: 'editGrid',
+			type: 'editgrid',
+			input: true,
+			components: [
+				{
+					label: 'Text Field',
+					tableView: true,
+					key: 'textField',
+					type: 'textfield',
+					input: true,
+          validate :  {
+            required: true
+          }
+				}
+			]
+		},
+		{
+			label: 'Submit',
+			showValidations: false,
+			tableView: false,
+			key: 'submit',
+			type: 'button',
+			input: true
+		}
+	],
+	title: 'test20',
+	display: 'form',
+	name: 'test20',
+	path: 'test20',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,10 +381,10 @@
     fuse.js "^6.6.2"
     redux "^4.2.0"
 
-"@formio/core@2.3.0-dev.160.cabaa43":
-  version "2.3.0-dev.160.cabaa43"
-  resolved "https://registry.yarnpkg.com/@formio/core/-/core-2.3.0-dev.160.cabaa43.tgz#d61abaeecdfe7adb472afa33f68fe40f3f833751"
-  integrity sha512-GOpg2Fihsxph6aShM76q5SzrUSo5Xg3fm0aV6Up1hS+fZmJZb5xl+Ig5ABh3CnVncxkNPBsPj8I96sLYMdvj/A==
+"@formio/core@v2.1.0-dev.170.9d1e8b7":
+  version "2.1.0-dev.170.9d1e8b7"
+  resolved "https://registry.yarnpkg.com/@formio/core/-/core-2.1.0-dev.170.9d1e8b7.tgz#84285824392c638c6225cc54081600b4cc277770"
+  integrity sha512-x64oZuOj8wGJpzr5wQpa9pCGR5li8BZZwPtaYKZEOFmHdRjyaJeDPQYsgQsfYGvud3pt7fZiQWdOVslcpsMMIQ==
   dependencies:
     "@types/json-logic-js" "^2.0.7"
     browser-cookies "^1.2.0"


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9176

## Description
In  triggerCaptcha  function use webform's eachComponent.  This avoids setting incorrect path for components inside editgrid components with openWhenEmpty parameter.



## Dependencies

https://github.com/formio/core/pull/170

## How has this PR been tested?

autotests
manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
