### PR TITLE
FIO-7195: Fixes an issue where Radio/SelectBoxes will show values instead of labels on View tab and in DataTable

### DIFF
--- a/src/components/_classes/list/ListComponent.js
+++ b/src/components/_classes/list/ListComponent.js
@@ -22,7 +22,7 @@ export default class ListComponent extends Field {
 
   get selectData() {
     const selectData = _.get(this.root, 'submission.metadata.selectData', {});
-    return _.get(selectData, this.path) || this.component.selectData;
+    return _.get(selectData, this.path);
   }
 
   get dataReady() {

--- a/src/components/_classes/list/ListComponent.js
+++ b/src/components/_classes/list/ListComponent.js
@@ -22,7 +22,7 @@ export default class ListComponent extends Field {
 
   get selectData() {
     const selectData = _.get(this.root, 'submission.metadata.selectData', {});
-    return _.get(selectData, this.path);
+    return _.get(selectData, this.path) || this.component.selectData;
   }
 
   get dataReady() {
@@ -145,7 +145,7 @@ export default class ListComponent extends Field {
   set itemsLoaded(promise) {
     this._itemsLoaded = promise;
   }
-  
+
   handleLoadingError(err) {
     this.loading = false;
     if (err.networkError) {

--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -128,6 +128,14 @@ export default class RadioComponent extends ListComponent {
     return _.get(listData, this.path);
   }
 
+  get selectMetadata() {
+    return super.selectData;
+  }
+
+  get selectData() {
+    return this.selectMetadata || this.component.selectData;
+  }
+
   init() {
     super.init();
     this.templateData = {};

--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -282,13 +282,16 @@ export default class RadioComponent extends ListComponent {
       value = _.toString(value);
     }
 
-    const isModalPreviewWithUrlDataSource = options.modalPreview && this.component.dataSrc === 'url';
-    if (this.component.dataSrc !== 'values' && !isModalPreviewWithUrlDataSource) {
+    const shouldUseSelectData = (options.modalPreview || this.inDataTable)
+      && this.component.dataSrc === 'url' && (this.loadedOptions.length || this.selectData);
+    if (this.component.dataSrc !== 'values' && !shouldUseSelectData) {
       return value;
     }
 
-    const values = isModalPreviewWithUrlDataSource ? this.loadedOptions : this.component.values;
-    const option = _.find(values, (v) => v.value === value);
+    const values = shouldUseSelectData ? this.loadedOptions : this.component.values;
+    const option = !values?.length && shouldUseSelectData ? {
+      label: this.itemTemplate(this.selectData),
+    } : _.find(values, (v) => v.value === value);
 
     if (!value) {
       return _.get(option, 'label', '');

--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -200,8 +200,13 @@ export default class SelectBoxesComponent extends RadioComponent {
     }
 
     if (this.isSelectURL) {
-      if (options.modalPreview && this.loadedOptions) {
-        return this.loadedOptions.filter((option) => value[option.value]).map((option) => option.label).join(', ');
+      if (options.modalPreview || this.options.readOnly || this.inDataTable) {
+        const checkedItems = _.keys(_.pickBy(value, (val) => val));
+        if (this.selectData?.length === checkedItems.length) {
+          return this.selectData.map(item => this.itemTemplate(item)).join(', ');
+        } else if (this.loadedOptions?.length) {
+          return this.loadedOptions.filter((option) => value[option.value]).map((option) => option.label).join(', ');
+        }
       }
       return _(value).pickBy((val) => val).keys().join(', ');
     }

--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -356,10 +356,10 @@ export default class TextAreaComponent extends TextFieldComponent {
   }
 
   /**
- * Normalize values coming into updateValue. For example, depending on the configuration, string value `"true"` will be normalized to boolean `true`.
- * @param {*} value - The value to normalize
- * @returns {*} - Returns the normalized value
- */
+   * Normalize values coming into updateValue. For example, depending on the configuration, string value `"true"` will be normalized to boolean `true`.
+   * @param {*} value - The value to normalize
+   * @returns {*} - Returns the normalized value
+   */
   normalizeValue(value) {
     if (this.component.multiple && Array.isArray(value)) {
       return value.map((singleValue) => this.normalizeSingleValue(singleValue));


### PR DESCRIPTION
…tead of labels on View tab and in DataTable

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7195

## Description

Implemented changes required to force SelectBoxes/Radio components to use saved selectData when loaded options are not available (View tab/DataTable)

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
