### PR TITLE
FIO-9360: validate current page only on wizard change

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -1002,7 +1002,7 @@ export default class Wizard extends Webform {
   onChange(flags, changed, modified, changes) {
     super.onChange(flags, changed, modified, changes);
     // The onChange loop doesn't need all components for wizards
-    const errors = this.submitted ? this.validate(this.localData, { dirty: false }) : this.validateCurrentPage();
+    const errors = this.submitted ? this.validate(this.localData, { dirty: true }) : this.validateCurrentPage();
     if (this.alert) {
       this.showErrors(errors, true, true);
     }

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -1075,17 +1075,6 @@ export default class Wizard extends Webform {
     return super.errors;
   }
 
-  showErrors(errors, triggerEvent) {
-    // if (this.hasExtraPages) {
-    //   this.subWizards.forEach((subWizard) => {
-    //     if(Array.isArray(subWizard.errors)) {
-    //       errors = [...errors, ...subWizard.errors]
-    //     }
-    //   })
-    // }
-    return super.showErrors(errors, triggerEvent)
-  }
-
   focusOnComponent(key) {
     const component = this.getComponent(key);
     if (component) {

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -824,8 +824,9 @@ export default class Wizard extends Webform {
   }
 
   validateCurrentPage(flags = {}) {
+    const components = this.currentPage?.components.map((component) => component.component);
     // Accessing the parent ensures the right instance (whether it's the parent Wizard or a nested Wizard) performs its validation
-    return this.currentPage?.parent.validateComponents(this.currentPage.component.components, this.currentPage.parent.data, flags);
+    return this.currentPage?.parent.validateComponents(components, this.currentPage.parent.data, flags);
   }
 
   emitPrevPage() {
@@ -1000,7 +1001,8 @@ export default class Wizard extends Webform {
 
   onChange(flags, changed, modified, changes) {
     super.onChange(flags, changed, modified, changes);
-    const errors = this.validate(this.localData, { dirty: false });
+    // The onChange loop doesn't need all components for wizards
+    const errors = this.submitted ? this.validate(this.localData, { dirty: false }) : this.validateCurrentPage();
     if (this.alert) {
       this.showErrors(errors, true, true);
     }
@@ -1074,13 +1076,13 @@ export default class Wizard extends Webform {
   }
 
   showErrors(errors, triggerEvent) {
-    if (this.hasExtraPages) {
-      this.subWizards.forEach((subWizard) => {
-        if(Array.isArray(subWizard.errors)) {
-          errors = [...errors, ...subWizard.errors]
-        }
-      })
-    };
+    // if (this.hasExtraPages) {
+    //   this.subWizards.forEach((subWizard) => {
+    //     if(Array.isArray(subWizard.errors)) {
+    //       errors = [...errors, ...subWizard.errors]
+    //     }
+    //   })
+    // }
     return super.showErrors(errors, triggerEvent)
   }
 

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -535,7 +535,7 @@ export default class FormComponent extends Component {
     options = options || {};
     const silentCheck = options.silentCheck || false;
 
-    if (this.subForm && !this.isNestedWizard) {
+    if (this.subForm) {
       return this.subForm.checkValidity(this.subFormData, dirty, null, silentCheck, errors);
     }
 

--- a/test/unit/Wizard.unit.js
+++ b/test/unit/Wizard.unit.js
@@ -517,7 +517,7 @@ describe('Wizard tests', () => {
     await wait(200);
     assert.equal(form.errors.length, 1, 'Should have one error from the first page');
   });
-  
+
   it('Should validate the entire wizard\'s components when the form has been submitted', async function () {
     const wizardDefinition = {
       display: 'wizard',
@@ -580,13 +580,12 @@ describe('Wizard tests', () => {
     const form = await Formio.createForm(document.createElement('div'), wizardDefinition);
     assert(form, 'Form should be created');
     form.submitted = true;
-    const checkbox = form.getComponent('triggerChange');
-    const clickEvent = new Event('click');
-    checkbox.refs.input[0].dispatchEvent(clickEvent);
+    form.setSubmission({ data: { triggerChange: true } });
     await wait(200);
-    assert.equal(form.errors.length, 2, 'Should have two errors total');
+    assert(form.alert, 'Form should have an error list');
+    assert.equal(form.alert.querySelectorAll("span[ref=errorRef]").length, 2, 'Should have two errors total');
   });
-  
+
 
   it('Should have validation errors when parent form is valid but nested wizard is not', function(done) {
     const formElement = document.createElement('div');


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9360

## Description

This PR reverts:

* #5884 
* #5830 

to consolidate validation of Wizard components into one simple rule: on change, only validate and show the current page's validation errors unless you've already attempted to submit the form.

## Breaking Changes / Backwards Compatibility

Technically this is a breaking change - previously, the renderer would validate all components (much like it does with forms) and selectively display them based on the UI's context. However, this proves to be tricky with nested forms, and it's easiest to just only validate the currently displayed components when it comes to wizards.

## Dependencies

n/a

## How has this PR been tested?

All tests pass. Added a few automated tests to ensure that Wizards will only validate currently displayed components.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
