### PR TITLE
FIO-9913: Fixed problems where conditionally hidden fields would reset when their parents are hidden but have clearOnHide set to false.

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -765,32 +765,18 @@ export default class Component extends Element {
   }
 
   shouldConditionallyClear(skipParent = false) {
+    // Skip if this component has clearOnHide set to false.
     if (this.component.clearOnHide === false) {
       return false;
     }
+
     // If the component is logically hidden, then it is conditionally hidden and should clear.
     if (this.logicallyHidden) {
       return true;
     }
 
-    // If this component does not have a condition.
-    if (!this.hasCondition()) {
-      if (skipParent) {
-        // Stop recurrsion for the parent checks.
-        return false;
-      }
-
-      // If we are conditionally hidden, then clear.
-      if (this.conditionallyHidden()) {
-        return true;
-      }
-
-      // Try the parent to see if it should conditionally clear.
-      return this.parentShouldConditionallyClear();
-    }
-
-    // If we are not conditionally visible, then we should conditionally clear.
-    if (!this.conditionallyVisible()) {
+    // If we have a condition and it is not conditionally visible, the it should conditionally clear.
+    if (this.hasCondition() && !this.conditionallyVisible()) {
       return true;
     }
 
@@ -799,23 +785,24 @@ export default class Component extends Element {
       return false;
     }
 
-    // Check the parent to see if it should conditionally clear.
-    return this.parentShouldConditionallyClear();
+    // If this component has a set value, then it should ONLY clear if a parent is hidden
+    // and has the clearOnHide set to true.
+    if (this.hasSetValue) {
+      return this.parentShouldConditionallyClear();
+    }
+
+    // Clear the value if the parent is conditionally hidden.
+    return this.parentConditionallyHidden();
   }
 
   conditionallyHidden(skipParent = false) {
     if (this.logicallyHidden) {
       return true;
     }
-    if (!this.hasCondition()) {
-      if (skipParent) {
-        // Stop recurrsion for the parent checks.
-        return false;
-      }
-      // Try the parent.
+    if (!this.hasCondition() && !skipParent) {
       return this.parentConditionallyHidden();
     }
-    // If we are not conditionally visible, then we should conditionally clear.
+    // Return if we are not conditionally visible (conditionallyHidden)
     if (!this.conditionallyVisible()) {
       return true;
     }

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -455,7 +455,7 @@ export default class Component extends Element {
       if (this.allowData && this.key) {
         this.options.name += `[${this.key}]`;
         // If component is visible or not set to clear on hide, set the default value.
-        if (!(this.conditionallyHidden() && this.component.clearOnHide)) {
+        if (!this.shouldConditionallyClear()) {
           if (!this.hasValue()) {
             if (this.shouldAddDefaultValue) {
               this.dataValue = this.defaultValue;
@@ -491,6 +491,17 @@ export default class Component extends Element {
 
   get componentsMap() {
     return this.root?.childComponentsMap || {};
+  }
+
+  parentShouldConditionallyClear() {
+    let currentParent = this.parent;
+    while (currentParent) {
+      if (currentParent.shouldConditionallyClear(true)) {
+        return true;
+      }
+      currentParent = currentParent.parent;
+    }
+    return false;
   }
 
   parentConditionallyHidden() {
@@ -753,11 +764,67 @@ export default class Component extends Element {
     return this._logicallyHidden;
   }
 
-  conditionallyHidden(skipParent = false) {
-    if (!this.hasCondition()) {
-      return this.logicallyHidden || (skipParent ? false : this.parentConditionallyHidden());
+  shouldConditionallyClear(skipParent = false) {
+    if (this.component.clearOnHide === false) {
+      return false;
     }
-    return !this.conditionallyVisible() || this.logicallyHidden || (skipParent ? false : this.parentConditionallyHidden());
+    // If the component is logically hidden, then it is conditionally hidden and should clear.
+    if (this.logicallyHidden) {
+      return true;
+    }
+
+    // If this component does not have a condition.
+    if (!this.hasCondition()) {
+      if (skipParent) {
+        // Stop recurrsion for the parent checks.
+        return false;
+      }
+
+      // If we are conditionally hidden, then clear.
+      if (this.conditionallyHidden()) {
+        return true;
+      }
+
+      // Try the parent to see if it should conditionally clear.
+      return this.parentShouldConditionallyClear();
+    }
+
+    // If we are not conditionally visible, then we should conditionally clear.
+    if (!this.conditionallyVisible()) {
+      return true;
+    }
+
+    if (skipParent) {
+      // Stop recurrsion for the parent checks.
+      return false;
+    }
+
+    // Check the parent to see if it should conditionally clear.
+    return this.parentShouldConditionallyClear();
+  }
+
+  conditionallyHidden(skipParent = false) {
+    if (this.logicallyHidden) {
+      return true;
+    }
+    if (!this.hasCondition()) {
+      if (skipParent) {
+        // Stop recurrsion for the parent checks.
+        return false;
+      }
+      // Try the parent.
+      return this.parentConditionallyHidden();
+    }
+    // If we are not conditionally visible, then we should conditionally clear.
+    if (!this.conditionallyVisible()) {
+      return true;
+    }
+    if (skipParent) {
+      // Stop recurrsion for the parent checks.
+      return false;
+    }
+    // Check the parent.
+    return this.parentConditionallyHidden();
   }
 
   get currentForm() {
@@ -2374,7 +2441,7 @@ export default class Component extends Element {
             }
           );
 
-          if (!_.isEqual(oldValue, newValue) && !(this.component.clearOnHide && this.conditionallyHidden())) {
+          if (!_.isEqual(oldValue, newValue) && !this.shouldConditionallyClear()) {
             this.setValue(newValue);
 
             if (this.viewOnly) {
@@ -2419,7 +2486,7 @@ export default class Component extends Element {
           },
           'value');
 
-          if (!_.isEqual(oldValue, newValue) && !(this.component.clearOnHide && this.conditionallyHidden())) {
+          if (!_.isEqual(oldValue, newValue) && !this.shouldConditionallyClear()) {
             this.setValue(newValue);
 
             if (this.viewOnly) {
@@ -2542,7 +2609,7 @@ export default class Component extends Element {
   clearComponentOnHide() {
     // clearOnHide defaults to true for old forms (without the value set) so only trigger if the value is false.
     if (this.component.clearOnHide !== false && !this.options.readOnly && !this.options.showHiddenFields) {
-      if (this.conditionallyHidden()) {
+      if (this.shouldConditionallyClear()) {
         this.deleteValue();
       }
       else if (!this.hasValue() && this.shouldAddDefaultValue) {
@@ -2921,19 +2988,18 @@ export default class Component extends Element {
     );
   }
 
+  /**
+   * Determine if we should add a default value for this component.
+   * @returns {boolean} - TRUE if a default value should be set
+   */
   get shouldAddDefaultValue() {
-    // It should add a default value if...
-    //  1.) The component is pristine (user has not manually modified it).  AND
-    //      1.) There is a default value setting present OR
-    //      2.) The noDefaults flag is not true AND the empty value is either an empty string or boolean
-    return this.pristine && (
-      this.hasDefaultValue || 
-      (
-        !this.options.noDefaults && (this.emptyValue === '' || (typeof this.emptyValue === 'boolean')
-      )
-    ));
+    return this.pristine && this.allowData && (this.hasDefaultValue || !this.options.noDefaults);
   }
 
+  /**
+   * Get the default value of this component.
+   * @returns {*} - The default value for this component.
+   */
   get defaultValue() {
     let defaultValue = this.emptyValue;
     if (this.component.defaultValue) {
@@ -3236,11 +3302,9 @@ export default class Component extends Element {
     }
     // If no calculated value or
     // hidden and set to clearOnHide (Don't calculate a value for a hidden field set to clear when hidden)
-    const { clearOnHide } = this.component;
-    const shouldBeCleared = this.conditionallyHidden() && clearOnHide;
     const allowOverride = _.get(this.component, 'allowCalculateOverride', false);
 
-    if (shouldBeCleared) {
+    if (this.shouldConditionallyClear()) {
       // remove calculated value so that the value is recalculated once component becomes visible
       if (this.hasOwnProperty('calculatedValue') && allowOverride) {
         _.unset(this, 'calculatedValue');

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -584,7 +584,7 @@ export default class FormComponent extends Component {
    * @returns {*|boolean} - TRUE if the subform should be submitted, FALSE if it should not.
    */
   get shouldSubmit() {
-    return this.subFormReady && (!this.component.hasOwnProperty('reference') || this.component.reference) && (!this.conditionallyHidden() || !this.component.clearOnHide);
+    return this.subFormReady && (!this.component.hasOwnProperty('reference') || this.component.reference) && !this.shouldConditionallyClear();
   }
 
   /**


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9913
https://formio.atlassian.net/browse/FIO-9912

## Description

With the recent changes, all of the behavior for clearOnHide was correct except the case where your value is set to "clearOnHide", but your parent has the clearOnHide set to false. This was causing some erroneous clearing of values deeply nested within nested data components (datagrid, editgrid, etc).

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Manual

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
