### PR TITLE
FIO-9327: Fixed an issue where select boxes default values would become messed up during builder mode.

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1243,6 +1243,7 @@ export default class WebformBuilder extends Component {
           parentComponent.tabs[tabIndex].splice(index, 1, newComp);
           newComp.checkValidity = () => true;
           newComp.build(defaultValueComponent.element);
+          this.editForm._data.defaultValue = _.get(this.preview._data, this.editForm._data.key);
         }
       }
       else {

--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -164,6 +164,14 @@ export default class SelectBoxesComponent extends RadioComponent {
       _.set(submission.metadata.selectData, this.path, selectData);
     }
 
+    // Ensure that for dataSrc == 'values' that there are not any other superfluous values.
+    if (this.component.dataSrc === 'values') {
+      for (const key in value) {
+        if (!this.component.values.find((val) => val.value === key)) {
+          delete value[key];
+        }
+      }
+    }
     return value;
   }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9327

## Description

When you are in builder mode, there were a few things that were causing the default values to not get set correctly. First of all, the value of the defaultValue was only updating on the first change made to the component. The next thing that was happening is that the Select Boxes component was not adding the correct defaultValue to the component.

## Breaking Changes / Backwards Compatibility

None.

## Dependencies

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
