### PR TITLE
FIO-9851 fixed appearing configurable component options

### DIFF
--- a/src/components/_classes/component/editForm/utils.js
+++ b/src/components/_classes/component/editForm/utils.js
@@ -6,7 +6,7 @@ const EditFormUtils = {
   },
   unifyComponents(objValue, srcValue) {
     if (objValue.key && srcValue.key) {
-      if (objValue.skipMerge || srcValue.skipMerge) {
+      if ((objValue.skipMerge || srcValue.skipMerge) && !objValue.ignore) {
         return false;
       }
       if (objValue.key === srcValue.key) {

--- a/src/components/_classes/component/editForm/utils.spec.js
+++ b/src/components/_classes/component/editForm/utils.spec.js
@@ -33,6 +33,20 @@ describe('Edit Form Utils', function() {
       ]);
     });
 
+    it('should merge objects with "ignore" flag', () => {
+      const components = [
+        { key: 'a', label: 1, skipMerge: true },
+        { key: 'a', label: 2, ignore: true },
+        { key: 'b', one: 1, two: 2 },
+        { key: 'b', one: 1, ok: true }
+      ];
+
+      expect(_.unionWith(components, utils.unifyComponents)).to.deep.equal([
+        { key: 'a', label: 1, skipMerge: true, ignore: true },
+        { key: 'b', one: 1, two: 2, ok: true }
+      ]);
+    });
+
     it('should override with "override" flag', () => {
       const components = [
         { key: 'a', label: 1, ok: true },


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9851
https://formio.atlassian.net/browse/FIO-9856

## Description

*Previously, some component configuration fields in the modal Edit Form window could not be hidden when set in the Form Builder options `ignore: true` flag. This was fixed and now options can be hidden if necessary by setting the ignored flag to true.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

**

## How has this PR been tested?

*Automated test was added/ all tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
