### PR TITLE
Fixing issues with the data map and unnecessary reset model functions.

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -832,7 +832,10 @@ export default class Wizard extends Webform {
   validateCurrentPage(flags = {}) {
     const components = this.currentPage?.components.map((component) => component.component);
     // Accessing the parent ensures the right instance (whether it's the parent Wizard or a nested Wizard) performs its validation
-    return this.currentPage?.parent.validateComponents(components, this.root.data, flags);
+    if (this.currentPage?.parent) {
+      return this.currentPage?.parent.validateComponents(components, this.root.data, flags);
+    }
+    return this.currentPage?.validateComponents(components, this.root ? this.root.data : this.data, flags);
   }
 
   emitPrevPage() {

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -398,6 +398,14 @@ export default class Component extends Element {
     }
 
     /**
+     * Same as customDefaultValue, but for calculateValue.
+     */
+    this.shouldSetCalculatedValue = true;
+    if (this.component.calculateValue && (typeof this.component.calculateValue === 'string')) {
+      this.shouldSetCalculatedValue = this.component.calculateValue.match(/value\s*=/);
+    }
+
+    /**
      * Used to trigger a new change in this component.
      * @type {Function} - Call to trigger a change in this component.
      */
@@ -3210,7 +3218,7 @@ export default class Component extends Element {
   }
 
   doValueCalculation(dataValue, data, row) {
-      return this.evaluate(this.component.calculateValue, {
+      const calculatedValue = this.evaluate(this.component.calculateValue, {
         value: dataValue,
         data,
         row: row || this.data,
@@ -3218,6 +3226,10 @@ export default class Component extends Element {
           data: this.rootValue
         }
       }, 'value');
+      if (this.shouldSetCalculatedValue) {
+        return calculatedValue;
+      }
+      return dataValue;
   }
 
   /* eslint-disable max-statements */

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2223,7 +2223,7 @@ export default class Component extends Element {
       this.visible = visible;
     }
 
-    this.clearOnHide();
+    this.clearComponentOnHide();
     return visible;
   }
 
@@ -2547,9 +2547,9 @@ export default class Component extends Element {
   }
 
   /**
-   * Clears the components data if it is conditionally hidden AND clearOnHide is set to true for this component.
+   * Clear any conditionally hidden components for this component only.
    */
-  clearOnHide() {
+  clearComponentOnHide() {
     // clearOnHide defaults to true for old forms (without the value set) so only trigger if the value is false.
     if (this.component.clearOnHide !== false && !this.options.readOnly && !this.options.showHiddenFields) {
       if (this.conditionallyHidden()) {
@@ -2562,6 +2562,13 @@ export default class Component extends Element {
         });
       }
     }
+  }
+
+  /**
+   * Clears the components data if it is conditionally hidden AND clearOnHide is set to true for this component.
+   */
+  clearOnHide() {
+    this.clearComponentOnHide();
   }
 
   /**

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -693,19 +693,7 @@ export default class NestedComponent extends Field {
 
   clearOnHide(show) {
     super.clearOnHide(show);
-    if (this.component.clearOnHide) {
-      if (this.allowData && !this.hasValue() && !this.conditionallyHidden()) {
-        this.dataValue = this.defaultValue;
-      }
-      if (this.hasValue()) {
-        this.restoreComponentsContext();
-      }
-    }
     this.getComponents().forEach(component => component.clearOnHide(show));
-  }
-
-  restoreComponentsContext() {
-    this.getComponents().forEach((component) => component.data = this.dataValue);
   }
 
   /**

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -724,10 +724,6 @@ export default class DataGridComponent extends NestedArrayComponent {
     return changed;
   }
 
-  restoreComponentsContext() {
-    this.rows.forEach((row, index) => _.forIn(row, (component) => component.data = this.dataValue[index]));
-  }
-
   toggleGroup(element, index) {
     element.classList.toggle('collapsed');
     _.each(this.refs.chunks[index], row => {

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -648,14 +648,6 @@ export default class EditGridComponent extends NestedArrayComponent {
     });
   }
 
-  restoreComponentsContext() {
-    this.getComponents().forEach((component) => {
-      const rowData = this.dataValue[component.rowIndex];
-      const editRowData = this.editRows[component.rowIndex]?.data;
-      component.data = rowData || editRowData;
-    });
-  }
-
   flattenComponents(rowIndex) {
     const result = {};
 

--- a/src/components/select/editForm/Select.edit.data.js
+++ b/src/components/select/editForm/Select.edit.data.js
@@ -206,7 +206,7 @@ export default [
     label: 'Value Property',
     key: 'valueProperty',
     skipMerge: true,
-    clearOnHide: true,
+    clearOnHide: false,
     tooltip: 'The field to use as the value.',
     weight: 11,
     refreshOn: 'data.resource',

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1690,27 +1690,6 @@ export function getDataParentComponent(componentInstance) {
  }
 
 /**
- * Determines if the component has a scoping parent in tree (a component which scopes its children and manages its
- * changes by itself, e.g. EditGrid)
- * @param {Component} componentInstance - The component to check for the scoping parent.
- * @param {boolean} firstPass - Whether it is the first pass of the function
- * @returns {boolean|*} - TRUE if the component has a scoping parent; FALSE otherwise
- */
-export function isInsideScopingComponent(componentInstance, firstPass = true) {
-  if (!firstPass && componentInstance?.hasScopedChildren) {
-    return true;
-  }
-  const dataParent = getDataParentComponent(componentInstance);
-  if (dataParent?.hasScopedChildren) {
-    return true;
-  }
-  else if (dataParent?.parent) {
-    return isInsideScopingComponent(dataParent.parent, false);
-  }
-  return false;
-}
-
-/**
  * Returns all the focusable elements within the provided dom element.
  * @param {HTMLElement} element - The element to get the focusable elements from.
  * @returns {NodeList<HTMLElement>} - The focusable elements within the provided element.

--- a/test/unit/Select.unit.js
+++ b/test/unit/Select.unit.js
@@ -352,8 +352,8 @@ describe('Select Component', () => {
     const value = 'b';
     select.setValue(value);
 
-    // timeout(0) need to complete triggerChange
-    await Promise.all([select.itemsLoaded, timeout(0)]);
+    // timeout(50) need to complete triggerChange
+    await Promise.all([select.itemsLoaded, timeout(50)]);
     assert.equal(select.dataValue, value);
     assert.equal(select.getValue(), value);
 

--- a/test/unit/Wizard.unit.js
+++ b/test/unit/Wizard.unit.js
@@ -563,11 +563,9 @@ describe('Wizard Form with Nested Form validation', () => {
           setTimeout(() => {
             checkPage(2);
             const errors = wizard.errors;
-            assert.equal(errors.length, 2, 'Must err before next page');
-            errors.forEach((error) => {
-              assert.equal(error.ruleName, 'required');
-              assert.equal(error.message, 'Text Field is required', 'Should set correct lebel in the error message');
-            });
+            assert.equal(errors.length, 1, 'Must err before next page');
+            assert.equal(errors[0].ruleName, 'required');
+            assert.equal(errors[0].message, 'Text Field is required');
             done();
           }, 300)
         }, 300)
@@ -2240,12 +2238,12 @@ it('Should show tooltip for wizard pages', function(done) {
                     const pages = form.element.querySelectorAll('.formio-form nav .pagination .page-item');
                     assert.equal(pages.length, 3, 'Should show the hidden initially page');
                     done();
-                  });
-                }, 400);
-              }, 500);
-            }, 400);
-          }, 500);
-        }, 400);
+                  }, 250);
+                }, 250);
+              }, 250);
+            }, 250);
+          }, 250);
+        }, 250);
       }).catch(done);
     });
   });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9856


## Description

This changes multiple issues:

 1.) Performance issues - It was identified that a major performance bottleneck was that clearOnHide was being called within the checkComponentConditions method. The issue is that clearOnHide for NestedComponents iterate through all the children to perform clearOnHide for those children. The problem presents itself within the checkData loop where it is already iterating through all of the children and performing these checks, so adding multiple tree iterations is a major performance drain. This solves the problem by implementing a clearComponentOnHide method which is not implemented by the NestedComponent class, and that method is what is called within the checkComponentConditions method.
 
 2.) Data Map data model issues - With the recent data model fixes and streamlining, it became clear we had an issue with Data Map setting data properly. The issue was because there was some zombie code that was resurrected and executed after the recent data model changes that were made. This method is called "restoreComponentsContext" and was introduced @ https://github.com/formio/formio.js/commit/d75812e5b0583c1bbbc4c324504a3ba718b8e2a0 which attempted to solve an old problem where the data models would become "detached" within EditGrid and DataGrids. This issue was solved a while back and no longer was necessary. The reason this clobbered the Data Map was because of this line of code in DataGrid (DataMap extends DataGrid) https://github.com/formio/formio.js/blob/e7c608aeb25ef2aede01b54ffb85858534b7d36c/src/components/datagrid/DataGrid.js#L728.  This code is not compatible with DataMaps.

 3.) valuePropery on Select edit forms was getting reset:  The "valueProperty" is implemented in two different places based on the data source type. One of them "clearOnHide" is set to false, but the other one is true. Due to the streamlined data model fixes, what was happening is that the other valueProperty configuration would be hidden and the data would be reset because it is hidden. The fact that we fixed the bug, exposed this bug.  We can solve this by just making valueProperty not clear when hidden.

 4.) Another issue presented itself with the customDefaultValue and calculatedValues.  There are cases when the these functions are implemented not to set a value, but rather just execute a script. There is now a check to see if the script sets the value using a regex that looks for "value=".  If that is provided then we know we need to set the value to what is returned.

## Breaking Changes / Backwards Compatibility

None that we are aware of. All existing tests pass.

## Dependencies

None

## How has this PR been tested?

This change affects most components that already have many automated tests written to test for the capabilities of the things that were changed in this PR.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
