### PR TITLE
FIO-9176: update rewriting of components  path into EditGrid with openWhenEmpty

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -14,7 +14,7 @@ import {
     convertStringToHTMLElement,
     getArrayFromComponentPath,
 } from "./utils/utils";
-import { eachComponent } from "./utils/formUtils";
+import { eachComponent, eachComponentData } from "./utils/formUtils";
 
 // We need this here because dragula pulls in CustomEvent class that requires global to exist.
 if (typeof window !== 'undefined' && typeof window.global === 'undefined') {
@@ -1777,7 +1777,7 @@ export default class Webform extends NestedDataComponent {
             return;
         }
         const captchaComponent = [];
-        eachComponent(this.components, (component) => {
+        eachComponentData(this.components, {}, (component) => {
             if (/^(re)?captcha$/.test(component.type) && component.component.eventType === 'formLoad') {
                 captchaComponent.push(component);
             }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9176

## Description

Function eachComponent was replaced with eachComponentData with empty data in triggerCaptcha.
Those changes allow to set path to the component inside EditGrid components with openWhenEmpty parameter in the format: EditGridKey[i].componentKey. Which ensures correct access to the component via the reference in the validation error.

## Dependencies

https://github.com/formio/core/pull/170

## How has this PR been tested?
autotests
manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
