### PR TITLE
FIO-9207: Fix image preview for file component when using google drive

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -118,7 +118,8 @@ export default class FileComponent extends Field {
     if (this.component.privateDownload) {
       fileInfo.private = true;
     }
-    return this.fileService.downloadFile(fileInfo).then((result) => result.url);
+    // pass the component to the downloadFile method
+    return this.fileService.downloadFile(fileInfo, this.component).then((result) => result.url);
   }
 
   get emptyValue() {

--- a/src/providers/storage/googleDrive.js
+++ b/src/providers/storage/googleDrive.js
@@ -60,10 +60,11 @@ function googledrive(formio) {
         xhr.send(fd);
       }));
     },
-    downloadFile(file) {
+    downloadFile(file, component) {
       const token = formio.getToken();
+      // Constructed the url with the fileId, fileName, displayImage, imageSize if applicable
       file.url =
-        `${formio.formUrl}/storage/gdrive?fileId=${file.id}&fileName=${file.originalName}${token ? `&x-jwt-token=${token}` : ''}`;
+        `${formio.formUrl}/storage/gdrive?fileId=${file.id}&fileName=${file.originalName}${token ? `&x-jwt-token=${token}` : ''}${component.image ? '&displayImage=true' : ''}${component.imageSize ? `&imageSize=${component.imageSize}` : ''}`;
       return Promise.resolve(file);
     },
     deleteFile: function deleteFile(fileInfo) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9207

## Description

**What changed?**

Added new params in the URL construction to switch between weblink and webcontentlink using google drive endpoint.

**Why have you chosen this solution?**

As per Google Drive documentation in order to render the image in a img tag we need to use /thumbnail endpoint and to preview the image we need to use the weblink by default.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

Change in Server: [PR](https://github.com/formio/formio-server/pull/1620)

## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
