### PR TITLE
FIO-9385 Preserve non-default widget settings after evaluating field logic

### DIFF
--- a/src/components/datetime/DateTime.js
+++ b/src/components/datetime/DateTime.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import moment from 'moment';
 import FormioUtils from '../../utils';
-import { componentValueTypes, getComponentSavedTypes } from '../../utils/utils';
+import { componentValueTypes, fastCloneDeep, getComponentSavedTypes } from '../../utils/utils';
 import Input from '../_classes/input/Input';
 
 export default class DateTimeComponent extends Input {
@@ -139,6 +139,10 @@ export default class DateTimeComponent extends Input {
       maxDate: _.get(this.component, 'datePicker.maxDate'),
       ...customOptions,
     };
+    // update originalComponent to include widget and other updated settings
+    // it is done here since these settings depend on properties present after the component is initialized 
+    // originalComponent is used to restore the component (and widget) after evaluating field logic 
+    this.originalComponent = fastCloneDeep(this.component);
     /* eslint-enable camelcase */
   }
 

--- a/src/components/textfield/TextField.js
+++ b/src/components/textfield/TextField.js
@@ -99,6 +99,9 @@ export default class TextFieldComponent extends Input {
         locale: this.component.widget.locale || this.options.language,
         saveAs: 'text'
       };
+      // update originalComponent to include widget settings after component initialization 
+      // originalComponent is used to restore the component (and widget) after evaluating field logic 
+      this.originalComponent = FormioUtils.fastCloneDeep(this.component);
     }
   }
 

--- a/test/unit/DateTime.unit.js
+++ b/test/unit/DateTime.unit.js
@@ -18,7 +18,8 @@ import {
   comp11,
   comp12,
   comp13,
-  comp14
+  comp14,
+  requiredFieldLogicComp,
 } from './fixtures/datetime';
 
 describe('DateTime Component', () => {
@@ -769,6 +770,14 @@ describe('DateTime Component', () => {
         },200);
       },200);
     })
+  });
+
+  it('Should preserve the calendar widget settings after field logic is evaluated', async () => {
+    // see https://formio.atlassian.net/browse/FIO-9385
+    // emulate viewing a submission in the portal with { readOnly: true }
+    const form = await Formio.createForm(document.createElement('div'), requiredFieldLogicComp, { readOnly: true });
+    const dateTimeComponent = form.getComponent('dateTime');
+    assert.equal(dateTimeComponent.widget.settings.readOnly, true);
   });
 
   // it('Should provide correct date in selected timezone after submission', (done) => {

--- a/test/unit/TextField.unit.js
+++ b/test/unit/TextField.unit.js
@@ -13,6 +13,7 @@ import {
   comp6,
   withDisplayAndInputMasks,
   comp7,
+  requiredFieldLogicComp,
 } from './fixtures/textfield';
 
 import { comp10 as formWithCalendarTextField } from './fixtures/datetime';
@@ -1377,6 +1378,14 @@ describe('TextField Component', () => {
         done();
       }, 200);
     }).catch(done);
+  });
+
+  it('Should preserve the calendar widget settings after field logic is evaluated', async () => {
+    // see https://formio.atlassian.net/browse/FIO-9385
+    // emulate viewing a submission in the portal with { readOnly: true }
+    const form = await Formio.createForm(document.createElement('div'), requiredFieldLogicComp, { readOnly: true });
+    const textFieldComponent = form.getComponent('textField');
+     assert.equal(textFieldComponent.widget.settings.readOnly, true);
   });
 
   it('Test Display mask', (done) => {

--- a/test/unit/fixtures/datetime/index.js
+++ b/test/unit/fixtures/datetime/index.js
@@ -11,4 +11,5 @@ import comp11 from './comp11';
 import comp12 from './comp12';
 import comp13 from './comp13';
 import comp14 from './comp14';
-export { comp1, comp2, comp3, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14 };
+import requiredFieldLogicComp from './requiredFieldLogicComp';
+export { comp1, comp2, comp3, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, requiredFieldLogicComp };

--- a/test/unit/fixtures/datetime/requiredFieldLogicComp.js
+++ b/test/unit/fixtures/datetime/requiredFieldLogicComp.js
@@ -1,0 +1,62 @@
+export default {
+    components: [
+        {
+            "label": "dateTime",
+            "displayInTimezone": "submission",
+            "format": "MM/dd/yyyy:HH:mm:ss",
+            "tableView": false,
+            "datePicker": {
+                "disableWeekends": false,
+                "disableWeekdays": false
+            },
+            "timePicker": {
+                "showMeridian": false
+            },
+            "enableMinDateInput": false,
+            "enableMaxDateInput": false,
+            "validateWhenHidden": false,
+            "key": "dateTime",
+            "logic": [
+                {
+                    "name": "requiredLogic",
+                    "trigger": {
+                        "type": "javascript",
+                        "javascript": "result = true;"
+                    },
+                    "actions": [
+                        {
+                            "name": "setRequired",
+                            "type": "property",
+                            "property": {
+                                "label": "Required",
+                                "value": "validate.required",
+                                "type": "boolean"
+                            },
+                            "state": true
+                        }
+                    ]
+                }
+            ],
+            "type": "datetime",
+            "input": true,
+            "widget": {
+                "type": "calendar",
+                "displayInTimezone": "submission",
+                "locale": "en",
+                "useLocaleSettings": false,
+                "allowInput": true,
+                "mode": "single",
+                "enableTime": true,
+                "noCalendar": false,
+                "format": "MM/dd/yyyy:HH:mm:ss",
+                "hourIncrement": 1,
+                "minuteIncrement": 1,
+                "time_24hr": true,
+                "minDate": null,
+                "disableWeekends": false,
+                "disableWeekdays": false,
+                "maxDate": null
+            }
+        }
+    ]
+}

--- a/test/unit/fixtures/textfield/index.js
+++ b/test/unit/fixtures/textfield/index.js
@@ -6,4 +6,5 @@ import comp5 from './comp5';
 import comp6 from './comp6';
 import withDisplayAndInputMasks from './comp-with-display-and-value-masks';
 import comp7 from './comp7';
-export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, withDisplayAndInputMasks };
+import requiredFieldLogicComp from './requiredFieldLogicComp';
+export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, withDisplayAndInputMasks, requiredFieldLogicComp };

--- a/test/unit/fixtures/textfield/requiredFieldLogicComp.js
+++ b/test/unit/fixtures/textfield/requiredFieldLogicComp.js
@@ -1,0 +1,53 @@
+export default {
+    components: [
+        {
+            "label": "Text Field",
+            "widget": {
+                "type": "calendar",
+                "altInput": true,
+                "allowInput": true,
+                "clickOpens": true,
+                "enableDate": true,
+                "enableTime": true,
+                "mode": "single",
+                "noCalendar": false,
+                "format": "MM/dd/yyyy:HH:mm:ss",
+                "dateFormat": "MM/dd/yyyy:HH:mm:ss",
+                "useLocaleSettings": false,
+                "hourIncrement": 1,
+                "minuteIncrement": 5,
+                "time_24hr": false,
+                "saveAs": "text",
+                "displayInTimezone": "viewer",
+                "locale": "en"
+            },
+            "applyMaskOn": "change",
+            "tableView": true,
+            "validateWhenHidden": false,
+            "key": "textField",
+            "logic": [
+                {
+                    "name": "requiredLogic",
+                    "trigger": {
+                        "type": "javascript",
+                        "javascript": "result = true;"
+                    },
+                    "actions": [
+                        {
+                            "name": "setRequired",
+                            "type": "property",
+                            "property": {
+                                "label": "Required",
+                                "value": "validate.required",
+                                "type": "boolean"
+                            },
+                            "state": true
+                        }
+                    ]
+                }
+            ],
+            "type": "textfield",
+            "input": true
+        }
+    ]
+}


### PR DESCRIPTION
- originalComponent in Component.js did not capture non-default widget settings since they were added after component initialization
- During field logic evaluation, the component was falling back to originalComponent and not preserving the widget settings
- Update originalComponent after applying widget settings in TextField and DateTime to maintain them after field logic eval

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9385

## Description

**What changed?**

Set `this.originalComponent` in the `DateTime` and `TextField` components. Since `this.originalComponent` was only being set when the component was initialized and the non-default widget settings are applied after, none of those widget settings were preserved after field logic was evaluated (see [here](https://github.com/formio/formio.js/blob/master/src/components/_classes/component/Component.js#L3953)) due to `this.originalComponent` being used [to update `this.component`](https://github.com/formio/formio.js/blob/master/src/components/_classes/component/Component.js#L3957) after evaluation. 

Since the non-default widget settings were not preserved after evaluating field logic, `this.settings.readOnly` was not present in `CalendarWidget` [when setting the value](https://github.com/formio/formio.js/blob/master/src/widgets/CalendarWidget.js#L355), which for some reason caused the wrong timezone to display in the `DateTime` component (see Jira ticket). 

**Why have you chosen this solution?**

I wanted to fix the bug closer to the source of the issue. It seems that in the case of `DateTime` and `TextField` components, no non-default widget settings were being applied to `this.originalComponent` such that any non-default widget settings would be wiped after evaluating field logic. The original bug report didn't touch on `TextField`s, but I wanted to address any potential bugs there as well. 

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Automated and manual testing.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
