### PR TITLE
FIO-9548:fixed setting of form._data for  NestedDataComponent into forms with noDefaults option

### DIFF
--- a/src/components/_classes/nesteddata/NestedDataComponent.js
+++ b/src/components/_classes/nesteddata/NestedDataComponent.js
@@ -29,6 +29,10 @@ export default class NestedDataComponent extends NestedComponent {
     return {};
   }
 
+  get shouldAddDefaultValue() {
+    return !this.options.noDefaults || !this.options.server;
+  }
+
   componentContext() {
     return this.dataValue;
   }

--- a/src/components/container/Container.unit.js
+++ b/src/components/container/Container.unit.js
@@ -126,4 +126,74 @@ describe('Container Component', () => {
     assert(textField, 'TextField component found');
     assert.strictEqual(textField.path, 'editGrid[0].container.textField');
   });
+
+  describe('Container component calculations when noDefaults Form Renderer Option', () => {
+    const formTemplate = {
+      '_id': '67978d7ab71bdbf9f76c6bf7',
+      'title': 'testNoDef',
+      'name': 'testNoDef',
+      'path': 'testnodef',
+      'type': 'form',
+      'display': 'form',
+      'components': [
+        {
+          'label': 'Container',
+          'tableView': false,
+          'key': 'container',
+          'type': 'container',
+          'input': true,
+          'components': [
+            {
+              'label': 'Text Field',
+              'key': 'textField',
+              'type': 'textfield',
+              'input': true,
+            },
+            {
+              'label': 'Text Field Calculation',
+              'key': 'textFieldCalculation',
+              'type': 'textfield',
+              'input': true,
+              'calculateValue': 'value = data.container.textField'
+            }
+          ]
+        },
+        {
+          'type': 'button',
+          'label': 'Submit',
+          'key': 'submit',
+          'disableOnInvalid': true,
+          'input': true
+        }
+      ]
+    };
+
+    it('Should set correct form data and make correct container component calculations when noDefaults Form Renderer Option is set', async() => {
+      const element = document.createElement('div');
+      const form = await Formio.createForm(element, formTemplate, { noDefaults: true });
+
+      const textField = form.getComponent('textField');
+      textField.setValue('test');
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      assert.deepEqual(form._data.container, {
+          textField: 'test',
+          textFieldCalculation: 'test'
+      });
+    });
+
+    it('Should set correct form data and make correct container component calculations when noDefaults Form Renderer Option is not set', async() => {
+      const element = document.createElement('div');
+      const form = await Formio.createForm(element, formTemplate);
+
+      const textField = form.getComponent('textField');
+      textField.setValue('test');
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      assert.deepEqual(form._data.container, {
+          textField: 'test',
+          textFieldCalculation: 'test'
+      });
+    });
+  });
 });

--- a/src/components/editgrid/EditGrid.unit.js
+++ b/src/components/editgrid/EditGrid.unit.js
@@ -1451,6 +1451,32 @@ describe('EditGrid Open when Empty', () => {
       .catch(done);
   });
 
+  it('Should correctly set data in EditGrid when noDefaults is set', async() => {
+    const element = document.createElement('div');
+    const form = await Formio.createForm(element, compOpenWhenEmpty, { noDefaults: true });
+    const editGrid = form.getComponent('editGrid');
+
+    // Function to add a row and set value to the textField
+    const addRowAndSetValue = async(rowIndex, value) => {
+      await editGrid.addRow();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      const textField = editGrid.getComponent([rowIndex, 'textField']);
+      textField.setValue(value);
+    };
+
+    await addRowAndSetValue(0, '1');
+    editGrid.saveRow(0);
+    await addRowAndSetValue(1, '2');
+    editGrid.saveRow(1);
+
+    assert.equal(form._data.editGrid.length, 2);
+    assert.deepEqual(form._data, { editGrid: [{ textField: '1' }, { textField: '2' }] });
+    const event = await form.submitForm();
+    const submissionData = event.submission.data;
+
+    assert.deepEqual(submissionData, { editGrid: [{ textField: '1' }, { textField: '2' }] });
+  });
+
   it('Should always add a first row', (done) => {
     const formElement = document.createElement('div');
     Formio.createForm(formElement, compOpenWhenEmpty)


### PR DESCRIPTION


## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9548

## Description
The issue with calculations was caused by incorrect filling of form._data, which led to incorrect data in submission data and calculation errors when components related to form with noDefaults option is set to true. (loss of data structure information for Container component, loss of the first row for EditGrid component).
Adding method shouldAddDefaultValue to NestedDataComponent prevents this problem.


## Dependencies
-


## How has this PR been tested?
autotests,
manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
