### PR TITLE
FIO-9855 removed deprecated settings

### DIFF
--- a/src/components/select/editForm/Select.edit.data.js
+++ b/src/components/select/editForm/Select.edit.data.js
@@ -61,42 +61,6 @@ export default [
     },
   },
   {
-    type: 'textfield',
-    weight: 10,
-    input: true,
-    key: 'indexeddb.database',
-    label: 'Database name',
-    tooltip: 'The name of the indexeddb database.',
-    conditional: {
-      json: { '===': [{ var: 'data.dataSrc' }, 'indexeddb'] },
-    },
-  },
-  {
-    type: 'textfield',
-    input: true,
-    key: 'indexeddb.table',
-    label: 'Table name',
-    weight: 16,
-    tooltip: 'The name of table in the indexeddb database.',
-    conditional: {
-      json: { '===': [{ var: 'data.dataSrc' }, 'indexeddb'] },
-    }
-  },
-  {
-    type: 'textarea',
-    as: 'json',
-    editor: 'ace',
-    weight: 18,
-    input: true,
-    key: 'indexeddb.filter',
-    label: 'Row Filter',
-    tooltip: 'Filter table items that match the object.',
-    defaultValue: {},
-    conditional: {
-      json: { '===': [{ var: 'data.dataSrc' }, 'indexeddb'] },
-    },
-  },
-  {
     type: 'textarea',
     as: 'json',
     editor: 'ace',


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9855

## Description

*Since the `indexeddb` option was deleted according to [FIO-4103](https://formio.atlassian.net/browse/FIO-4103),the corresponding properties for `dataSrc ===' indexeddb'` condition were deleted from Data tab of Modal Edit window for Select Component. At the same time, all the functionality for  `dataSrc ===' indexeddb'` was remained unchanged.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*locally. All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above


[FIO-4103]: https://formio.atlassian.net/browse/FIO-4103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ