### PR TITLE
FIO-9361: Fix showing extra submit buttons

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1040,15 +1040,19 @@ export default class WebformBuilder extends Component {
     }
     this.keyboardActionsEnabled = keyboardActionsEnabled;
 
-    const isSubmitButton = (comp) => {
-      return (comp.type === 'button') && ((comp.action === 'submit') || !comp.action);
-    }
+    const { display, noAddSubmitButton, noDefaultSubmitButton } = this.options;
+    const { _id, components } = form;
 
-    const isShowSubmitButton = !this.options.noDefaultSubmitButton
-      && (!form.components.length || !form.components.find(comp => isSubmitButton(comp)));
+    const isSubmitButton = ({ type, action }) => type === 'button' && (action === 'submit' || !action);
+    const hasSubmitButton = components.some(isSubmitButton);
+    // Add submit button if form display was switched from wizard
+    // Don't add if there is noAddSubmitButton flag passed, or the form has id, or the form has a submit button already
+    const shouldAddSubmitButton =
+      (display === 'wizard' && !hasSubmitButton) ||
+      (!noAddSubmitButton && !_id && !hasSubmitButton);
 
-    // Ensure there is at least a submit button.
-    if (isShowSubmitButton) {
+      // Ensure there is at least a submit button.
+    if (!noDefaultSubmitButton && shouldAddSubmitButton) {
       form.components.push({
         type: 'button',
         label: 'Submit',

--- a/test/unit/WebformBuilder.unit.js
+++ b/test/unit/WebformBuilder.unit.js
@@ -250,11 +250,14 @@ describe('WebformBuilder tests', function() {
 
   it('Should add submit button after switching from wizard form', (done) => {
     const builder = Harness.getBuilder();
+    builder.options.noAddSubmitButton = true;
+    builder.options.display = 'wizard';
     builder.setForm(formBasedOnWizard).then(() => {
       const components = builder.webform.components;
       const submit = components[components.length - 1];
-
       assert.equal(submit.key, 'submit');
+      builder.options.noAddSubmitButton = false;
+      builder.options.display = 'form';
       done();
     }).catch(done);
   });
@@ -266,6 +269,22 @@ describe('WebformBuilder tests', function() {
       const submit = components[1];
       assert.equal(components.length, 2);
       assert.equal(components[1].key, 'testSubmit');
+      done();
+    }).catch(done);
+  });
+
+  it('Should not add extra submit button if button action was changed', (done) => {
+    const builder = Harness.getBuilder();
+    builder.options.noAddSubmitButton = true;
+
+    const cloneForm = _.cloneDeep(simpleWebform);
+    cloneForm.components[1].action = 'reset'
+
+    builder.setForm(cloneForm).then(() => {
+      const components = builder.webform.components;
+      assert.equal(components.length, 2);
+      assert.equal(components[1].component.action, 'reset');
+      builder.options.noAddSubmitButton = false;
       done();
     }).catch(done);
   });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9361

## Description

**What changed?**

Made better checks for different cases when to add submit button to the form, so to prevent scenarios when couple submit buttons could appear.

**Why have you chosen this solution?**

It should work for all those cases:
1) changing submit button action on an unsaved form shouldn't cause doubled submit button
2) changing submit button api key on an unsaved form shouldn't cause double submit button
3) switching existing or imported wizard form to a simple form should add submit button
4) imported form shouldn't have doubled submit button
5) copied form shouldn't have doubled submit button

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

Automated tests added

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
