### PR TITLE
FIO-9889: added backwards compatibility checks for provider options

### DIFF
--- a/src/components/address/Address.js
+++ b/src/components/address/Address.js
@@ -127,6 +127,20 @@ export default class AddressComponent extends ContainerComponent {
     }
     Field.prototype.init.call(this);
 
+    // Added for backwards compatibility
+    if (this.component.providerOptions) {
+      const {params, url, queryProperty, responseProperty, displayValueProperty } = this.component.providerOptions;
+      const {key, autocompleteOptions} = params;
+
+      delete this.component.providerOptions
+      this.component.url = url;
+      this.component.queryProperty = queryProperty;
+      this.component.responseProperty = responseProperty;
+      this.component.displayValueProperty = displayValueProperty;
+      this.component.apiKey = key;
+      this.component.autocompleteOptions = autocompleteOptions;
+    }
+
     let provider = this.component.provider;
     const providerOptions = this.providerOptions;
     const map = this.component.map;

--- a/src/components/address/Address.js
+++ b/src/components/address/Address.js
@@ -130,7 +130,8 @@ export default class AddressComponent extends ContainerComponent {
     // Added for backwards compatibility
     if (this.component.providerOptions) {
       const {params, url, queryProperty, responseProperty, displayValueProperty } = this.component.providerOptions;
-      const {key, autocompleteOptions} = params;
+      const key = params?.key;
+      const autocompleteOptions = params?.autocompleteOptions;
 
       delete this.component.providerOptions
       this.component.url = url;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9889

## Description

**What changed?**

Added a backwards compatibility check that will populate the appropriate JSON properties for the address component. 

**Why have you chosen this solution?**

If someone's address JSON is using the legacy providerOptions object this will take the properties of that object and assign them to the new JSON properties. e.g. this.component.providerOptions.params.key would be assigned to this.component.apiKey

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

Manually tested

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
