### PR TITLE
Fixing the embed code to export the Formio construct.

### DIFF
--- a/src/formio.embed.js
+++ b/src/formio.embed.js
@@ -1,2 +1,3 @@
 import { embed } from './InlineEmbed';
 embed();
+export { Formio } from './InlineEmbed';


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9552

## Description

The "formio.embed.js" file on the CDN was throwing an error that the "Formio" class was undefined. Turns out, this was not getting exported and picked up on by Webpack so it was not getting defined as a global. This simply ensures that it is exported so that it will be defined globally.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Manual

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
