### PR TITLE
FIO-9758: fixed an issue where interpolated content data is not displayed in PDF download

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -110,7 +110,7 @@ export default class FormComponent extends Component {
   }
 
   get dataReady() {
-    return this.subFormReady || Promise.resolve();
+    return this.subForm?.dataReady || this.subFormReady || Promise.resolve();
   }
 
   get defaultValue() {
@@ -743,6 +743,9 @@ export default class FormComponent extends Component {
    */
   onSetSubFormValue(submission, flags) {
     this.subForm.setValue(submission, flags);
+    if (flags.fromSubmission) {
+      this.subForm.submissionReadyResolve(submission);
+    }
   }
 
   isEmpty(value = this.dataValue) {

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -743,7 +743,7 @@ export default class FormComponent extends Component {
    */
   onSetSubFormValue(submission, flags) {
     this.subForm.setValue(submission, flags);
-    if (flags.fromSubmission) {
+    if (flags?.fromSubmission) {
       this.subForm.submissionReadyResolve(submission);
     }
   }

--- a/test/forms/nestedFormWithContentComp.js
+++ b/test/forms/nestedFormWithContentComp.js
@@ -1,0 +1,122 @@
+export const parentForm = {
+  _id: '67c19d4a0b924378e690a99a',
+  title: 'pdf form',
+  name: 'pdfForm',
+  path: 'pdfform',
+  type: 'form',
+  display: 'wizard',
+  owner: '67c19d9d0b924378e690af80',
+  components: [
+    {
+      title: 'Page 1',
+      label: 'Page 1',
+      type: 'panel',
+      key: 'page1',
+      components: [
+        {
+          label: 'database',
+          calculateValue: 'instance.setValue({name: "hey", last:"foo"});',
+          key: 'database',
+          type: 'hidden',
+          input: true,
+          tableView: false,
+        },
+        {
+          label: 'Form',
+          tableView: true,
+          form: '67c19d4a0b924378e690a993',
+          useOriginalRevision: true,
+          calculateValue:
+            'value = { data: \n{name: data.database.name, \nlast: data.database.last\n}};',
+          key: 'form',
+          type: 'form',
+          lazyLoad: false,
+          input: true,
+        },
+      ],
+      input: false,
+      tableView: false,
+    },
+  ],
+  machineName: 'tlrqtysnoafumph:pdfForm',
+  project: '67bf135578d9de8633fd050e',
+};
+
+export const childForm = {
+  _id: '67c19d4a0b924378e690a993',
+  title: 'child',
+  name: 'child',
+  path: 'child',
+  type: 'form',
+  display: 'form',
+  owner: '67c19dfe0b924378e690b400',
+  components: [
+    {
+      label: 'Name',
+      key: 'name',
+      type: 'hidden',
+      input: true,
+      tableView: false,
+    },
+    {
+      label: 'Last',
+      key: 'last',
+      type: 'hidden',
+      input: true,
+      tableView: false,
+    },
+    {
+      html: '<p>Name: {{data.name}}</p><p>Last: {{data.last}}</p>',
+      label: 'Content',
+      refreshOnChange: true,
+      key: 'content',
+      type: 'content',
+      input: false,
+      tableView: false,
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  pdfComponents: [],
+  machineName: 'tlrqtysnoafumph:child',
+  project: '67bf135578d9de8633fd050e',
+  created: '2025-02-28T11:26:02.316Z',
+  modified: '2025-02-28T13:37:46.387Z',
+};
+
+export const submission = {
+  form: '67c19d4a0b924378e690a99a',
+  owner: '637b2e6b48c1227e60b1f910',
+  data: {
+    database: {
+      name: 'hey',
+      last: 'foo',
+    },
+    form: {
+      form: '67c19d4a0b924378e690a993',
+      owner: '637b2e6b48c1227e60b1f910',
+      data: {
+        name: 'hey',
+        last: 'foo',
+      },
+      _id: '67c596918806d7e31b1858de',
+      _fvid: 0,
+      project: '67bf135578d9de8633fd050e',
+      state: 'submitted',
+      created: '2025-03-03T11:46:25.997Z',
+      modified: '2025-03-03T11:46:26.000Z',
+    },
+  },
+  _id: '67c596928806d7e31b185908',
+  _fvid: 0,
+  project: '67bf135578d9de8633fd050e',
+  state: 'submitted',
+  created: '2025-03-03T11:46:26.260Z',
+  modified: '2025-03-03T11:46:26.260Z',
+};

--- a/test/unit/Form.unit.js
+++ b/test/unit/Form.unit.js
@@ -3,7 +3,7 @@ import { fastCloneDeep } from '../../src/utils/utils.js';
 import Harness from '../harness.js';
 import FormComponent from '../../src/components/form/Form.js';
 import { expect } from 'chai';
-import assert from 'power-assert';
+import assert, { equal } from 'power-assert';
 
 import {
   comp1,
@@ -20,6 +20,7 @@ import { Formio } from '../../src/formio.form.js';
 import formModalEdit from './fixtures/form/formModalEdit.js';
 import { formComponentWithConditionalRenderingForm } from '../formtest/index.js';
 import * as nestedFormWithDisabledClearOnHide from '../forms/nestedFormWithDisabledClearOnHide.js';
+import * as nestedFormWIthContentComponent from '../forms/nestedFormWithContentComp.js';
 
 describe('Form Component', () => {
   it('Should build a form component', () => {
@@ -633,6 +634,53 @@ describe('Disabled clearOnHide functionality for Nested Form', () => {
     }).catch((err) => done(err));
   });
 });
+
+describe('Test Nested Form value setting', () => {
+  const originalMakeRequest = Formio.makeRequest;
+  before((done) => {
+    Formio.setUser({
+      _id: '123'
+    });
+
+    Formio.makeRequest = (formio, type, url, method, data) => {
+      if (type === 'form' && method === 'get' && (url).includes('/datareadytest')) {
+        const mainForm = fastCloneDeep(nestedFormWIthContentComponent.parentForm);
+        return Promise.resolve(mainForm);
+      };
+
+      if (type === 'form' && method === 'get' && (url).includes('/67c19d4a0b924378e690a993')) {
+        return Promise.resolve(nestedFormWIthContentComponent.childForm);
+      };
+    };
+    done();
+  });
+
+
+  after((done) => {
+    Formio.makeRequest = originalMakeRequest;
+    Formio.setUser();
+    done();
+  });
+
+  it('The nested form submission should be set and correctly displayed once dataReady promise is resolved', (done) => {
+    const formElement = document.createElement('div');
+    Formio.createForm(
+      formElement,
+      'http://localhost:3000/ryyclyrmbzvuqog/datareadytest',
+      { readOnly: true }
+    ).then((instance) => {
+      instance.setSubmission(nestedFormWIthContentComponent.submission).then(function() {
+        instance.dataReady.then(function() {
+            const contentText = instance.element.querySelector('.formio-component-content').textContent;
+            assert.equal(contentText.includes('foo'), true);
+            assert.equal(contentText.includes('hey'), true);
+            done();
+          })
+        })
+      }).catch((err) => done(err));
+    })
+});
+
 
 
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9758

## Description

**What changed?**

When the submission is rendered is PDF format, the formio-viewer sets the submission and after that waits until the dataReady promise is resolved. It appears that the dataReady promise is resolved for nested forms before the data is actually set because the data is considered to be ready when the subFormReady promise is resolved.  Because of it, the pdf file can be generated before all submission data is correctly set and displayed.
This PR makes it so that the nested form data is considered to be ready when the subForm data is ready. This allows to wait until all nested form data is set and only after that the PDF is generated. 

## How has this PR been tested?

Manually + tests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
