### PR TITLE
FIO-9217 Fix: allow moment.js datetime custom default values in calendar widget-text field components

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2884,7 +2884,7 @@ export default class Component extends Element {
       return value;
     };
 
-    if (this.defaultMask) {
+    if (Array.isArray(this.defaultMask) ? this.defaultMask.length > 0 : this.defaultMask) {
       if (Array.isArray(defaultValue)) {
         defaultValue = defaultValue.map(checkMask);
       }

--- a/test/unit/TextField.unit.js
+++ b/test/unit/TextField.unit.js
@@ -15,6 +15,8 @@ import {
   comp7,
 } from './fixtures/textfield';
 
+import { comp10 as formWithCalendarTextField } from './fixtures/datetime';
+
 describe('TextField Component', () => {
   it('Should create a new TextField', () => {
     const textField = new TextFieldComponent({
@@ -1357,6 +1359,23 @@ describe('TextField Component', () => {
           }, 300);
         }, 300);
       }, 300);
+    }).catch(done);
+  });
+  // see https://formio.atlassian.net/browse/FIO-9217
+  it('Should allow the populating of a calendar widget–text field component with a custom default value that is a moment datetime', (done) => {
+    const form = _.cloneDeep(formWithCalendarTextField);
+    const textFieldComponent = form.components[1];
+    textFieldComponent.customDefaultValue = "value=moment('2024-11-13 15:00:00')";
+
+    const element = document.createElement('div');
+
+    Formio.createForm(element, form).then(renderedForm => {
+      const renderedTextFieldComponent = renderedForm.getComponent('textField');
+      setTimeout(() => {
+        const input = renderedTextFieldComponent.element.querySelector('.input');
+        assert.equal(input.value, '2024-11-13 03:00 PM');
+        done();
+      }, 200);
     }).catch(done);
   });
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9217

## Description

When attempting to populate a text field component with a calendar widget with a custom default value that is a moment.js datetime the value eventually renders as empty string after initially rendering as the correct value. For some reason the default mask in component.js was being set to an empty array in this scenario. 

**What changed?**

Check for empty array in component.js to avoid erroneously setting the default value to an empty string. 

**Why have you chosen this solution?**

It was minimally invasive and is a check that should be in place already. If we don't have any masks in the default masks array, we don't want to treat it like we do have a mask. Empty arrays in JS evaluate as true, but we only want to execute the code if we actually have a mask. It's also worth noting that I believe the empty default mask array was being created in `TextField.js`'s [`setInputMask`](https://github.com/formio/formio.js/blob/854241f5fae66ab09066e649df0aa94e5be26440/src/components/textfield/TextField.js#L249) method.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Manual + automated

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
