### PR TITLE
FIO-9290: fixed an issue where infinite loader is shown when radio/selectboxes with url type is failed to load options

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -365,12 +365,13 @@ export default class RadioComponent extends ListComponent {
     .then((response) => {
       this.loading = false;
       this.setItems(response);
-      this.optionsLoaded = true;
-      this.redraw();
     })
     .catch((err) => {
-      this.optionsLoaded = true;
       this.handleLoadingError(err);
+    })
+    .finally(() => {
+      this.optionsLoaded = true;
+      this.redraw();
     });
   }
 

--- a/test/unit/Radio.unit.js
+++ b/test/unit/Radio.unit.js
@@ -322,6 +322,27 @@ describe('Radio Component', () => {
       done();
     }).catch(done);
   });
+
+  it('Should not show infinite loader for radio with URL data source if options loading failed', (done) => {
+    const form = _.cloneDeep(comp9);
+    const element = document.createElement('div');
+    const originalMakeRequest = Formio.makeRequest;
+
+    Formio.makeRequest = function() {
+      return new Promise((res, rej) => {
+        setTimeout(() => rej('loading error'), 200);
+      });
+    };
+    Formio.createForm(element, form).then(form => {
+      const radio = form.getComponent('radio');
+      assert.equal(!!radio.element.querySelector('.loader'), true, 'Should show loader.')
+      setTimeout(()=>{
+        assert.equal(!!radio.element.querySelector('.loader'), false, 'Should not show loader.')
+        Formio.makeRequest = originalMakeRequest;
+        done();
+      }, 350);
+    }).catch(done);
+  });
 });
 
 describe('Radio Component', () => {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9290

## Description

**What changed?**

Always redraw the radio/selectboxes after request promise is resolved/rejected to remove the loader.

## How has this PR been tested?

Manually + tests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
