### PR TITLE
FIO-9569: Fixes an issue where Wizard will paste a copy of the current page instead of the copied one

### DIFF
--- a/src/WizardBuilder.js
+++ b/src/WizardBuilder.js
@@ -306,28 +306,21 @@ export default class WizardBuilder extends WebformBuilder {
     if (!window.sessionStorage) {
       return console.warn(this.t('sessionStorageSupportError'));
     }
-    const isWizardPageCopied = window.sessionStorage.getItem('formio.isWizardPageCopied') === 'true' ? true : false;
-    if (isWizardPageCopied) {
+    // If pasting after the Wizard's page, check if a full Wizard page was copied and pass it to addPage method
+    if (this._form.components.find(comp => _.isEqual(component.component, comp))) {
       const data = window.sessionStorage.getItem('formio.clipboard');
       if (data) {
         const schema = JSON.parse(data);
+        // If the copied component is not a Wizard's page, do nothing since we can't paste outside the panel in Wizard
         if (schema.type !== 'panel') {
-          window.sessionStorage.setItem('formio.isWizardPageCopied', 'false');
-          return super.pasteComponent(component);
+          return;
         }
         this.addPage(schema);
       }
     }
     else {
+      // If we are not trying to paster after the current Wizard's page, just pass it to the WebformBuilder
       return super.pasteComponent(component);
-    }
-  }
-
-  copyComponent(component) {
-    super.copyComponent(component);
-    if (window.sessionStorage) {
-      const isWizardPageCopied = this._form.components.indexOf(comp => _.isEqual(component.component, comp)) !== -1;
-      window.sessionStorage.setItem('formio.isWizardPageCopied', isWizardPageCopied.toString());
     }
   }
 }

--- a/src/WizardBuilder.js
+++ b/src/WizardBuilder.js
@@ -303,11 +303,27 @@ export default class WizardBuilder extends WebformBuilder {
     if (component instanceof WizardBuilder) {
       return;
     }
-    if (this._form.components.find(comp => _.isEqual(component.component, comp))) {
-      this.addPage(component);
+    if (!window.sessionStorage) {
+      return console.warn(this.t('sessionStorageSupportError'));
+    }
+    const isWizardPageCopied = window.sessionStorage.getItem('formio.isWizardPageCopied') === 'true' ? true : false;
+    if (isWizardPageCopied) {
+      const data = window.sessionStorage.getItem('formio.clipboard');
+      if (data) {
+        const schema = JSON.parse(data);
+        this.addPage(schema);
+      }
     }
     else {
       return super.pasteComponent(component);
+    }
+  }
+
+  copyComponent(component) {
+    super.copyComponent(component);
+    if (window.sessionStorage) {
+      const isWizardPageCopied = this._form.components.indexOf(comp => _.isEqual(component.component, comp)) !== -1;
+      window.sessionStorage.setItem('formio.isWizardPageCopied', isWizardPageCopied.toString());
     }
   }
 }

--- a/src/WizardBuilder.js
+++ b/src/WizardBuilder.js
@@ -311,6 +311,10 @@ export default class WizardBuilder extends WebformBuilder {
       const data = window.sessionStorage.getItem('formio.clipboard');
       if (data) {
         const schema = JSON.parse(data);
+        if (schema.type !== 'panel') {
+          window.sessionStorage.setItem('formio.isWizardPageCopied', 'false');
+          return super.pasteComponent(component);
+        }
         this.addPage(schema);
       }
     }


### PR DESCRIPTION
## Link to Jira Ticket

FIO-9569-wizard-page-copying

## Description

Before Wizard's builder pastComponents handler was performing a check weather the component parameter is a Wizard's page or not to either call addPage method or pass it to the parent's pastComponent method. But the issue was that it was passing the 'component' (which is actually a component on which 'Paste After' was clicked) parameter from pasteComponent method to the addPage method, so it was always adding a current page instead of the copied one.

Now we check if we are trying to paste after the existing Wizard's page, get the copied component's schema and check if it is a panel (since we can't paste anything else as a page) and only after that pass it to the addPage method.  
## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
