### PR TITLE
[4.21.x] FIO-8195: Fixed visibility of nested form in pdf with viewer:show tag

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -667,6 +667,10 @@ export default class FormComponent extends Component {
   }
 
   isHidden() {
+    if (this.shouldForceShow()) {
+      return false;
+    }
+
     if (!this.visible) {
       return true;
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8195

## Description

**Issue**: PDF generation can use the `viewer:show` tag to display hidden components. However, the `isHidden` method in the Form component does not consider the `options.show` property (which checks the `viewer:show` tag). As a result, the subform is not loading at all.

**Solution**: Update the `isHidden` method to take into account the `options.show` property.

## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
