### PR TITLE
FIO-9271: Scientific notation in number component.

### DIFF
--- a/src/components/number/Number.js
+++ b/src/components/number/Number.js
@@ -183,10 +183,23 @@ export default class NumberComponent extends Input {
     if (typeof input === 'string') {
       input = input.split(this.delimiter).join('').replace(this.decimalSeparator, '.');
     }
-    let value = parseFloat(input);
+    let value;
 
-    if (!_.isNaN(value)) {
-      value = String(value).replace('.', this.decimalSeparator);
+    if (!_.isNaN(input)) {
+      // Format scientific notation
+      if (/[0-9]+[eE]/.test(String(input))) {
+        // Convert to exponential notation will depend on the decimal limit set in the component
+        // Example: 1.23e-5 will be converted to 1.23e-5 if decimal limit is set to 2
+        // Example: 1.23e5 will be converted to 1.23e+5 if decimal limit is set to 2
+        // if decimal limit is 3, 1.23e5 will be converted to 1.230e+5
+        // if decimal limit is not set, 1.23e5 will be converted to 1.23000000000000000000e+5
+        value = parseFloat(input);
+        value = value.toExponential(this.decimalLimit);
+      }
+      else {
+        value = parseFloat(input);
+        value = !_.isNaN(value) ? String(value).replace('.', this.decimalSeparator) : null;
+      }
     }
     else {
       value = null;

--- a/src/components/number/Number.unit.js
+++ b/src/components/number/Number.unit.js
@@ -14,7 +14,8 @@ import {
   comp6,
   comp7,
   comp8,
-  comp9
+  comp9,
+  scientificNotation
 } from './fixtures';
 import CurrencyComponent from '../currency/Currency';
 
@@ -22,6 +23,24 @@ describe('Number Component', () => {
   it('Should build an number component', () => {
     return Harness.testCreate(NumberComponent, comp1).then((component) => {
       Harness.testElements(component, 'input[type="text"]', 1);
+    });
+  });
+
+  it('Should correctly handle scientific notation', () => {
+    return Harness.testCreate(NumberComponent, scientificNotation).then((component) => {
+      const testCases = [
+        ['6.54e+12', 6.54e+12, '6.54e+12'],
+        ['1.23e-5', 1.23e-5, '1.23e-5'],
+        ['3.14e+2', 3.14e+2, '3.14e+2'],
+        ['2e-3', 2e-3, '2e-3'],
+        ['7.5e+5', 7.5e+5, '7.5e+5'],
+        ['1.23e+10', 1.23e+10, '1.23e+10'],
+      ];
+      testCases.forEach(([input, expectedValue, expectedDisplayValue]) => {
+        component.setValue(input);
+        assert.equal(component.dataValue, expectedValue, `setValue: ${input} should result in ${expectedValue}`);
+        assert.equal(component.getValueAsString(input), expectedDisplayValue, `getValueAsString: ${input} should result in ${expectedDisplayValue}`);
+      });
     });
   });
 

--- a/src/components/number/fixtures/scientificNotation.js
+++ b/src/components/number/fixtures/scientificNotation.js
@@ -1,0 +1,13 @@
+export default {
+  'label': 'Number',
+  'mask': false,
+  'spellcheck': true,
+  'tableView': true,
+  'delimiter': true,
+  'requireDecimal': false,
+  'inputFormat': 'plain',
+  'key': 'number',
+  'type': 'number',
+  'decimalLimit': 2,
+  'input': true
+};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9271

## Description

**What changed?**

Adding Scientific notation to the number component 

**Why have you chosen this solution?**

We needed to identify and show scientific notation in the component

## Breaking Changes / Backwards Compatibility

NA

## Dependencies

@formio/text-mask-addons

## How has this PR been tested?

Unit Tests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
