### PR TITLE
FIO-9482 fixed setting Formio version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ const replace = require('gulp-replace');
 const rename = require('gulp-rename');
 const cleanCSS = require('gulp-clean-css');
 const clean = require('gulp-clean');
+const packageJson = require('./package.json');
 
 // Clean lib folder.
 gulp.task('clean:dist', () => {
@@ -21,6 +22,12 @@ gulp.task('clean', gulp.parallel('clean:dist', 'clean:lib'));
 gulp.task('builder-fonts', function builderFonts() {
   return gulp.src('./node_modules/bootstrap-icons/font/fonts/*').pipe(gulp.dest('dist/fonts'));
 });
+
+gulp.task('version', () => {
+  return gulp.src(['./lib/**/Formio.js', './lib/**/Embed.js'])
+    .pipe(replace('FORMIO_VERSION', packageJson.version))
+    .pipe(gulp.dest('lib'));
+})
 
 // Generate styles
 const compileStyles = (styles, file) => {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build": "yarn doc && yarn lib && yarn dist",
     "doc": "typedoc",
     "dist": "gulp clean:dist && webpack --config webpack.config.js && webpack --config webpack.prod.js && gulp build",
-    "lib": "gulp clean:lib && tsc --project tsconfig.cjs.json && tsc --project tsconfig.mjs.json && yarn lib:package",
+    "lib": "gulp clean:lib && tsc --project tsconfig.cjs.json && tsc --project tsconfig.mjs.json && yarn lib:package  && gulp version",
     "lib:package": "node ./libpackage.js",
     "version": "node -e 'console.log(require(`./package.json`).version)'",
     "build-app": "yarn build-app:create-app && yarn build-app:jekyll && yarn build-app:remove-app",


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9482

## Description

*Fixed setting the Formio.version property. Previously  the Formio.version property was set as 'FORMIO_VERSION' and was not overwritten according to the version installed in package.json during the build process. This meant that the grid library was loaded only from cdn.form.io (instead of cdn.test-form.io for testing), because 'FORMIO_VERSION' doesn't include 'rc'. It was fixed by adding a gulp task and replacing the static 'FORMIO_VERSION' with the appropriate FJS version.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
