### PR TITLE
fix select styling

### DIFF
--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -31,6 +31,10 @@ $autocomplete-in-dialog-z-index: $dialog-z-index + 1000;
   border-color: #ffeeba;
 }
 
+.form-control {
+  height: calc(1.4em + 0.75rem + 2px);
+}
+
 .formio-disabled-input .form-control.flatpickr-input {
   background-color: #eee;
 }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9453

## Description

Select components in Bootstrap 5 had no static height - it turns out that Bootstrap 5 removed the static height declaration for the `.form-control` class. This PR adds it in the formio global styles for backwards compatibility.

A possible alternative involved adding this style, perhaps inline, to the select component's bootstrap5 template. However, this would not work - choicesjs masks the actual input, so nothing in the template would really have a visual effect. Furthermore, we need to modify the select's parent element, and it the [renderer handles adding the class in question](https://github.com/formio/formio.js/blob/3ff37eb652a83ecc88dac3e3788283d97e7cac27/src/components/_classes/component/Component.js#L3912).

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
