### PR TITLE
FIO-9766: Fixing issues with conditionally hidden fields and state being stored…

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -380,8 +380,7 @@ export default class Component extends Element {
      * This is necessary because of clearOnHide behavior that only clears when conditionally hidden - we need to track
      * conditionallyHidden separately from "regular" visibility.
      */
-    this._parentConditionallyHidden = this.options.hasOwnProperty('parentConditionallyHidden') ? this.options.parentConditionallyHidden : false;
-    this._conditionallyHidden = this.checkConditionallyHidden(null, data) || this._parentConditionallyHidden;
+    this.checkConditionallyHidden(null, data);
 
     /**
      * Determines if this component is visible, or not.
@@ -501,6 +500,19 @@ export default class Component extends Element {
     return this.root?.childComponentsMap || {};
   }
 
+  get parentConditionallyHidden() {
+    let parentHidden = false;
+    let currentParent = this.parent;
+    while (currentParent) {
+      parentHidden = parentHidden || currentParent._conditionallyHidden;
+      if (parentHidden) {
+        break;
+      }
+      currentParent = currentParent.parent;
+    }
+    return parentHidden;
+  }
+
   get data() {
     return this._data;
   }
@@ -549,7 +561,7 @@ export default class Component extends Element {
 
   init() {
     this.disabled = this.shouldDisabled;
-    this._conditionallyHidden = this.checkConditionallyHidden();
+    this.checkConditionallyHidden();
     this._visible = (this.hasCondition() ? !this.conditionallyHidden : !this.component.hidden);
     if (this.component.addons?.length) {
       this.component.addons.forEach((addon) => this.createAddon(addon));
@@ -745,7 +757,7 @@ export default class Component extends Element {
   }
 
   get conditionallyHidden() {
-    return this._conditionallyHidden || this._parentConditionallyHidden;
+    return this._conditionallyHidden || this.parentConditionallyHidden;
   }
 
   /**
@@ -755,10 +767,13 @@ export default class Component extends Element {
    * @returns {boolean} - Whether the component is conditionally hidden.
    */
   checkConditionallyHidden(data = null, row = null) {
+    this._conditionallyHidden = false;
     if (!this.hasCondition()) {
-      return false;
+      this._conditionallyHidden = this.parentConditionallyHidden;
+      return this._conditionallyHidden;
     }
-    return !this.conditionallyVisible(data, row);
+    this._conditionallyHidden = !this.conditionallyVisible(data, row) || this.parentConditionallyHidden;
+    return this._conditionallyHidden;
   }
 
   get currentForm() {
@@ -2208,13 +2223,7 @@ export default class Component extends Element {
     }
 
     // Check advanced conditions (and cache the result)
-    const isConditionallyHidden = this.checkConditionallyHidden(data, row) || this._parentConditionallyHidden;
-    let shouldClear = false;
-
-    if (isConditionallyHidden !== this._conditionallyHidden) {
-      this._conditionallyHidden = isConditionallyHidden;
-      shouldClear = true;
-    }
+    const shouldClear = this.checkConditionallyHidden(data, row);
 
     // Check visibility
     const visible = (this.hasCondition() ? !this.conditionallyHidden : !this.component.hidden);
@@ -2856,10 +2865,7 @@ export default class Component extends Element {
    * @returns {*} - The value for this component.
    */
   get dataValue() {
-    if (
-      !this.key ||
-      (this.conditionallyHidden && this.component.clearOnHide && !this.rootPristine)
-    ) {
+    if (!this.key) {
       return this.emptyValue;
     }
     if (!this.hasValue() && this.shouldAddDefaultValue) {
@@ -2877,11 +2883,7 @@ export default class Component extends Element {
    * @param {*} value - The value to set for this component.
    */
   set dataValue(value) {
-    if (
-      !this.allowData ||
-      !this.key ||
-      (this.conditionallyHidden && this.component.clearOnHide && !this.rootPristine)
-    ) {
+    if (!this.allowData || !this.key) {
       return;
     }
     if ((value !== null) && (value !== undefined)) {

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -86,18 +86,16 @@ export default class NestedComponent extends Field {
     const visibilityChanged = this._visible !== value;
     this._visible = value;
     const isVisible = this.visible;
-    const isConditionallyHidden = this.checkConditionallyHidden();
+    this.checkConditionallyHidden();
     const forceShow = this.shouldForceShow();
     const forceHide = this.shouldForceHide();
     this.components.forEach((component) => {
       // Set the parent visibility first since we may have nested components within nested components
       // and they need to be able to determine their visibility based on the parent visibility.
       component.parentVisible = isVisible;
-      component._parentConditionallyHidden = isConditionallyHidden;
       let visible;
       if (component.hasCondition()) {
-        component._conditionallyHidden = component.checkConditionallyHidden() || component._parentConditionallyHidden;
-        visible = !component.conditionallyHidden;
+        visible = !component.checkConditionallyHidden();
       }
       else {
         visible = !component.component.hidden;
@@ -408,7 +406,6 @@ export default class NestedComponent extends Field {
     data = data || this.data;
     options.parent = this;
     options.parentVisible = this.visible;
-    options.parentConditionallyHidden = this.conditionallyHidden;
     options.root = options?.root || this.root || this;
     options.localRoot = this.localRoot;
     options.skipInit = true;

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -1359,9 +1359,6 @@ export default class EditGridComponent extends NestedArrayComponent {
     }
 
     const changed = this.hasChanged(value, this.dataValue);
-    if (this.parent) {
-      this.parent.checkComponentConditions();
-    }
     this.dataValue = value;
     // Refresh editRow data when data changes.
     this.dataValue.forEach((row, rowIndex) => {
@@ -1394,10 +1391,7 @@ export default class EditGridComponent extends NestedArrayComponent {
 
     this.openWhenEmpty();
     this.updateOnChange(flags, changed);
-    this.checkData();
-
     this.changeState(changed, flags);
-
     return changed;
   }
 

--- a/src/components/html/HTML.js
+++ b/src/components/html/HTML.js
@@ -64,8 +64,7 @@ export default class HTMLComponent extends Component {
     super.checkRefreshOn(changed);
     let visible;
     if (this.hasCondition()) {
-      this._conditionallyHidden = this.checkConditionallyHidden();
-      visible = !this.conditionallyHidden;
+      visible = !this.checkConditionallyHidden();
     }
     else {
       visible = !this.component.hidden;

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -165,6 +165,7 @@ export default class TabsComponent extends NestedComponent {
       this.addClass(this.refs[this.tabLinkKey][index], 'active');
       this.addClass(this.refs[this.tabLinkKey][index], 'formio-tab-link-active');
     }
+    this.setValue(this.data);
     this.triggerChange();
   }
 

--- a/test/unit/Form.unit.js
+++ b/test/unit/Form.unit.js
@@ -607,9 +607,9 @@ describe('Disabled clearOnHide functionality for Nested Form', () => {
       instance.submit().then(() => {
         assert.equal(loadSubForm, true);
         assert.equal(submitSubForm, true);
-        assert.deepEqual(subFormSubmission.data, { textField: 'test', textArea: '' });
+        assert.deepEqual(subFormSubmission.data, { textField: 'test' });
         assert.equal(mainFormSubmission.data?.form?._id, 'nestedSubmissionId');
-        assert.deepEqual(mainFormSubmission.data?.form?.data, { textField: 'test', textArea: '' });
+        assert.deepEqual(mainFormSubmission.data?.form?.data, { textField: 'test' });
         done();
       });
     }).catch((err) => done(err));
@@ -627,7 +627,7 @@ describe('Disabled clearOnHide functionality for Nested Form', () => {
         assert.equal(submitSubForm, false);
         assert.deepEqual(!!subFormSubmission, false);
         assert.equal(!!mainFormSubmission.data?.form?._id, false);
-        assert.deepEqual(mainFormSubmission.data?.form?.data, { textField: 'test', textArea: '' });
+        assert.deepEqual(mainFormSubmission.data?.form?.data, { textField: 'test' });
         done();
       });
     }).catch((err) => done(err));


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9766

## Description

The original ticket for this was to investigate why Edit Grid values were getting reset and cleared within the Project settings. After investigation, it became clear that our recent work with clearOnHide was the culprit.  This pull request ensures that the "parentConditionallyHidden" property is evaluated at runtime so that we do not run into problems where the state is stale when the checks are being performed.

There was also a lot of code that seemed to be getting around issues with clearOnHide (for example the getter and setter for "dataValue"). Now that the functionality of clearOnHide has been streamlined, removing these hacks ensure proper functionality of clearOnHide. 

## Breaking Changes / Backwards Compatibility

This change is risky, but I do not believe that it has any reverse compatibility issues.

## Dependencies

None

## How has this PR been tested?

Manual testing within Developer Portal / Automated tests.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
