### PR TITLE
FIO-9314: made select data property a hidden component and changed hidden component empty value to null

### DIFF
--- a/src/components/hidden/Hidden.js
+++ b/src/components/hidden/Hidden.js
@@ -51,7 +51,7 @@ export default class HiddenComponent extends Input {
   }
 
   get emptyValue() {
-    return '';
+    return null;
   }
 
   setValue(value, flags = {}) {

--- a/src/components/select/editForm/Select.edit.data.js
+++ b/src/components/select/editForm/Select.edit.data.js
@@ -686,6 +686,7 @@ export default [
   },
   {
     key: 'selectData',
+    type: 'hidden',
     conditional: {
       json: {
         and: [


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9314

## Description

**What changed?**

Changed the selectData property to be a hidden component and made hidden components empty values be null

**Why have you chosen this solution?**

The selectData property is a property that needs to be on the select component in certain cases but does not need to be shown or modified directly by a user. Making it a hidden component removes it from the edit form and making the hidden component have a empty value of null allows tests to pass. The reason why I thought it was ok to change the hidden component empty value to null is because the hidden component is usually used to store some kind of meta data in the form. This means the hidden component can be used to store any type of data such as Strings, Numbers, Objects, etc. It made more sense to me for the hidden component to have an empty value of null because having an empty value of '' (empty string) implies that you should only use hidden component to store string values.

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

Manually tested

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
