### PR TITLE
FIO-9176: updated instance.component.path

### DIFF
--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -773,6 +773,11 @@ export default class NestedComponent extends Field {
     if (!instance) {
       return;
     }
+
+    if(!instance.component.path) {
+      instance.component.path = component.path;
+    }
+
     instance.checkComponentValidity(data, dirty, row, flags, scope.errors);
     if (instance.processOwnValidation) {
       scope.noRecurse = true;

--- a/src/components/editgrid/EditGrid.unit.js
+++ b/src/components/editgrid/EditGrid.unit.js
@@ -1585,6 +1585,8 @@ describe('EditGrid Open when Empty', () => {
             assert.equal(editRow.errors.length, 1, 'Should show error on row');
             const textField = editRow.components[0];
             assert(textField.element.className.includes('formio-error-wrapper'), 'Should add error class to component');
+            const error = editRow.errors[0];
+            assert.equal(error.formattedKeyOrPath, 'editGrid[0].textField');
             done();
           }, 450);
       }, 100);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9176

## Description
The problem was caused by the absence of instance.component.path for components inside rows of components such as edit grid. So in the validation processor for nested components, the instance.component.path is updated with current data from component.path (obtained from eachComponentData (core)).
This allows to get full path to components inside components such as edit grid and avoid an error when there are components with same key inside and outside edit grid component. Which ensures correct access to the component via the reference in the validation error.

## Breaking Changes / Backwards Compatibility

-

## Dependencies

-

## How has this PR been tested?
autotests
manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
