### PR TITLE
FIO-9418: Fixed the edit grid errors to show the outer error wrapper if any fields in the edit grid are invalid.

### DIFF
--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -1219,8 +1219,11 @@ export default class EditGridComponent extends NestedArrayComponent {
       }
     }
 
-    if (!this.component.rowDrafts || this.root?.submitted) {
+    if (editRow.alerts && (!this.component.rowDrafts || this.root?.submitted)) {
       this.showRowErrorAlerts(editRow, editRow.errors);
+    }
+    else if (editRow.errors?.length) {
+      this.setCustomValidity(editRow.errors, dirty);
     }
 
     return editRow.errors;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9418

## Description

We previously used to show the "wrapper" error around the EditGrid component when a value inside the EditGrid is invalid. This was recently changed to where we only show the error around the component that has the problem. This works fine until that component is "hidden" to where you don't see any visual feedback if your row is invalid. This change ensures that we add the "wrapper" error around the EditGrid when a row error occurs which always gives the user a visual feedback if an EditGrid component is invalid.

## Breaking Changes / Backwards Compatibility

This does re-introduce the error "wrapper" around the EditGrid, even if the error in the row is visually seen. Some may see this as "to many" visual indications of an error, but this also goes back to the way it used to work.

## Dependencies

None

## How has this PR been tested?

Manual

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
