### PR TITLE
FIO-9339: fixed an issue where preview shows an error when editing component JSON

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1444,7 +1444,8 @@ export default class WebformBuilder extends Component {
           helplinks: this.helplinks,
         }));
         this.editForm.attach(this.componentEdit.querySelector(`[${this._referenceAttributeName}="editForm"]`));
-        this.updateComponent(this.editForm.submission.data ?? component);
+        const editFormData = this.editForm.submission?.data;
+        this.updateComponent(editFormData?.componentJson || editFormData || component);
         this.attachEditComponentControls(component, parent, isNew, original, ComponentClass);
       });
     });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9339

## Description

**What changed?**

This PR fixes an issue where the preview shows an error instead of the component when the component settings are opened in the JSON mode. When the component is edited in JSON mode, the component settings are stored not on the top level of the edit form submission data, but inside the componentJson property of the data. This PR add this case.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
