### PR TITLE
FIO-9480: ensure parent references are stable before subform creation

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -162,9 +162,8 @@ export default class FormComponent extends Component {
     // Make sure to not show the submit button in wizards in the nested forms.
     _.set(options, 'buttonSettings.showSubmit', false);
     
-    // Set the parent options to the subform so those references are stable when the subform is created
+    // Set the parent option to the subform so those references are stable when the subform is created
     options.parent = this;
-    options.parentVisible = this.visible;
     
     if (!this.options) {
       return options;
@@ -444,6 +443,7 @@ export default class FormComponent extends Component {
       return (new Form(form, this.getSubOptions())).ready.then((instance) => {
         this.subForm = instance;
         this.subForm.currentForm = this;
+        this.subForm.parentVisible = this.visible;
         const componentsMap = this.componentsMap;
         const formComponentsMap = this.subForm.componentsMap;
         _.assign(componentsMap, formComponentsMap);

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -161,7 +161,11 @@ export default class FormComponent extends Component {
 
     // Make sure to not show the submit button in wizards in the nested forms.
     _.set(options, 'buttonSettings.showSubmit', false);
-
+    
+    // Set the parent options to the subform so those references are stable when the subform is created
+    options.parent = this;
+    options.parentVisible = this.visible;
+    
     if (!this.options) {
       return options;
     }
@@ -443,9 +447,7 @@ export default class FormComponent extends Component {
         const componentsMap = this.componentsMap;
         const formComponentsMap = this.subForm.componentsMap;
         _.assign(componentsMap, formComponentsMap);
-        this.component.components = this.subForm.components.map((comp) => comp.component);
-        this.subForm.parent = this;
-        this.subForm.parentVisible = this.visible;
+        this.component.components = this.subForm.components.map((comp) => comp.component); 
         this.subForm.on('change', () => {
           if (this.subForm) {
             this.dataValue = this.subForm.getValue();


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9480

## Description

Sometimes a deeply nested child needs state or data from a distant parent, and needs to crawl up the reference tree to get it. E.g. a calculated value that looks like 
```javascript
const myValue = instance?.root.parent?.root?.parent?.root?.parent?.data?.role;
``` 

Previously these references were not stable, because they were being instantiated _after_ subForm creation. This PR fixes this behavior so that they are passed along with the creation options, and those references will be stable from the start.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?


## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
