### PR TITLE
FIO-9720 fixed triggering captcha for wizard

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1773,25 +1773,29 @@ export default class Webform extends NestedDataComponent {
         }
     }
 
-    triggerCaptcha() {
+    triggerCaptcha(components = null) {
         if (!this || !this.components || this.options.preview) {
             return;
         }
         const captchaComponent = [];
-        eachComponent(this.components,(component) => {
+        eachComponent(components || this.components,(component) => {
             if (/^(re)?captcha$/.test(component.type) && component.component.eventType === 'formLoad') {
                 captchaComponent.push(component);
             }
         }, true);
 
         if (captchaComponent.length > 0) {
+            if (captchaComponent[0].component.provider === 'google' && components) {
+                return;
+            }
+
             if (this.parent) {
                 this.parent.subFormReady.then(()=> {
                     captchaComponent[0].verify(`${this.form.name ? this.form.name : 'form'}Load`);
                 });
             } else {
                 captchaComponent[0].verify(`${this.form.name ? this.form.name : 'form'}Load`);
-            };
+            }
         }
     }
 

--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -690,6 +690,7 @@ export default class Wizard extends Webform {
       }
       this.redraw().then(() => {
         this.checkData(this.submission.data);
+        this.triggerCaptcha(this.currentPanel.componets);
         const errors = this.submitted ? this.validate(this.localData, { dirty: true }) : this.validateCurrentPage();
         if (this.alert) {
           this.showErrors(errors, true, true);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9720

## Description

*Previously, there was an issue with rendering and verification captcha using cloudflare provider for wizard forms, if the captcha component was not on the first page. The reason for the issue was that the verification took place before the rendering of the component and, accordingly, the rendering of the captcha widget. The problem was fixed by adding a captcha cloudflare trigger when setPage for wizard forms.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*https://github.com/formio/premium/pull/376*

## How has this PR been tested?

*locally using cloudflare CAPTCHA provider*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
