### PR TITLE
FIO-9246 fixed saving draft for form with nested form and reference false

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -838,7 +838,7 @@ export default class Webform extends NestedDataComponent {
     }
 
     saveDraft() {
-        if (!this.draftEnabled) {
+        if (!this.draftEnabled || this.parent?.component.reference === false) {
             return;
         }
         if (!this.formio) {

--- a/test/unit/Form.unit.js
+++ b/test/unit/Form.unit.js
@@ -492,6 +492,31 @@ describe('SaveDraft functionality for Nested Form', () => {
     }).catch((err) => done(err));
   });
 
+  it('Should not create a draft submission for nested form if Save as reference is set to false', function(done) {
+    _.set(comp7.components[1], 'reference', false);
+    const formElement = document.createElement('div');
+    Formio.createForm(
+      formElement,
+      'http://localhost:3000/idwqwhclwioyqbw/testdraftparent',
+      {
+        saveDraft: true
+      }
+    ).then((form)=>{
+      setTimeout(() => {
+        const tfNestedInput = form.getComponent('form.nested').refs.input[0];
+        tfNestedInput.value = 'test Nested Input';
+        const inputEvent = new Event('input');
+        tfNestedInput.dispatchEvent(inputEvent);
+        setTimeout(() => {
+          assert.equal(saveDraftCalls, 1);
+          assert.equal(state, 'draft');
+          _.unset(comp7.components[1], 'reference');
+          done();
+        }, 1000);
+      }, 200);
+    }).catch((err) => done(err));
+  });
+
   it('Should pass all the required options to the nested form properly', function(done) {
     const formElement = document.createElement('div');
     Formio.createForm(


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9246

## Description

*Fixed the behavior of the Save as draft functionality, in which a request was sent to save a draft for a child form when the reference property was set to false. Now, if the reference property is set to false, then the draft is saved only for the parent form*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated tests have been added. All test pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
