### PR TITLE
FIO-8677: Fixes an issue where its possible to draweon Signature on the View tab of PDF form

### DIFF
--- a/src/components/signature/Signature.js
+++ b/src/components/signature/Signature.js
@@ -180,7 +180,9 @@ export default class SignatureComponent extends Input {
         this.setDataToSigaturePad();
       }
 
-      this.showCanvas(true);
+      if (!this.disabled) {
+        this.showCanvas(true);
+      }
     }
   }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8677

## Description

showCanvas(true) should be never called if component is disabled since it will make it drawable (which should not happen in disabled state) 

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
