### PR TITLE
FIO-9170 Added a fix for default templates to include custom components

### DIFF
--- a/src/formio.form.js
+++ b/src/formio.form.js
@@ -61,6 +61,10 @@ export function registerModule(mod, defaultFn = null, options = {}) {
       case 'templates':
         for (const framework of Object.keys(mod.templates)) {
           Formio.Templates.extendTemplate(framework, mod.templates[framework]);
+          Formio.Templates.defaultTemplates = _.defaults(
+            mod.templates[framework],
+            Formio.Templates.defaultTemplates
+          );
         }
         if (mod.templates[current]) {
           Formio.Templates.current = mod.templates[current];


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9170

## Description

**What changed?**

Previously, if a module (i.e. premium) had their own components, there was no fallback for the template in the case of  different template library usage (i.e. if 2 modules were registered and on of them is currently in use, then the components from the other were using defaultTemplate fallback, which was always just a bootstrap set of templates. I've added an ability to add extra components to the defaultTemplates when registering modules, so that for every module there is a fallback for their own components inside of the defaultTemplates

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## How has this PR been tested?

Tested locally

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
