### PR TITLE
FIO-9280 fixed validation for select boxes with valid values and when value property is not set

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -398,10 +398,9 @@ export default class RadioComponent extends ListComponent {
       };
       listData.push(this.templateData[this.component.valueProperty ? valueAtProperty : i]);
 
-      if ((this.component.valueProperty || !this.isRadio) && (
-        _.isUndefined(valueAtProperty) ||
-        (!this.isRadio && _.isObject(valueAtProperty)) ||
-        (!this.isRadio && _.isBoolean(valueAtProperty))
+      const value = this.loadedOptions[i].value;
+      if (!this.isRadio && (
+        _.isObject(value) || _.isBoolean(value) || _.isUndefined(value)
       )) {
         this.loadedOptions[i].invalid = true;
       }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9280

## Description

*Fixed an issue where validation was triggered with the correct value for items of the SelectBoxes component if Value Property was not set*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

https://github.com/formio/core/pull/185

https://github.com/formio/formio.js/pull/5894 

## How has this PR been tested?

*locally. Automated test have been added previously *

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
