### PR TITLE
FIO-9888: Fixed issue where the noDefaults flag would skip defaults even for calculations.

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2923,14 +2923,15 @@ export default class Component extends Element {
 
   get shouldAddDefaultValue() {
     // It should add a default value if...
-    //  1.) Ensure they have not set "noDefaults". If that is true, then will always return false.  AND
-    //  2.) The component is pristine (user has not manually modified it).  AND
-    //  3.) There is a default value setting present and it is not NULL or UNDEFINED.
-    return !this.options.noDefaults && this.pristine && (
+    //  1.) The component is pristine (user has not manually modified it).  AND
+    //      1.) There is a default value setting present OR
+    //      2.) The noDefaults flag is not true AND the empty value is either an empty string or boolean
+    return this.pristine && (
       this.hasDefaultValue || 
-      // Empty strings and booleans are allowed primitives whose defaults are automatically added.
-      (this.emptyValue === '' || (typeof this.emptyValue === 'boolean'))
-    );
+      (
+        !this.options.noDefaults && (this.emptyValue === '' || (typeof this.emptyValue === 'boolean')
+      )
+    ));
   }
 
   get defaultValue() {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9888

## Description

Previously, we had a "noDefaults" flag, whose purpose is to not establish the default values for all components within a form when the form is initialized. The reason for this flag is to ensure that we "minify" the submission data when the form is established. This flag, however, should not skip over any calculated default values as well as any explicitly defined default values provided within the component settings. This change ensures that the defaults are still established if the calculated defaults are provided and the noDefaults flag is set in the form options.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

The project settings form in the Developer Portal uses the "noDefaults" flag, but there are many calculated default values (such as API Keys) which need to still function with the noDefaults flag.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
