### PR TITLE
FIO-9354: Fix custom translation not applied to error message

### DIFF
--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -83,6 +83,10 @@ export class I18n {
 
     t(text, ...args) {
         if (this.currentLanguage[text]) {
+            const customTranslationFieldName = args[0]?.field;
+            if (customTranslationFieldName && this.currentLanguage[customTranslationFieldName]) {
+                args[0].field = this.currentLanguage[customTranslationFieldName]
+            }
             return Evaluator.interpolateString(this.currentLanguage[text], ...args);
         }
         return Evaluator.interpolateString(text, ...args);

--- a/test/forms/translationErrorMessages.js
+++ b/test/forms/translationErrorMessages.js
@@ -1,0 +1,25 @@
+export default {
+	name: "textrandom",
+	path: "textrandom",
+	type: "form",
+	display: "form",
+	components: [
+		{
+			label: "My textField",
+			applyMaskOn: "change",
+			tableView: true,
+			validate: {
+				minLength: 5,
+				minWords: 2
+			},
+			validateWhenHidden: false,
+			key: "textField",
+			type: "textfield",
+			input: true
+		},
+	],
+	created: "2024-11-14T15:52:30.402Z",
+	modified: "2024-11-15T07:03:41.301Z",
+	machineName: "glvmkehegcvqksg:text",
+}
+

--- a/test/unit/Webform.unit.js
+++ b/test/unit/Webform.unit.js
@@ -86,6 +86,7 @@ import webformWithNestedWizard from '../forms/webformWIthNestedWizard';
 import formWithUniqueValidation from '../forms/formWithUniqueValidation.js';
 import formWithConditionalEmail from '../forms/formWithConditionalEmail.js';
 import formsWithSimpleConditionals from '../forms/formsWithSimpleConditionals.js';
+import translationErrorMessages from '../forms/translationErrorMessages.js';
 const SpySanitize = sinon.spy(FormioUtils, 'sanitize');
 
 if (_.has(Formio, 'Components.setComponents')) {
@@ -925,6 +926,29 @@ describe('Webform tests', function() {
       assert.equal(label, 'English Label');
       document.body.innerHTML = '';
       done();
+    }).catch(done);
+  });
+
+  it('Should translate field name in error messages', (done) => {
+    const element = document.createElement('div');
+    const form = new Webform(element, {
+      language: 'en',
+      i18n: {
+        en: {
+          'My textField': 'My Value'
+        },
+      }
+    });
+    form.setForm(translationErrorMessages).then(() => {
+      const textField = form.getComponent('textField');
+      textField.setValue('123');
+      textField.onChange()
+      setTimeout(() => {
+        assert.equal(form.errors.length, 2);
+        assert.equal(form.errors[0].message, 'My Value must have at least 5 characters.');
+        assert.equal(form.errors[1].message, 'My Value must have at least 2 words.');
+        done();
+      }, 300);
     }).catch(done);
   });
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9354

## Description

**What changed?**

Used custom translation field name if it's specified

**Why have you chosen this solution?**

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

None

## How has this PR been tested?

Automated test added

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
