### PR TITLE
FIO-9666: Add class missing when PDF Render a File Component Error

### DIFF
--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -387,6 +387,10 @@ td > .formio-form-group {
   font-size: 0.9rem;
 }
 
+.formio-component-file .status .text-danger {
+  color: #a94442;
+}
+
 .formio-component-file .list-group-item .fa {
   cursor: pointer;
 }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9666

## Description

**What changed?**

Added CSS Class to handle error in File Component UI Change.

**Why have you chosen this solution?**

Following the new UI change for the File Component. 

## Breaking Changes / Backwards Compatibility

NA

## Dependencies

NA 

## How has this PR been tested?

Manually, PDF Renderer

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
