### PR TITLE
FIO-8208: Ensure that all file uploads alter the request options before sending the fetch requests.

### DIFF
--- a/src/providers/storage/s3.js
+++ b/src/providers/storage/s3.js
@@ -96,7 +96,7 @@ function s3(formio) {
       const { changeMessage } = multipart;
       changeMessage('Completing AWS S3 multipart upload...');
       const token = formio.getToken();
-      const response = await fetch(`${formio.formUrl}/storage/s3/multipart/complete`, {
+      const response = await XHR.fetch(`${formio.formUrl}/storage/s3/multipart/complete`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -117,7 +117,7 @@ function s3(formio) {
     abortMultipartUpload(serverResponse) {
       const { uploadId, key } = serverResponse;
       const token = formio.getToken();
-      fetch(`${formio.formUrl}/storage/s3/multipart/abort`, {
+      XHR.fetch(`${formio.formUrl}/storage/s3/multipart/abort`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -134,7 +134,7 @@ function s3(formio) {
         const start = i * partSize;
         const end = (i + 1) * partSize;
         const blob = i < urls.length ? file.slice(start, end) : file.slice(start);
-        const promise = fetch(urls[i], {
+        const promise = XHR.fetch(urls[i], {
           method: 'PUT',
           headers,
           body: blob,

--- a/src/providers/storage/xhr.js
+++ b/src/providers/storage/xhr.js
@@ -1,4 +1,5 @@
 import _trim from 'lodash/trim';
+import { Formio } from '../../Formio';
 export const setXhrHeaders = (formio, xhr) => {
   const { headers } = formio.options;
   if (headers) {
@@ -21,12 +22,16 @@ const XHR = {
   path(items) {
     return items.filter(item => !!item).map(XHR.trim).join('/');
   },
+  fetch(url, options) {
+    options = Formio.pluginAlter('requestOptions', options, url);
+    return fetch(url, options);
+  },
   async upload(formio, type, xhrCallback, file, fileName, dir, progressCallback, groupPermissions, groupId, abortCallback, multipartOptions) {
     // make request to Form.io server
     const token = formio.getToken();
     let response;
     try {
-      response = await fetch(`${formio.formUrl}/storage/${type}`, {
+      response = await XHR.fetch(`${formio.formUrl}/storage/${type}`, {
         method: 'POST',
         headers: {
           'Accept': 'application/json',


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8208

## Description

The file upload requests were not using the x-remote-token. This is because the plugins to alter the request options is not swapping out the token to use the remote token if it is available.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

N/A

## How has this PR been tested?

N/A

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
