### PR TITLE
FIO-9837: cant approve valid api key

### DIFF
--- a/src/components/address/Address.js
+++ b/src/components/address/Address.js
@@ -25,7 +25,6 @@ export default class AddressComponent extends ContainerComponent {
       key: 'address',
       switchToManualModeLabel: 'Can\'t find address? Switch to manual mode.',
       provider: '',
-      providerOptions: {},
       manualModeViewString: '',
       hideLabel: false,
       disableClearIcon: false,
@@ -128,23 +127,12 @@ export default class AddressComponent extends ContainerComponent {
     }
     Field.prototype.init.call(this);
 
-    // Created to maintain reverse compatibility
-    this.component.providerOptions = {
-      params: {subscriptionKey: this.component.subscriptionKey, key: this.component.apiKey, ...this.component.params},
-      url: this.component.url,
-      queryProperty: this.component.queryProperty,
-      responseProperty: this.component.responseProperty,
-      displayValueProperty: this.component.displayValueProperty,
-      autocompleteOptions: this.component.autocompleteOptions
-    }
+    const provider = this.component.provider;
+    const providerOptions = this.providerOptions;
+    const map = this.component.map;
 
     if (!this.builderMode) {
-      if (this.component.provider) {
-        const {
-          provider,
-          providerOptions,
-        } = this.component;
-
+      if (provider) {
         if (_.get(providerOptions, 'params.subscriptionKey')) {
           _.set(providerOptions, "params['subscription-key']", _.get(providerOptions, 'params.subscriptionKey'));
           _.unset(providerOptions, 'params.subscriptionKey');
@@ -152,16 +140,9 @@ export default class AddressComponent extends ContainerComponent {
 
         this.provider = this.initializeProvider(provider, providerOptions);
       }
-      else if (this.component.map) {
+      else if (map) {
         // Fallback to legacy version where Google Maps was the only provider.
         this.component.provider = GoogleAddressProvider.name;
-        this.component.providerOptions = this.component.providerOptions || {};
-
-        const {
-          map,
-          provider,
-          providerOptions,
-        } = this.component;
 
         const {
           key,
@@ -330,6 +311,17 @@ export default class AddressComponent extends ContainerComponent {
       : null;
   }
 
+  get providerOptions() {
+    return {
+      params: {subscriptionKey: this.component.subscriptionKey, key: this.component.apiKey, ...this.component.params},
+      url: this.component.url,
+      queryProperty: this.component.queryProperty,
+      responseProperty: this.component.responseProperty,
+      displayValueProperty: this.component.displayValueProperty,
+      autocompleteOptions: this.component.autocompleteOptions
+    }
+  }
+
   get removeValueIcon() {
     return this.refs
       ? (this.refs[AddressComponent.removeValueIconRef] || null)
@@ -468,10 +460,8 @@ export default class AddressComponent extends ContainerComponent {
 
     if (!this.builderMode) {
       if (!this.provider && this.component.provider) {
-        const {
-          provider,
-          providerOptions,
-        } = this.component;
+        const provider = this.component.provider;
+        const providerOptions = this.providerOptions;
         this.provider = this.initializeProvider(provider, providerOptions);
       }
     }

--- a/src/components/address/Address.js
+++ b/src/components/address/Address.js
@@ -127,7 +127,7 @@ export default class AddressComponent extends ContainerComponent {
     }
     Field.prototype.init.call(this);
 
-    const provider = this.component.provider;
+    let provider = this.component.provider;
     const providerOptions = this.providerOptions;
     const map = this.component.map;
 
@@ -142,7 +142,7 @@ export default class AddressComponent extends ContainerComponent {
       }
       else if (map) {
         // Fallback to legacy version where Google Maps was the only provider.
-        this.component.provider = GoogleAddressProvider.name;
+        provider = this.component.provider = GoogleAddressProvider.name;
 
         const {
           key,

--- a/src/components/address/Address.js
+++ b/src/components/address/Address.js
@@ -128,6 +128,16 @@ export default class AddressComponent extends ContainerComponent {
     }
     Field.prototype.init.call(this);
 
+    // Created to maintain reverse compatibility
+    this.component.providerOptions = {
+      params: {subscriptionKey: this.component.subscriptionKey, key: this.component.apiKey, ...this.component.params},
+      url: this.component.url,
+      queryProperty: this.component.queryProperty,
+      responseProperty: this.component.responseProperty,
+      displayValueProperty: this.component.displayValueProperty,
+      autocompleteOptions: this.component.autocompleteOptions
+    }
+
     if (!this.builderMode) {
       if (this.component.provider) {
         const {

--- a/src/components/address/editForm/Address.edit.provider.js
+++ b/src/components/address/editForm/Address.edit.provider.js
@@ -28,7 +28,7 @@ export default [
   {
     type: 'textfield',
     input: true,
-    key: "providerOptions.params.subscriptionKey",
+    key: "subscriptionKey",
     label: 'Subscription Key',
     placeholder: 'Enter Subscription Key',
     weight: 10,
@@ -43,7 +43,7 @@ export default [
   {
     type: 'textfield',
     input: true,
-    key: 'providerOptions.url',
+    key: 'url',
     label: 'Url',
     placeholder: 'Enter Url',
     weight: 10,
@@ -58,7 +58,7 @@ export default [
   {
     type: 'textfield',
     input: true,
-    key: 'providerOptions.queryProperty',
+    key: 'queryProperty',
     label: 'Query Property',
     defaultValue: 'query',
     placeholder: 'Enter Query Property',
@@ -71,7 +71,7 @@ export default [
   {
     type: 'textfield',
     input: true,
-    key: 'providerOptions.responseProperty',
+    key: 'responseProperty',
     label: 'Response Property',
     placeholder: 'Enter Response Property',
     weight: 30,
@@ -83,7 +83,7 @@ export default [
   {
     type: 'textfield',
     input: true,
-    key: 'providerOptions.displayValueProperty',
+    key: 'displayValueProperty',
     label: 'Display Value Property',
     placeholder: 'Display Value Property',
     weight: 40,
@@ -95,7 +95,7 @@ export default [
   {
     type: 'textarea',
     input: true,
-    key: 'providerOptions.params',
+    key: 'params',
     label: 'Params',
     placeholder: '{ ... }',
     weight: 50,
@@ -110,7 +110,7 @@ export default [
   {
     type: 'textfield',
     input: true,
-    key: 'providerOptions.params.key',
+    key: 'apiKey',
     label: 'API Key',
     placeholder: 'Enter API Key',
     weight: 10,
@@ -125,7 +125,7 @@ export default [
   {
     type: 'textarea',
     input: true,
-    key: 'providerOptions.params.autocompleteOptions',
+    key: 'autocompleteOptions',
     label: 'Provider options',
     placeholder: 'Enter provider options as JSON object',
     defaultValue:{},


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9837

## Description

**What changed?**

Removed nested keys via the providerOptions and providerOptions.params
Cleanup code to make sure that this change does not break other areas of code

**Why have you chosen this solution?**

providerOptions.params is conditionally hidden. Because providerOptions.params.key is displayed and providerOptions.params is conditionally hidden whenever you try to input into providerOptions.params.key it will immediately clear itself. To be honest I think this method of creating nested keys using dot (.) is wrong. If you want a component to be namespaced or have some kind of object like pathing then put it in a container component.

## Breaking Changes / Backwards Compatibility

You will no longer be searching through component.providerOptions.[key] to find information about the provider for the address. This is now flattened

## Dependencies

N/A

## How has this PR been tested?

Manually tested

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
