### PR TITLE
FIO-9838: fix rendering an unknown component on the builder causing error

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1914,6 +1914,10 @@ export default class WebformBuilder extends Component {
   }
 
   hasEditTabs(type) {
+    // If the component type does not exist then it has no edit tabs
+    if(!Components.components[type]){
+      return false;
+    }
     const editTabs = getComponent(Components.components[type === 'custom' ? 'unknown' : type].editForm().components, 'tabs', true).components;
     const hiddenEditTabs = _.filter(_.get(this.options, `editForm.${type}`, []), 'ignore');
     return _.intersectionBy(editTabs, hiddenEditTabs, 'key').length !== editTabs.length;

--- a/test/unit/WebformBuilder.unit.js
+++ b/test/unit/WebformBuilder.unit.js
@@ -364,7 +364,7 @@ describe('WebformBuilder tests', function() {
     }).catch(done);
   });
 
-  it('Should not hilight error for default values', (done) => {
+  it('Should not highlight error for default values', (done) => {
     const builder = Harness.getBuilder();
     builder.setForm({}).then(() => {
       Harness.buildComponent('day');
@@ -379,6 +379,21 @@ describe('WebformBuilder tests', function() {
       }, 200)
     }).catch(done);
   })
+
+  it('should be able to render form with unknown component without crashing', () => {
+    return Formio.builder(document.createElement('div'), {
+      components: [
+        {
+          type: 'abc123'
+        }
+      ]
+    })
+  });
+
+  it('should return false if hasEditTabs is passed a type that does not exist', () => {
+    const webformBuilder = new WebformBuilder({});
+    assert.equal(webformBuilder.hasEditTabs('abc123'), false);
+  });
 });
 
 describe('Select Component selectData property', () => {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9838

## Description

**What changed?**

*Use this section to provide a summary description of the changes you've made*

hasEditTabs will return false if the component type does not exist

*Use this section to justify your choices*

hasEditTabs should stop checking if a component has editTabs if the component does not exist

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

Manually and automated tests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
