### PR TITLE
FIO-9280 fixed value property validation

### DIFF
--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { componentValueTypes, getComponentSavedTypes, boolValue } from '../../utils/utils';
+import { componentValueTypes, getComponentSavedTypes, boolValue, getComponent } from '../../utils/utils';
 import RadioComponent from '../radio/Radio';
 
 export default class SelectBoxesComponent extends RadioComponent {
@@ -297,6 +297,17 @@ export default class SelectBoxesComponent extends RadioComponent {
     }
 
     return super.checkComponentValidity(data, dirty, rowData, options, errors);
+  }
+
+  setCustomValidity(messages, dirty, external) {
+    if (this.options.building && _.find(messages, {ruleName: 'invalidValueProperty'})) {
+      setTimeout(() => {
+        this.root && getComponent(this.root.components, 'valueProperty').setCustomValidity(messages, dirty);
+      }, 0);
+      return super.setCustomValidity(_.filter(messages, (message) => message.ruleName !=='invalidValueProperty'), dirty, external);
+    } else {
+      return super.setCustomValidity(messages, dirty, external);
+    };
   }
 
   validateValueAvailability(setting, value) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9280

## Description

*Added value property validation for the Select Boxes component in the form builder. Now, when trying to save a component, the value property validation is triggered. If the value property is invalid, an error appears and the selectboxes component is not saved.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*https://github.com/formio/core/pull/185*

## How has this PR been tested?

*locally, automated tests have been added*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
