### PR TITLE
FIO-9912: Fixed issue where the default value of the address component would clear and not reset.

### DIFF
--- a/src/components/address/editForm/Address.edit.display.js
+++ b/src/components/address/editForm/Address.edit.display.js
@@ -13,6 +13,7 @@ export default [
     type: 'textfield',
     input: true,
     key: 'switchToManualModeLabel',
+    defaultValue: 'Can\'t find address? Switch to manual mode.',
     label: 'Switch To Manual Mode Label',
     placeholder: 'Switch To Manual Mode Label',
     tooltip: 'The label for the checkbox used to switch to manual mode.',


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9912

## Description

So, now that we have fixed the default value and the clear on hide functionality, this was a case where it was relying on a bug to work, and now that we fixed the bugs, the clear on hide is doing what it was supposed to do and reset the value of the "Switch to Manual Mode" text field.  

This field has "clearOnHide" set to "true", and when the checkbox is checked to enter manually, it hides the field clearing the value (as it should). This simply adds the default value to the field so that if you check the checkbox again, it sets the default of the field to what the value should be.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Manual

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
