### PR TITLE
FIO-9815: fixed an issue where nested form inside wizard does not highlight validation errors

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -656,21 +656,17 @@ export default class FormComponent extends Component {
       return Promise.resolve(this.dataValue);
     }
     // we need to load a hidden form (when clearOnHide is disabled) in order to get and submit (if needed) its data
-    const loadHiddenForm = !this.subForm && !this.component.clearOnHide;
-    if((this.isSubFormLazyLoad() || loadHiddenForm) && !this.subFormLoading){
+    const loadHiddenForm = !this.component.clearOnHide;
+    if((this.isSubFormLazyLoad() || loadHiddenForm) && !this.subFormLoading && !this.subForm){
       return this.createSubForm(true, true)
-      .then(this.submitSubForm(false))
-        .then(() => {
-          return this.dataValue;
-        })
+        .then(() => this.submitSubForm(false))
+        .then(() => this.dataValue)
         .then(() => super.beforeSubmit());
 
     }
     else {
       return this.submitSubForm(false)
-      .then(() => {
-        return this.dataValue;
-      })
+      .then(() => this.dataValue)
       .then(() => super.beforeSubmit());
     }
   }

--- a/test/unit/Form.unit.js
+++ b/test/unit/Form.unit.js
@@ -681,6 +681,99 @@ describe('Test Nested Form value setting', () => {
     })
 });
 
+describe('Nested Form validation inside Wizard', () => {
+  const originalMakeRequest = Formio.makeRequest;
+  let postRequestCount = 0;
+  let childFormRequestCount = 0;
 
+  const parentForm = {
+    "_id": "677d3efea934773d422a05fa",
+    "title": "Wizard parent",
+    "name": "fdAsWizardParent",
+    "path": "fdaswizardparent",
+    "type": "form",
+    "display": "wizard",
+    "components": [{
+      "title": "Page 1",
+      "key": "page1",
+      "type": "panel",
+      "components": [{
+        "label": "Form",
+        "key": "form",
+        "type": "form",
+        "form": "677d3efea934773d422a05ec",
+        "lazyLoad": true
+      }]
+    }, ]
+  
+  };
+  
+  const childForm = {
+    "_id": "677d3efea934773d422a05ec",
+    "title": "Wizard Child",
+    "name": "WizardChild",
+    "path": "wizardchild",
+    "type": "form",
+    "components": [{
+        "label": "Text Field",
+        "key": "textField",
+        "type": "textfield",
+        "validate": {
+          "required": true
+        }
+      },
+      {
+        "label": "Submit",
+        "key": "submit",
+        "type": "button"
+      }
+    ]
+  };
 
+  before((done) => {
+    // Mock Formio.makeRequest to count POST requests and serve mock forms
+    Formio.makeRequest = (formio, type, url, method, data) => {
+      if (type === 'form' && method === 'get') {
+        if (url.includes('parentForm')) {
+          return Promise.resolve(_.cloneDeep(parentForm));
+        } else if (url.includes('677d3efea934773d422a05ec')) {
+          ++childFormRequestCount;
+          return Promise.resolve(_.cloneDeep(childForm));
+        }
+        if (type === 'submission' && ['post'].includes(method)) {
+          postRequestCount++;
+        }
+        return Promise.resolve();
+      }
+    };
+    done()
+  });
 
+  after((done) => {
+    // Restore the original makeRequest
+    Formio.makeRequest = originalMakeRequest;
+    done();
+  });
+
+  it('Should show validation errors for nested form components inside wizard', (done) => {
+    const formElement = document.createElement('div');
+    postRequestCount = 0;
+    Formio.createForm(formElement, 'http://localhost:3000/idwqwhclwioyqbw/parentForm')
+      .then((wizard) => {
+        setTimeout(() => {
+          const btn = _.get(wizard.refs, `${wizard.wizardKey}-submit`);
+          const clickEvent = new Event('click');
+          btn.dispatchEvent(clickEvent);
+
+          setTimeout(() => {
+            assert.equal(wizard.errors.length, 1, 'Should trigger validation error');
+            assert.equal(wizard.errors[0].ruleName, 'required');
+            assert.equal(wizard.element.querySelectorAll('.formio-error-wrapper').length, 1, 'Should set error classes for invalid component inside nested form')
+            assert.equal(postRequestCount, 0, 'No submission POST requests should be made');
+            assert.equal(childFormRequestCount, 1);
+            done()
+          }, 300);
+        }, 100)
+      });
+  });
+})


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9815

## Description

**What changed?**

Do not load/recreate subForm in beforeSubmit if it has already been created. beforeSubmit does not call attach method of the subForm, it means that new subForm will not have refs where error classes can be set.
Also this PR refactored a bit then statement with submitSubForm call in order to make sure that it waits submitSubForm promise to be resolved.


## How has this PR been tested?

Manually + tests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
