### PR TITLE
FIO-9524: Fix bad request when fetching nested form

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -65,7 +65,7 @@ export default class FormComponent extends Component {
         this.options.project = this.formSrc;
       }
       else {
-        this.formSrc = Formio.getProjectUrl();
+        this.formSrc = this.options.project || Formio.getProjectUrl();
         this.options.project = this.formSrc;
       }
       if (this.component.form) {
@@ -161,10 +161,10 @@ export default class FormComponent extends Component {
 
     // Make sure to not show the submit button in wizards in the nested forms.
     _.set(options, 'buttonSettings.showSubmit', false);
-    
+
     // Set the parent option to the subform so those references are stable when the subform is created
     options.parent = this;
-    
+
     if (!this.options) {
       return options;
     }
@@ -447,7 +447,7 @@ export default class FormComponent extends Component {
         const componentsMap = this.componentsMap;
         const formComponentsMap = this.subForm.componentsMap;
         _.assign(componentsMap, formComponentsMap);
-        this.component.components = this.subForm.components.map((comp) => comp.component); 
+        this.component.components = this.subForm.components.map((comp) => comp.component);
         this.subForm.on('change', () => {
           if (this.subForm) {
             this.dataValue = this.subForm.getValue();
@@ -505,12 +505,10 @@ export default class FormComponent extends Component {
     }
     else if (this.formSrc) {
       this.subFormLoading = true;
-      const options = this.root?.formio?.base && this.root?.formio?.projectUrl
-        ? {
-            base: this.root.formio.base,
-            project: this.root.formio.projectUrl,
-          }
-        : {};
+      const options = {
+        base: this.root?.formio?.base || this.options.baseUrl || '',
+        project: this.root?.formio?.projectUrl || this.options.project || '',
+      };
       return (new Formio(this.formSrc, options)).loadForm({ params: { live: 1 } })
         .then((formObj) => {
           this.formObj = formObj;

--- a/test/unit/Form.unit.js
+++ b/test/unit/Form.unit.js
@@ -13,6 +13,7 @@ import {
   comp6,
   comp7,
   comp8,
+  comp9,
   nestedWizardForm,
 } from './fixtures/form';
 import Webform from '../../src/Webform.js';
@@ -532,6 +533,45 @@ describe('SaveDraft functionality for Nested Form', () => {
         assert.equal(form.options.readOnly, true);
         done();
       });
+    }).catch((err) => done(err));
+  });
+});
+
+describe('Rendering nested forms', () => {
+  const originalMakeRequest = Formio.makeRequest;
+  let urlRequest = "";
+
+  before((done) => {
+    Formio.makeRequest = (formio, type, url, method, data) => {
+        urlRequest = url;
+        return Promise.resolve({})
+    };
+    done();
+  });
+
+  afterEach(() => {
+    urlRequest = "";
+   });
+
+  after((done) => {
+    Formio.makeRequest = originalMakeRequest;
+    done();
+  });
+
+   const options = {
+      "baseUrl": "http://someHost",
+      "hooks": {},
+      "sanitize": true,
+      "readOnly": false,
+      "project": "http://soneHost/skpbdisfmqlnydv"
+  }
+  it('Should provide correct url for requsted nested form', (done) => {
+    const formElement = document.createElement('div');
+    Formio.createForm(formElement, comp9, options).then((form) => {
+      setTimeout(() => {
+        assert.equal(urlRequest.includes("skpbdisfmqlnydv"), true);
+        done()
+        600});
     }).catch((err) => done(err));
   });
 });

--- a/test/unit/Form.unit.js
+++ b/test/unit/Form.unit.js
@@ -539,18 +539,18 @@ describe('SaveDraft functionality for Nested Form', () => {
 
 describe('Rendering nested forms', () => {
   const originalMakeRequest = Formio.makeRequest;
-  let urlRequest = "";
+  let urlRequests = [];
 
   before((done) => {
     Formio.makeRequest = (formio, type, url, method, data) => {
-        urlRequest = url;
+        urlRequests.push(url);
         return Promise.resolve({})
     };
     done();
   });
 
   afterEach(() => {
-    urlRequest = "";
+    urlRequests = [];
    });
 
   after((done) => {
@@ -569,7 +569,8 @@ describe('Rendering nested forms', () => {
     const formElement = document.createElement('div');
     Formio.createForm(formElement, comp9, options).then((form) => {
       setTimeout(() => {
-        assert.equal(urlRequest.includes("skpbdisfmqlnydv"), true);
+        const isProjectIncluded = urlRequests.some(url => url.includes("skpbdisfmqlnydv"))
+        assert.equal(isProjectIncluded, true);
         done()
         600});
     }).catch((err) => done(err));

--- a/test/unit/fixtures/form/comp9.js
+++ b/test/unit/fixtures/form/comp9.js
@@ -1,0 +1,51 @@
+export default {
+  "name": "parent",
+  "path": "parent",
+  "type": "form",
+  "display": "form",
+  "components": [
+    {
+      "label": "Number",
+      "applyMaskOn": "change",
+      "mask": false,
+      "tableView": false,
+      "delimiter": false,
+      "requireDecimal": false,
+      "inputFormat": "plain",
+      "truncateMultipleSpaces": false,
+      "validateWhenHidden": false,
+      "key": "number",
+      "type": "number",
+      "input": true
+    },
+    {
+      "label": "Text Area",
+      "applyMaskOn": "change",
+      "autoExpand": false,
+      "tableView": true,
+      "validateWhenHidden": false,
+      "key": "textArea",
+      "conditional": {
+        "show": true,
+        "conjunction": "all",
+        "conditions": [
+          {
+            "component": "number",
+            "operator": "isEqual",
+            "value": 5
+          }]
+      },
+      "type": "textarea",
+      "input": true
+    },
+    {
+      "label": "Form",
+      "tableView": true,
+      "form": "676ec7413b531fd4c8986dc5",
+      "useOriginalRevision": false,
+      "key": "form",
+      "type": "form",
+      "input": true
+    }
+  ],
+}

--- a/test/unit/fixtures/form/index.js
+++ b/test/unit/fixtures/form/index.js
@@ -7,6 +7,7 @@ import comp5 from './comp5';
 import comp6 from './comp6';
 import comp7 from './comp7';
 import comp8 from './comp8';
+import comp9 from './comp9';
 import nestedWizardForm from './nestedWizardForm';
-export { formModalEdit, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, nestedWizardForm };
+export { formModalEdit, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, nestedWizardForm };
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9524

## Description

**What changed?**

When esignature module is used, the nested form gets initialized with a Formio from it's build. And it doesn't have a set project url that matches currently open project. So the final link to the nested form is malformed and 400 Bad Request happens.
I've tried adjusting the imports of Formio to point to same Formio instance, but didn't succeed with that approach.
So as another solution I've managed to pass the project URL in the options object and use it if it's present.

**Why have you chosen this solution?**

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

[ngFormio#741](https://github.com/formio/ngFormio/pull/741)

## How has this PR been tested?

Automated test is added

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
