### PR TITLE
FIO-9517: nested forms with lazy load validation fix

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -763,7 +763,7 @@ export default class Wizard extends Webform {
   }
 
   beforeSubmit() {
-    const pages = this.getPages();
+    const pages = this.getPages({all: true});
 
     return Promise.all(pages.map((page) => {
       page.options.beforeSubmit = true;
@@ -1065,7 +1065,7 @@ export default class Wizard extends Webform {
     );
   }
 
-  get errors() { 
+  get errors() {
     return !this.isLastPage() && !this.submitted ? this.currentPage.errors : super.errors;
   }
 

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -161,10 +161,10 @@ export default class FormComponent extends Component {
 
     // Make sure to not show the submit button in wizards in the nested forms.
     _.set(options, 'buttonSettings.showSubmit', false);
-    
+
     // Set the parent option to the subform so those references are stable when the subform is created
     options.parent = this;
-    
+
     if (!this.options) {
       return options;
     }
@@ -451,7 +451,7 @@ export default class FormComponent extends Component {
         const componentsMap = this.componentsMap;
         const formComponentsMap = this.subForm.componentsMap;
         _.assign(componentsMap, formComponentsMap);
-        this.component.components = this.subForm.components.map((comp) => comp.component); 
+        this.component.components = this.subForm.components.map((comp) => comp.component);
         this.subForm.on('change', () => {
           if (this.subForm) {
             this.dataValue = this.subForm.getValue();
@@ -652,11 +652,23 @@ export default class FormComponent extends Component {
       this.dataValue = submission;
       return Promise.resolve(this.dataValue);
     }
-    return this.submitSubForm(false)
+
+    if(this.isSubFormLazyLoad() && !this.subFormLoading){
+      return this.createSubForm(true)
+      .then(this.submitSubForm(false))
+        .then(() => {
+          return this.dataValue;
+        })
+        .then(() => super.beforeSubmit());
+
+    }
+    else {
+      return this.submitSubForm(false)
       .then(() => {
         return this.dataValue;
       })
       .then(() => super.beforeSubmit());
+    }
   }
 
   isSubFormLazyLoad() {

--- a/test/unit/Wizard.unit.js
+++ b/test/unit/Wizard.unit.js
@@ -54,6 +54,146 @@ describe('Wizard tests', () => {
     btn.dispatchEvent(clickEvent);
   };
 
+
+
+const parentForm = {
+  "_id": "677d3efea934773d422a05fa",
+  "title": "Wizard parent",
+  "name": "fdAsWizardParent",
+  "path": "fdaswizardparent",
+  "type": "form",
+  "display": "wizard",
+  "components": [
+    {
+      "title": "Page 1",
+      "key": "page1",
+      "type": "panel",
+      "components": []
+    },
+    {
+      "title": "Page 2",
+      "key": "page2",
+      "type": "panel",
+      "components": [
+        {
+          "label": "Form",
+          "key": "form",
+          "type": "form",
+          "form": "677d3efea934773d422a05f3",
+          "lazyLoad": true
+        }
+      ]
+    },
+    {
+      "title": "Page 3",
+      "key": "page3",
+      "type": "panel",
+      "components": []
+    }
+  ]
+};
+
+const childFormOwner = {
+  "_id": "677d3efea934773d422a05f3",
+  "title": "Wizard Child Owner",
+  "name": "fdaWizardChildOwner",
+  "path": "fdawizardchildOwner",
+  "type": "form",
+  "components": [
+    {
+      "label": "Form",
+      "key": "form",
+      "type": "form",
+      "form": "677d3efea934773d422a05ec",
+      "lazyLoad": true
+    },
+    {
+      "label": "Submit",
+      "key": "submit",
+      "type": "button"
+    }
+  ]
+};
+
+
+
+const childForm = {
+  "_id": "677d3efea934773d422a05ec",
+  "title": "Wizard Child",
+  "name": "WizardChild",
+  "path": "wizardchild",
+  "type": "form",
+  "components": [
+    {
+      "label": "Text Field",
+      "key": "textField",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "label": "Submit",
+      "key": "submit",
+      "type": "button"
+    }
+  ]
+};
+
+describe('Wizard Form with Nested Form validation', () => {
+  const originalMakeRequest = Formio.makeRequest;
+  let postRequestCount = 0;
+
+  before(() => {
+    // Mock Formio.makeRequest to count POST requests and serve mock forms
+    Formio.makeRequest = (formio, type, url, method, data) => {
+      if (type === 'form' && method === 'get') {
+        if (url.includes('parentForm')) {
+          return Promise.resolve(_.cloneDeep(parentForm));
+        } else if (url.includes('677d3efea934773d422a05ec')) {
+          return Promise.resolve(_.cloneDeep(childForm));
+        } else if (url.includes('677d3efea934773d422a05f3')) {
+          return Promise.resolve(_.cloneDeep(childFormOwner));
+        }
+      }
+      if (type === 'submission' && ['put', 'post'].includes(method)) {
+        postRequestCount++;
+      }
+      return Promise.resolve();
+    };
+  });
+
+  after(() => {
+    // Restore the original makeRequest
+    Formio.makeRequest = originalMakeRequest;
+  });
+
+  it('Should validate wizard with nested forms with lazy load on without POST request (on client side)', async () => {
+    const formElement = document.createElement('div');
+    const wizard = await Formio.createForm(formElement, 'http://localhost:3000/idwqwhclwioyqbw/parentForm')
+      // Navigate directly to the last page, don't open page with nested form to avoid loading before submission process
+      wizard.setPage(2);
+      await(300);
+
+      // Assert we are on last
+      assert.equal(wizard.page, 2, 'Should navigate to last');
+
+      // Try to submit the form with empty data
+      try {
+        wizard.submit();
+      }
+      catch(err) {
+        // Assert validation error
+        assert(err, 'Should trigger validation error');
+        assert.equal(err.length, 1);
+        assert.equal(err[0].ruleName, 'required');
+
+        // Assert no POST requests were made
+        assert.equal(postRequestCount, 0, 'No submission POST requests should be made');
+      }
+  });
+});
+
   it('Should recalculate values for components with "allow override" after wizard is canceled', function(done) {
     const formElement = document.createElement('div');
     Formio.createForm(formElement, formsWithAllowOverride.wizard).then((form) => {
@@ -323,7 +463,7 @@ describe('Wizard tests', () => {
     nestedWizard.components[2].conditional = { show: true, when: 'checkbox', eq: 'true' };
 
     await wizard.setForm(formWithNestedWizard);
-   
+
     const nestedFormComp = wizard.getComponent('formNested');
 
     nestedFormComp.loadSubForm = () => {
@@ -338,7 +478,7 @@ describe('Wizard tests', () => {
     const checkPage = (pageNumber) => {
       assert.equal(wizard.page, pageNumber, `Should open wizard page ${pageNumber + 1}`);
     };
-    
+
     checkPage(0);
     assert.equal(wizard.pages.length, 4, 'Should have 4 pages');
     assert.equal(wizard.allPages.length, 4, 'Should have 4 pages');
@@ -346,7 +486,7 @@ describe('Wizard tests', () => {
 
     clickWizardBtn(wizard, 'link[3]');
     await wait(300);
-    
+
     checkPage(3);
     assert.deepEqual(!!wizard.refs[`${wizard.wizardKey}-submit`], true, 'Should hav submit btn on the last page');
     wizard.getComponent('checkbox').setValue(true);
@@ -369,7 +509,7 @@ describe('Wizard tests', () => {
     checkPage(4);
     clickWizardBtn(wizard, 'previous');
     await wait(300);
-            
+
     checkPage(3);
     wizard.getComponent('checkbox').setValue(false);
     await wait(500);
@@ -377,7 +517,7 @@ describe('Wizard tests', () => {
     assert.equal(wizard.pages.length, 4, 'Should hide conditional page');
     assert.equal(wizard.allPages.length, 4, 'Should hide conditional page');
     assert.equal(wizard.refs[`${wizard.wizardKey}-link`].length, 4, 'Should contain refs to breadcrumbs of visible pages');
-    assert.deepEqual(!!wizard.refs[`${wizard.wizardKey}-submit`], true, 'Should have submit btn on the last page');  
+    assert.deepEqual(!!wizard.refs[`${wizard.wizardKey}-submit`], true, 'Should have submit btn on the last page');
   }).timeout(6000);
 
   it('Should trigger validation of nested wizard before going to the next page', function (done) {
@@ -629,16 +769,16 @@ describe('Wizard tests', () => {
     // you can't submit the form without first navigating to page 3
     wizard.submit();
     await wait(400);
-    const getRequiredFieldErrors = () => 
+    const getRequiredFieldErrors = () =>
         wizard.errors.filter(error => error.message === 'Text Field is required');
-    
-    assert.equal(getRequiredFieldErrors().length, 2);      
+
+    assert.equal(getRequiredFieldErrors().length, 2);
     // navigate to page 2
     clickWizardBtn(wizard, 'link[1]');
     await wait(200);
     // the form-level errors should still be the same
-    assert.equal(getRequiredFieldErrors().length, 2); 
-    // navigate to page 1 
+    assert.equal(getRequiredFieldErrors().length, 2);
+    // navigate to page 1
     clickWizardBtn(wizard, 'link[0]');
     const page1Input = wizard.element.querySelector('input[name="data[textField]"]');
     const inputEvent = new Event('input');
@@ -646,8 +786,8 @@ describe('Wizard tests', () => {
     page1Input.dispatchEvent(inputEvent);
     await wait(200);
     // maintain form-level error after supplying value for one required field
-    assert.equal(getRequiredFieldErrors().length, 1); 
-    assert.equal(getRequiredFieldErrors()[0].formattedKeyOrPath, 'textField1'); 
+    assert.equal(getRequiredFieldErrors().length, 1);
+    assert.equal(getRequiredFieldErrors()[0].formattedKeyOrPath, 'textField1');
   });
 
   it('Should render values in HTML render mode', function(done) {
@@ -875,7 +1015,7 @@ describe('Wizard tests', () => {
       nestedFormComp.createSubForm();
 
       setTimeout(() => {
-  
+
         clickWizardBtn(wizard, 'link[1]');
 
         setTimeout(() => {
@@ -2250,7 +2390,7 @@ it('Should show tooltip for wizard pages', function(done) {
 
   it('Should retain previous checkbox checked property when navigating to another page (unchecked)', (done) => {
     const wizard = new Wizard(document.createElement('div'));
-    wizard.setForm(WizardWithCheckboxes).then(()=> {      
+    wizard.setForm(WizardWithCheckboxes).then(()=> {
       wizard.element.querySelector('input').click();
       wizard.element.querySelector('input').click();
       clickWizardBtn(wizard, 'next');


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9517

## Description

The validation process of the wizard form with embedded forms using lazy loading has been fixed.

In the beforeSubmit method of the FormComponent class, the following changes were made:
 • Added a check to verify whether all nested forms with lazyload = true have been loaded.
 • If not, the missing forms are loaded.

These changes ensure that the submission data is validated correctly on the client side, meeting all requirements (including rules for all nested forms) without sending submission POST request to the server.

## Dependencies

-

## How has this PR been tested?

autotests,
manually

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
