### PR TITLE
FIO-8862: fixed unnecessary redrawings of the value component in conditional ui

### DIFF
--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -344,13 +344,16 @@ export default class EditGridComponent extends NestedArrayComponent {
 
   checkRowVariableTypeComponents(editRow, rowIndex) {
     const rowComponents = editRow.components;
+    let typeChanged = false;
 
     if (_.some(this.variableTypeComponentsIndexes, (compIndex) => {
       const variableTypeComp = rowComponents[compIndex];
       return variableTypeComp.type !== variableTypeComp.component.type;
     })) {
       editRow.components = this.createRowComponents(editRow.data, rowIndex, true);
+      typeChanged = true;
     }
+    return typeChanged;
   }
 
   setVariableTypeComponents() {
@@ -1120,8 +1123,10 @@ export default class EditGridComponent extends NestedArrayComponent {
         }
 
         if (this.variableTypeComponentsIndexes.length) {
-          this.checkRowVariableTypeComponents(editRow, rowIndex);
-          this.redraw();
+          const typeChanged = this.checkRowVariableTypeComponents(editRow, rowIndex);
+          if (typeChanged) {
+            this.redraw();
+          }
         }
       };
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8862

## Description

**What changed?**

Redraw the the grid that has components with 'typeChangeEnabled' only when the type is really changed.

## Dependencies

https://github.com/formio/premium/pull/361

## How has this PR been tested?

Manually

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
