### PR TITLE
FIO-9499 Component: Check if ref is instance of NodeList on detach

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -1480,7 +1480,7 @@ export default class Component extends Element {
   detach() {
     // First iterate through each ref and delete the component so there are no dangling component references.
     _.each(this.refs, (ref) => {
-      if (typeof ref === NodeList) {
+      if (ref instanceof NodeList) {
         ref.forEach((elem) => {
           delete elem.component;
         });


### PR DESCRIPTION
## Link to Jira Ticket

closely related, but not directly responsible for the initial bug. It was discovered while working on:

https://formio.atlassian.net/browse/FIO-9499

## Description

**What changed?**

Updated check from `typeof ref === NodeList` to `ref instanceof NodeList` since the former returns `'object'` and not what we're checking for `'NodeList'`.

<img width="373" alt="Screenshot 2025-01-08 at 1 07 42 PM" src="https://github.com/user-attachments/assets/8adff702-ce01-42db-86f7-03f2dc949392" />

**Why have you chosen this solution?**

So that the result of this conditional is what we're expecting.  

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Manual testing + automated test in `formio` repo https://github.com/formio/formio/pull/1885.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
