### PR TITLE
FIO-9245 DataGrid: Update test files to match changes in @formio/bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "homepage": "https://github.com/formio/formio.js#readme",
   "dependencies": {
-    "@formio/bootstrap": "3.0.0-dev.111.ae7f187",
+    "@formio/bootstrap": "3.0.0-dev.118.f146cb4",
     "@formio/choices.js": "^10.2.1",
     "@formio/core": "2.1.0-dev.193.68cf8c3",
     "@formio/text-mask-addons": "3.8.0-formio.4",

--- a/test/renders/component-bootstrap-datagrid-multiple.html
+++ b/test/renders/component-bootstrap-datagrid-multiple.html
@@ -6,8 +6,8 @@
     ">
     <tbody ref="datagrid-dataGrid-tbody" data-key="datagrid-dataGrid">
       <tr ref="datagrid-dataGrid-row">
-        <td class="col-1">
-          <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove">
+        <td>
+          <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove" style="display: block; margin: 0 auto">
             <i class="fa fa-remove-circle bi bi-x-circle"></i>
           </button>
         </td>

--- a/test/renders/component-bootstrap-datagrid-required.html
+++ b/test/renders/component-bootstrap-datagrid-required.html
@@ -6,8 +6,8 @@
     ">
     <tbody ref="datagrid-dataGrid-tbody" data-key="datagrid-dataGrid">
       <tr ref="datagrid-dataGrid-row">
-        <td class="col-1">
-          <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove">
+        <td>
+          <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove" style="display: block; margin: 0 auto">
             <i class="fa fa-remove-circle bi bi-x-circle"></i>
           </button>
         </td>

--- a/test/renders/component-bootstrap-datagrid.html
+++ b/test/renders/component-bootstrap-datagrid.html
@@ -6,8 +6,8 @@
     ">
     <tbody ref="datagrid-dataGrid-tbody" data-key="datagrid-dataGrid">
       <tr ref="datagrid-dataGrid-row">
-        <td class="col-1">
-          <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove">
+        <td>
+          <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove" style="display: block; margin: 0 auto">
             <i class="fa fa-remove-circle bi bi-x-circle"></i>
           </button>
         </td>

--- a/test/renders/form-bootstrap-calculateValueWithManualOverride.html
+++ b/test/renders/form-bootstrap-calculateValueWithManualOverride.html
@@ -65,8 +65,8 @@
                       <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
                     </div>
                   </td>
-                  <td class="col-1">
-                    <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove">
+                  <td>
+                    <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove" style="display: block; margin: 0 auto">
                       <i class="fa fa-remove-circle bi bi-x-circle"></i>
                     </button>
                   </td>

--- a/test/renders/form-bootstrap-data.html
+++ b/test/renders/form-bootstrap-data.html
@@ -199,8 +199,8 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td class="col-1">
-              <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid2-removeRow" tabindex="0" aria-label="remove">
+            <td>
+              <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid2-removeRow" tabindex="0" aria-label="remove" style="display: block; margin: 0 auto">
                 <i class="fa fa-remove-circle bi bi-x-circle"></i>
               </button>
             </td>
@@ -253,8 +253,8 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td class="col-1">
-              <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-conditionalDataGrid-removeRow" tabindex="0" aria-label="remove">
+            <td>
+              <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-conditionalDataGrid-removeRow" tabindex="0" aria-label="remove" style="display: block; margin: 0 auto">
                 <i class="fa fa-remove-circle bi bi-x-circle"></i>
               </button>
             </td>

--- a/test/renders/form-bootstrap-defaults.html
+++ b/test/renders/form-bootstrap-defaults.html
@@ -426,8 +426,8 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td class="col-1">
-              <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove">
+            <td>
+              <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove" style="display: block; margin: 0 auto">
                 <i class="fa fa-remove-circle bi bi-x-circle"></i>
               </button>
             </td>

--- a/test/renders/form-bootstrap-formWithCustomFormatDate.html
+++ b/test/renders/form-bootstrap-formWithCustomFormatDate.html
@@ -64,8 +64,8 @@
                 <div ref="messageContainer" class="formio-errors invalid-feedback"></div>
               </div>
             </td>
-            <td class="col-1">
-              <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove">
+            <td>
+              <button type="button" class="btn btn-secondary formio-button-remove-row" ref="datagrid-dataGrid-removeRow" tabindex="0" aria-label="remove" style="display: block; margin: 0 auto">
                 <i class="fa fa-remove-circle bi bi-x-circle"></i>
               </button>
             </td>

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,10 +209,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@formio/bootstrap@3.0.0-dev.111.ae7f187":
-  version "3.0.0-dev.111.ae7f187"
-  resolved "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.0.0-dev.111.ae7f187.tgz#fc7021a6c10db7cc1bc5d17e140cd93451e991f2"
-  integrity sha512-96+YO+jOJ208g1p/EvW+duNLTyCytWu0aXVCu9HaTMQ1icO2zX4okreCUaE9BPp+/aoEs8VzRE/U+pfsb27Bew==
+"@formio/bootstrap@3.0.0-dev.118.f146cb4":
+  version "3.0.0-dev.118.f146cb4"
+  resolved "https://registry.yarnpkg.com/@formio/bootstrap/-/bootstrap-3.0.0-dev.118.f146cb4.tgz#a0f1b4304be38f79f556ad42e7f233fe7ad762c6"
+  integrity sha512-EAKiSdkV9dnvGr93FFjzJRNL2Abmnb6NBBBCppT8iRxmTctN3LdrvofkxTUc99cCzUR5LGAVy2Kq2ZaW2kvbJw==
 
 "@formio/choices.js@^10.2.1":
   version "10.2.1"


### PR DESCRIPTION
- Fixes unpredictable width for datagrid buttons
- See https://github.com/formio/bootstrap/pull/118

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9245

## Description

**What changed?**

See https://github.com/formio/bootstrap/pull/118

**Why have you chosen this solution?**

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

 https://github.com/formio/bootstrap/pull/118

## How has this PR been tested?

All automated tests pass.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
