### PR TITLE
FIO-9721 Added Submit button as available trigger option of captcha inside Wizard

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -766,6 +766,7 @@ export default class Wizard extends Webform {
     const pages = this.getPages({all: true});
 
     return Promise.all(pages.map((page) => {
+      this.triggerButtonCaptcha(page);
       page.options.beforeSubmit = true;
       return page.beforeSubmit();
     }));
@@ -1088,6 +1089,26 @@ export default class Wizard extends Webform {
       }
     }
     return super.focusOnComponent(key);
+  }
+
+  triggerButtonCaptcha(page) {
+    if (!page.components) {
+      return;
+    }
+
+    let captchaComponent;
+
+    page.eachComponent((component)=> {
+      if (/^(re)?captcha$/.test(component.component.type) &&
+        component.component.eventType === 'buttonClick' &&
+        component.component.buttonKey === 'submit') {
+          captchaComponent = component;
+        }
+    });
+
+    if (captchaComponent) {
+      captchaComponent.verify(`submitClick`);
+    }
   }
 }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9721

## Description

*The Submit button is not displayed in the "Button Key" field for the CAPTCHA component with the "Button Click" event in wizard forms, because for the wizard form, the Submit button is not a component, but is part of the Wizard template. The problem of setting the CAPTCHA verification event by clicking on the Submit button was fixed by adding the appropriate option for Wizard forms and the CAPTCHA verification method trigger before submitting the Wizard form.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*https://github.com/formio/premium/pull/373*

## How has this PR been tested?

*All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
