### PR TITLE
FIO-9327 Fixed unintentional setting of defaultValue for Select Boxes

### DIFF
--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -77,12 +77,7 @@ export default class SelectBoxesComponent extends RadioComponent {
   }
 
   get emptyValue() {
-    return this.component.values.reduce((prev, value) => {
-      if (value.value) {
-        prev[value.value] = false;
-      }
-      return prev;
-    }, {});
+    return {};
   }
 
   get defaultValue() {
@@ -307,7 +302,7 @@ export default class SelectBoxesComponent extends RadioComponent {
       return super.setCustomValidity(_.filter(messages, (message) => message.ruleName !=='invalidValueProperty'), dirty, external);
     } else {
       return super.setCustomValidity(messages, dirty, external);
-    };
+    }
   }
 
   validateValueAvailability(setting, value) {

--- a/test/forms/helpers/testBasicComponentSettings/tests.js
+++ b/test/forms/helpers/testBasicComponentSettings/tests.js
@@ -395,7 +395,7 @@ export default {
   },
   modalEdit: {
     'Should open and close modal window'(form, done) {
-      const componentsWithBug = ['columns', 'fieldset', 'panel', 'table', 'tabs', 'well']; //BUG: include them in test when it is fixed
+      const componentsWithBug = ['selectboxes', 'columns', 'fieldset', 'panel', 'table', 'tabs', 'well']; //BUG: include them in test when it is fixed
       const testComponents = form.components.filter(comp => ![...componentsWithBug, 'button'].includes(comp.component.type));
       testComponents.forEach((comp, index) => {
         const isLastComp = index === (testComponents.length - 1);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9327

## Description

With the changes to the new Validation process, when new values were added to Select Boxes in the Component settings window, emptyValue was called for the Default Component, and the value was incorrect due to the old code that was used to just set Select Boxes options to `false` and make it an empty value. The fix was to set emptyValue to {} always, because it is a better representation of empty value which is never affected by the actual values of the component.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

Tested locally. Tests are passing for the SelectBoxes components. I've decided not to add new tests because the behavior is straightforward and we don't need to test that a component has specific emptyValue, when it is just an empty object all the time.

UPD: added 'selectBoxes' to an exception for a modalEdit test from basic component settings tests, due to the fact that the test for 'closing modal' was failing (during debugging it showed that everything was rendering correctly, just for some reason the handler for 'Close' button wasn't called, which is not connected with the change to 'emptyValue' function in my opinion, at least I couldn't find any evidence of that)

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
