### PR TITLE
FIO-9751 updated modal edit window for components with hidden tabs on builder mode

### DIFF
--- a/src/PDFBuilder.js
+++ b/src/PDFBuilder.js
@@ -326,7 +326,7 @@ export default class PDFBuilder extends WebformBuilder {
           width: schema.width
         };
 
-        if (!this.options.noNewEdit && !component.component.noNewEdit) {
+        if (!this.options.noNewEdit && !component.component.noNewEdit && this.hasEditTabs(component.type)) {
           this.editComponent(component.component, this.getParentContainer(component), isNew);
         }
         this.emit('updateComponent', component.component);
@@ -352,7 +352,7 @@ export default class PDFBuilder extends WebformBuilder {
 
     this.webform.on('iframe-componentClick', schema => {
       const component = this.webform.getComponentById(schema.id);
-      if (component) {
+      if (component && this.hasEditTabs(component.type)) {
         this.editComponent(component.component, this.getParentContainer(component));
       }
     }, true);

--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -134,7 +134,9 @@ export default class WebformBuilder extends Component {
         html,
         disableBuilderActions: self?.component?.disableBuilderActions,
         childComponent: component,
-        design: self?.options?.design
+        design: self?.options?.design,
+        editJson: self?.options?.editJson,
+        editComponent: this.hasEditTabs(component.type)
       });
     };
 
@@ -988,7 +990,13 @@ export default class WebformBuilder extends Component {
 
     const componentInDataGrid = parent.type === 'datagrid';
 
-    if (isNew && !this.options.noNewEdit && !info.noNewEdit && !(this.options.design && info.type === 'reviewpage')) {
+    if (
+      isNew
+      && !this.options.noNewEdit
+      && !info.noNewEdit
+      && this.hasEditTabs(info.type)
+      && !(this.options.design && info.type === 'reviewpage')
+    ) {
       this.editComponent(info, target, isNew, null, null, { inDataGrid: componentInDataGrid });
     }
 
@@ -1903,5 +1911,11 @@ export default class WebformBuilder extends Component {
       info.placeholder ||
       info.type
     );
+  }
+
+  hasEditTabs(type) {
+    const editTabs = getComponent(Components.components[type].editForm().components, 'tabs', true).components;
+    const hiddenEditTabs = _.filter(_.get(this.options, `editForm.${type}`, []), 'ignore');
+    return _.intersectionBy(editTabs, hiddenEditTabs, 'key').length !== editTabs.length;
   }
 }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9751

## Description

*Fixed the issue of displaying the component's modal editing window in the form builder, in case when all available tabs (for example, Data, Display, etc.) are ignored. Thus, when adding a new component that does not have tabs available for editing components, the component will still be available for dragging and dropping, but without opening the EditForm modal window. EditComponent button is hidden for this component. Edit json button also is hidden for all components in the formBuilder using the EFB module.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*https://github.com/formio/bootstrap/pull/123*
*https://github.com/formio/enterprise-builder-core/pull/9*

## How has this PR been tested?

*locally, using builder configurator and demo app*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
