### PR TITLE
FIO-9241: Correctly set current page after conditionally hiding page in sibling nested wizard

### DIFF
--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -737,7 +737,7 @@ export default class NestedComponent extends Field {
 
   validationProcessor({ scope, data, row, instance, paths }, flags) {
     const { dirty } = flags;
-    if (this.root.hasExtraPages && this.page !== this.root.page) {
+    if (this.root.hasSubWizards && this.page !== this.root.page) {
       instance = this.componentsMap?.hasOwnProperty(paths.dataPath)
         ? this.componentsMap[paths.dataPath]
         : this.getComponent(paths.dataPath);

--- a/test/forms/wizardWithNestedWizardsAdvConditional.js
+++ b/test/forms/wizardWithNestedWizardsAdvConditional.js
@@ -1,0 +1,465 @@
+export default {
+    "_id": "67379d374d2df086c78c93d0",
+    "title": "WIZARD",
+    "name": "wizard",
+    "path": "wizard",
+    "type": "form",
+    "display": "wizard",
+    "tags": [],
+    "access": [
+        {
+            "type": "read_all",
+            "roles": [
+                "67379d374d2df086c78c93ae",
+                "67379d374d2df086c78c93b2",
+                "67379d374d2df086c78c93b6"
+            ]
+        }
+    ],
+    "submissionAccess": [],
+    "owner": null,
+    "components": [
+        {
+            "title": "A",
+            "breadcrumbClickable": true,
+            "buttonSettings": {
+                "previous": true,
+                "cancel": true,
+                "next": true
+            },
+            "navigateOnEnter": false,
+            "saveOnEnter": false,
+            "scrollToTop": false,
+            "collapsible": false,
+            "key": "page1",
+            "type": "panel",
+            "label": "Page 1",
+            "components": [
+                {
+                    "_id": "67379d374d2df086c78c93bb",
+                    "title": "CHILD A",
+                    "name": "childA",
+                    "path": "childa",
+                    "type": "form",
+                    "display": "wizard",
+                    "tags": [],
+                    "access": [
+                        {
+                            "type": "read_all",
+                            "roles": [
+                                "67379d374d2df086c78c93ae",
+                                "67379d374d2df086c78c93b2",
+                                "67379d374d2df086c78c93b6"
+                            ]
+                        }
+                    ],
+                    "submissionAccess": [],
+                    "owner": null,
+                    "components": [
+                        {
+                            "title": "A1",
+                            "breadcrumbClickable": true,
+                            "buttonSettings": {
+                                "previous": true,
+                                "cancel": true,
+                                "next": true
+                            },
+                            "navigateOnEnter": false,
+                            "saveOnEnter": false,
+                            "scrollToTop": false,
+                            "collapsible": false,
+                            "key": "page1",
+                            "type": "panel",
+                            "label": "Page 1",
+                            "components": [
+                                {
+                                    "label": "A1",
+                                    "applyMaskOn": "change",
+                                    "tableView": true,
+                                    "validateWhenHidden": false,
+                                    "key": "a",
+                                    "type": "textfield",
+                                    "input": true
+                                }
+                            ],
+                            "input": false,
+                            "tableView": false
+                        },
+                        {
+                            "title": "A2",
+                            "breadcrumbClickable": true,
+                            "buttonSettings": {
+                                "previous": true,
+                                "cancel": true,
+                                "next": true
+                            },
+                            "navigateOnEnter": false,
+                            "saveOnEnter": false,
+                            "scrollToTop": false,
+                            "collapsible": false,
+                            "key": "page2",
+                            "customConditional": "var b2comp = instance.root.root.getComponent('b2');\nshow = !(b2comp ? b2comp.getValue() === 'hide' : false);",
+                            "type": "panel",
+                            "label": "Page 2",
+                            "input": false,
+                            "tableView": false,
+                            "components": [
+                                {
+                                    "label": "A2",
+                                    "applyMaskOn": "change",
+                                    "tableView": true,
+                                    "validateWhenHidden": false,
+                                    "key": "a2",
+                                    "type": "textfield",
+                                    "input": true
+                                }
+                            ]
+                        },
+                        {
+                            "title": "A3",
+                            "breadcrumbClickable": true,
+                            "buttonSettings": {
+                                "previous": true,
+                                "cancel": true,
+                                "next": true
+                            },
+                            "navigateOnEnter": false,
+                            "saveOnEnter": false,
+                            "scrollToTop": false,
+                            "collapsible": false,
+                            "key": "page3",
+                            "type": "panel",
+                            "label": "Page 3",
+                            "input": false,
+                            "tableView": false,
+                            "components": [
+                                {
+                                    "label": "A3",
+                                    "applyMaskOn": "change",
+                                    "tableView": true,
+                                    "validateWhenHidden": false,
+                                    "key": "a3",
+                                    "type": "textfield",
+                                    "input": true
+                                }
+                            ]
+                        }
+                    ],
+                    "pdfComponents": [],
+                    "settings": {},
+                    "properties": {},
+                    "machineName": "authoring-qwwqrlcmffdcymd:childA",
+                    "project": "67379d374d2df086c78c93a4",
+                    "controller": "",
+                    "revisions": "",
+                    "submissionRevisions": "",
+                    "_vid": 0,
+                    "created": "2024-11-15T19:12:55.899Z",
+                    "modified": "2024-11-15T19:12:55.901Z"
+                }
+            ],
+            "input": false,
+            "tableView": false
+        },
+        {
+            "title": "B",
+            "breadcrumbClickable": true,
+            "buttonSettings": {
+                "previous": true,
+                "cancel": true,
+                "next": true
+            },
+            "navigateOnEnter": false,
+            "saveOnEnter": false,
+            "scrollToTop": false,
+            "collapsible": false,
+            "key": "page2",
+            "type": "panel",
+            "label": "Page 2",
+            "components": [
+                {
+                    "_id": "67379d374d2df086c78c93c2",
+                    "title": "CHILD B",
+                    "name": "childB",
+                    "path": "childb",
+                    "type": "form",
+                    "display": "wizard",
+                    "tags": [],
+                    "access": [
+                        {
+                            "type": "read_all",
+                            "roles": [
+                                "67379d374d2df086c78c93ae",
+                                "67379d374d2df086c78c93b2",
+                                "67379d374d2df086c78c93b6"
+                            ]
+                        }
+                    ],
+                    "submissionAccess": [],
+                    "owner": null,
+                    "components": [
+                        {
+                            "title": "B1",
+                            "breadcrumbClickable": true,
+                            "buttonSettings": {
+                                "previous": true,
+                                "cancel": true,
+                                "next": true
+                            },
+                            "navigateOnEnter": false,
+                            "saveOnEnter": false,
+                            "scrollToTop": false,
+                            "collapsible": false,
+                            "key": "page1",
+                            "type": "panel",
+                            "label": "Page 1",
+                            "components": [
+                                {
+                                    "label": "B1",
+                                    "applyMaskOn": "change",
+                                    "tableView": true,
+                                    "validateWhenHidden": false,
+                                    "key": "b",
+                                    "type": "textfield",
+                                    "input": true
+                                }
+                            ],
+                            "input": false,
+                            "tableView": false
+                        },
+                        {
+                            "title": "B2",
+                            "breadcrumbClickable": true,
+                            "buttonSettings": {
+                                "previous": true,
+                                "cancel": true,
+                                "next": true
+                            },
+                            "navigateOnEnter": false,
+                            "saveOnEnter": false,
+                            "scrollToTop": false,
+                            "collapsible": false,
+                            "key": "page2",
+                            "type": "panel",
+                            "label": "Page 2",
+                            "input": false,
+                            "tableView": false,
+                            "components": [
+                                {
+                                    "label": "B2",
+                                    "applyMaskOn": "change",
+                                    "tableView": true,
+                                    "validateWhenHidden": false,
+                                    "key": "b2",
+                                    "type": "textfield",
+                                    "input": true
+                                }
+                            ]
+                        },
+                        {
+                            "title": "B3",
+                            "breadcrumbClickable": true,
+                            "buttonSettings": {
+                                "previous": true,
+                                "cancel": true,
+                                "next": true
+                            },
+                            "navigateOnEnter": false,
+                            "saveOnEnter": false,
+                            "scrollToTop": false,
+                            "collapsible": false,
+                            "key": "page3",
+                            "type": "panel",
+                            "label": "Page 3",
+                            "input": false,
+                            "tableView": false,
+                            "components": [
+                                {
+                                    "label": "B3",
+                                    "applyMaskOn": "change",
+                                    "tableView": true,
+                                    "validate": {
+                                        "required": true
+                                    },
+                                    "validateWhenHidden": false,
+                                    "key": "b3",
+                                    "type": "textfield",
+                                    "input": true
+                                }
+                            ]
+                        }
+                    ],
+                    "pdfComponents": [],
+                    "settings": {},
+                    "properties": {},
+                    "machineName": "authoring-qwwqrlcmffdcymd:childB",
+                    "project": "67379d374d2df086c78c93a4",
+                    "controller": "",
+                    "revisions": "",
+                    "submissionRevisions": "",
+                    "_vid": 0,
+                    "created": "2024-11-15T19:12:55.909Z",
+                    "modified": "2024-11-15T19:12:55.911Z"
+                }
+            ],
+            "input": false,
+            "tableView": false
+        },
+        {
+            "title": "C",
+            "breadcrumbClickable": true,
+            "buttonSettings": {
+                "previous": true,
+                "cancel": true,
+                "next": true
+            },
+            "navigateOnEnter": false,
+            "saveOnEnter": false,
+            "scrollToTop": false,
+            "collapsible": false,
+            "key": "page3",
+            "type": "panel",
+            "label": "Page 3",
+            "components": [
+                {
+                    "_id": "67379d374d2df086c78c93c9",
+                    "title": "CHILD C",
+                    "name": "childC",
+                    "path": "childc",
+                    "type": "form",
+                    "display": "wizard",
+                    "tags": [],
+                    "access": [
+                        {
+                            "type": "read_all",
+                            "roles": [
+                                "67379d374d2df086c78c93ae",
+                                "67379d374d2df086c78c93b2",
+                                "67379d374d2df086c78c93b6"
+                            ]
+                        }
+                    ],
+                    "submissionAccess": [],
+                    "owner": null,
+                    "components": [
+                        {
+                            "title": "C1",
+                            "breadcrumbClickable": true,
+                            "buttonSettings": {
+                                "previous": true,
+                                "cancel": true,
+                                "next": true
+                            },
+                            "navigateOnEnter": false,
+                            "saveOnEnter": false,
+                            "scrollToTop": false,
+                            "collapsible": false,
+                            "key": "page1",
+                            "type": "panel",
+                            "label": "Page 1",
+                            "components": [
+                                {
+                                    "label": "C1",
+                                    "applyMaskOn": "change",
+                                    "tableView": true,
+                                    "validateWhenHidden": false,
+                                    "key": "c1",
+                                    "type": "textfield",
+                                    "input": true
+                                }
+                            ],
+                            "input": false,
+                            "tableView": false
+                        },
+                        {
+                            "title": "C2",
+                            "breadcrumbClickable": true,
+                            "buttonSettings": {
+                                "previous": true,
+                                "cancel": true,
+                                "next": true
+                            },
+                            "navigateOnEnter": false,
+                            "saveOnEnter": false,
+                            "scrollToTop": false,
+                            "collapsible": false,
+                            "key": "page2",
+                            "type": "panel",
+                            "label": "Page 2",
+                            "input": false,
+                            "tableView": false,
+                            "components": [
+                                {
+                                    "label": "C2",
+                                    "applyMaskOn": "change",
+                                    "tableView": true,
+                                    "validateWhenHidden": false,
+                                    "key": "c2",
+                                    "type": "textfield",
+                                    "input": true
+                                }
+                            ]
+                        },
+                        {
+                            "title": "C3",
+                            "breadcrumbClickable": true,
+                            "buttonSettings": {
+                                "previous": true,
+                                "cancel": true,
+                                "next": true
+                            },
+                            "navigateOnEnter": false,
+                            "saveOnEnter": false,
+                            "scrollToTop": false,
+                            "collapsible": false,
+                            "key": "page3",
+                            "type": "panel",
+                            "label": "Page 3",
+                            "input": false,
+                            "tableView": false,
+                            "components": [
+                                {
+                                    "label": "C3",
+                                    "applyMaskOn": "change",
+                                    "tableView": true,
+                                    "validateWhenHidden": false,
+                                    "key": "c3",
+                                    "type": "textfield",
+                                    "input": true
+                                }
+                            ]
+                        }
+                    ],
+                    "pdfComponents": [],
+                    "settings": {},
+                    "properties": {},
+                    "machineName": "authoring-qwwqrlcmffdcymd:childC",
+                    "project": "67379d374d2df086c78c93a4",
+                    "controller": "",
+                    "revisions": "",
+                    "submissionRevisions": "",
+                    "_vid": 0,
+                    "created": "2024-11-15T19:12:55.919Z",
+                    "modified": "2024-11-15T19:12:55.921Z"
+                }
+            ],
+            "input": false,
+            "tableView": false
+        }
+    ],
+    "pdfComponents": [],
+    "settings": {
+
+    },
+    "properties": {
+
+    },
+    "machineName": "authoring-qwwqrlcmffdcymd:wizard",
+    "project": "67379d374d2df086c78c93a4",
+    "controller": "",
+    "revisions": "",
+    "submissionRevisions": "",
+    "_vid": 0,
+    "created": "2024-11-15T19:12:55.928Z",
+    "modified": "2024-11-15T19:12:55.930Z"
+}

--- a/test/unit/Wizard.unit.js
+++ b/test/unit/Wizard.unit.js
@@ -32,6 +32,7 @@ import wizardWithPanel from '../forms/wizardWithPanel';
 import wizardWithWizard from '../forms/wizardWithWizard';
 import simpleTwoPagesWizard from '../forms/simpleTwoPagesWizard';
 import wizardWithNestedWizardInEditGrid from '../forms/wizardWithNestedWizardInEditGrid';
+import wizardWithNestedWizardsAdvConditional from '../forms/wizardWithNestedWizardsAdvConditional';
 import wizardNavigateOrSaveOnEnter from '../forms/wizardNavigateOrSaveOnEnter';
 import nestedConditionalWizard from '../forms/nestedConditionalWizard';
 import wizardWithPrefixComps from '../forms/wizardWithPrefixComps';
@@ -2105,6 +2106,31 @@ it('Should show tooltip for wizard pages', function(done) {
       })
       .catch(done);
   });
+
+  it('Should set correct page index after hiding a conditionally hidden page in sibling nested wizard.', async () => {
+    const formElement = document.createElement('div');
+    wizardForm = new Wizard(formElement);
+    await wizardForm.setForm(wizardWithNestedWizardsAdvConditional);
+    // navigate forward 4 pages to B2
+    // A1 -> A2 -> A3 -> B1 -> B2
+    for (let i = 0; i < 4; i++) {
+      wizardForm.nextPage();
+      await wait(200);
+    }
+    const getPageTitles = () => wizardForm.pages.map(p => p.component.title);
+    assert.equal(wizardForm.page, 4);
+    assert.equal(wizardForm.currentPanel.title, 'B2');
+    assert(getPageTitles().includes('A2'));
+    const b2Input = wizardForm.element.querySelector('input[name="data[b2]"]');
+    const inputEvent = new Event('input');
+    b2Input.value = 'hide';
+    b2Input.dispatchEvent(inputEvent);
+    await wait(400);
+    assert(!getPageTitles().includes('A2'), 'A2 is hidden when B2 has a value of "hide"');
+    assert.equal(wizardForm.page, 3, 'A2 is removed from the pages array and the page number/index must be decremented to maintain B2 as the current page');
+    assert.equal(wizardForm.currentPanel.title, 'B2');
+  });
+
   // BUG - uncomment once fixed (ticket FIO-6043)
   // it('Should render all pages as a part of wizard pagination', (done) => {
   //   const formElement = document.createElement('div');


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9241

## Description

**What changed?**

I updated the `onChange()` method in the Wizard class to call `this.setPage()` if the number of total pages in the parent/root-level wizard changes, which updates the current page of the root wizard to be the current page/page (i.e. `this.currentPanel`. `this.setPage()` was not being called `onChange()` for wizards with sub-wizards. I also updated `render()` to set `this.currentPanel` based on `id` and not `key`.

**Why have you chosen this solution?**

I changed `onChange()` in the way that I did to simplify the logic for when to set the current page and to ensure that the correct page is selected based on a (more) unique `id` and not `key`, which could be easily duplicated between sub-wizard pages.

For the update to `render()`, I made that change since another bug manifested where pages in multiple sub-wizards having the same `key` would cause the current page to jump from one sub-wizard to another. (i.e. `B2` to `C2`) when `A2` was conditionally hidden by the value of `B2` because both `B2` and `C2` have the same `key` of  (I think) `'page2'`. `A2` being a page of sub-wizard form `A`, and the same for pages `B2` and `C2`, in respect to the sub-wizards `B` and `C`.

## Breaking Changes / Backwards Compatibility

I removed `this.currentPanels` from the Wizard class in order to simplify the logic in `onChange()` since the current Wizard pages/panels (including those of all sub-wizards) can be accessed via `this.pages`. This might break something, but I'm not sure of a case where it would. All of the tests pass with it removed. See [this](https://github.com/formio/formio.js/pull/5913#discussion_r1853051774) comment for more details.

## Dependencies

n/a

## How has this PR been tested?

Manual and automated testing.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
