### PR TITLE
Replace in utils fastCloneDeep func cloning with json.parse-stringiry to structuredClone api

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -154,7 +154,7 @@ export function checkCalculated(component, submission, rowData) {
 }
 
 /**
- * Check if a simple conditional evaluates to true. 
+ * Check if a simple conditional evaluates to true.
  * @param {import('@formio/core').Component} component - The component to check for the conditional.
  * @param {import('@formio/core').SimpleConditional} condition - The condition to check.
  * @param {*} row - The row data for the component.
@@ -306,7 +306,7 @@ export function getComponentActualValue(compPath, data, row) {
   if (row && _.isNil(value)) {
     value = getValue({ data: row }, compPath);
   }
-  
+
   // FOR-400 - Fix issue where falsey values were being evaluated as show=true
   if (_.isNil(value) || (_.isObject(value) && _.isEmpty(value))) {
     value = '';
@@ -341,7 +341,7 @@ export function checkCustomConditional(component, custom, row, data, form, varia
 
 /**
  * Check a component for JSON conditionals.
- * @param {import('@formio/core').Component} component - The component 
+ * @param {import('@formio/core').Component} component - The component
  * @param {import('@formio/core').JSONConditional} json - The json conditional to check.
  * @param {*} row - The contextual row data for the component.
  * @param {*} data - The full submission data.
@@ -1488,7 +1488,7 @@ export function sanitize(string, options) {
  * @returns {any} - The cloned object.
  */
 export function fastCloneDeep(obj) {
-  return obj ? JSON.parse(JSON.stringify(obj)) : obj;
+  return obj ? structuredClone(obj) : obj;
 }
 
 export { Evaluator, interpolate };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9496
https://github.com/formio/angular/issues/1016

## Description

**What changed?**
in utils fastCloneDeep now native API structuredClone is used instead of JSON.parse(JSON.stringify(obj))

*Use this section to provide a summary description of the changes you've made*

**Why have you chosen this solution?**
Native browser API
And structuredClone allows to keep File object in event copy. More details in question link above https://github.com/formio/angular/issues/1016

*Use this section to justify your choices*
allows to keep File object in event copy. More details in question link above https://github.com/formio/angular/issues/1016
## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*
no breaking changes
## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
