### PR TITLE
FIO-9640: Fix date components have wrong timezone in email

### DIFF
--- a/src/components/datetime/DateTime.js
+++ b/src/components/datetime/DateTime.js
@@ -140,8 +140,8 @@ export default class DateTimeComponent extends Input {
       ...customOptions,
     };
     // update originalComponent to include widget and other updated settings
-    // it is done here since these settings depend on properties present after the component is initialized 
-    // originalComponent is used to restore the component (and widget) after evaluating field logic 
+    // it is done here since these settings depend on properties present after the component is initialized
+    // originalComponent is used to restore the component (and widget) after evaluating field logic
     this.originalComponent = fastCloneDeep(this.component);
     /* eslint-enable camelcase */
   }
@@ -199,15 +199,15 @@ export default class DateTimeComponent extends Input {
     return super.checkValidity(data, dirty, rowData);
   }
 
-  getValueAsString(value) {
+  getValueAsString(value, options) {
     let format = FormioUtils.convertFormatToMoment(this.component.format);
     format += format.match(/z$/) ? '' : ' z';
     const timezone = this.timezone;
     if (value && !this.attached && timezone) {
       if (Array.isArray(value) && this.component.multiple) {
-        return value.map(item => _.trim(FormioUtils.momentDate(item, format, timezone).format(format))).join(', ');
+        return value.map(item => _.trim(FormioUtils.momentDate(item, format, timezone, options).format(format))).join(', ');
       }
-      return _.trim(FormioUtils.momentDate(value, format, timezone).format(format));
+      return _.trim(FormioUtils.momentDate(value, format, timezone, options).format(format));
     }
 
     if (Array.isArray(value) && this.component.multiple) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -143,7 +143,7 @@ export function checkCalculated(component, submission, rowData) {
 }
 
 /**
- * Check if a simple conditional evaluates to true. 
+ * Check if a simple conditional evaluates to true.
  * @param {import('@formio/core').Component} component - The component to check for the conditional.
  * @param {import('@formio/core').SimpleConditional} condition - The condition to check.
  * @param {*} row - The row data for the component.
@@ -294,7 +294,7 @@ export function getComponentActualValue(compPath, data, row) {
   if (row && _.isNil(value)) {
     value = getValue({ data: row }, compPath);
   }
-  
+
   // FOR-400 - Fix issue where falsey values were being evaluated as show=true
   if (_.isNil(value) || (_.isObject(value) && _.isEmpty(value))) {
     value = '';
@@ -329,7 +329,7 @@ export function checkCustomConditional(component, custom, row, data, form, varia
 
 /**
  * Check a component for JSON conditionals.
- * @param {import('@formio/core').Component} component - The component 
+ * @param {import('@formio/core').Component} component - The component
  * @param {import('@formio/core').JSONConditional} json - The json conditional to check.
  * @param {*} row - The contextual row data for the component.
  * @param {*} data - The full submission data.
@@ -709,9 +709,10 @@ export function loadZones(url, timezone) {
  * @param {string|Date} value - The value to convert into a moment date.
  * @param {string} format - The format to convert the date to.
  * @param {string} timezone - The timezone to convert the date to.
+ * @param {object} options - The options object
  * @returns {Date} - The moment date object.
  */
-export function momentDate(value, format, timezone) {
+export function momentDate(value, format, timezone, options) {
   const momentDate = moment(value);
   if (!timezone) {
     return momentDate;
@@ -719,7 +720,7 @@ export function momentDate(value, format, timezone) {
   if (timezone === 'UTC') {
     timezone = 'Etc/UTC';
   }
-  if ((timezone !== currentTimezone() || (format && format.match(/\s(z$|z\s)/))) && moment.zonesLoaded) {
+  if ((timezone !== currentTimezone() || (format && format.match(/\s(z$|z\s)/))) && (moment.zonesLoaded || options?.email)) {
     return momentDate.tz(timezone);
   }
   return momentDate;

--- a/test/unit/DateTime.unit.js
+++ b/test/unit/DateTime.unit.js
@@ -4,7 +4,8 @@ import DateTimeComponent from '../../src/components/datetime/DateTime';
 import { Formio } from '../../src/Formio';
 import _ from 'lodash';
 import 'flatpickr';
-import moment from 'moment';
+import moment from 'moment-timezone';
+import Form from '../../src/Form.js'
 import {
   comp1,
   comp2,
@@ -13,7 +14,7 @@ import {
   comp6,
   comp7,
   comp8,
- // comp9,
+  // comp9,
   comp10,
   comp11,
   comp12,
@@ -47,6 +48,19 @@ describe('DateTime Component', () => {
         assert.equal(dateTime.getValueAsString('2020-09-18T12:12:00'), '2020-09-18 12:12 PM');
         dateTime.destroy();
       });
+  });
+
+  it('Should show date and time in submission time zone', async () => {
+    const form = await new Form(_.cloneDeep(comp3), {
+      server: true,
+      noeval: true,
+      noDefaults: true,
+      submissionTimezone: "Europe/Berlin"
+    }).ready;
+
+    const dateTime = form.getComponent('dateTime');
+    const response = dateTime.getValueAsString('2025-02-11T10:00:00.000Z', { email: true })
+    assert.equal(response, "2025-02-11 11:00 AM CET");
   });
 
   it('Should not change manually entered value on blur when time is disabled', (done) => {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9640

## Description

**What changed?**

Added options passing to 'getValueAsString' of DateTime component, so to make sure timezone offset is applied for emailed submissions

**Why have you chosen this solution?**

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

formio/vm/pull/49

## How has this PR been tested?

Automated test is added

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
