### PR TITLE
FIO-9510: Fixed the issue with multiple survey components

### DIFF
--- a/src/components/survey/Survey.js
+++ b/src/components/survey/Survey.js
@@ -142,7 +142,7 @@ export default class SurveyComponent extends Field {
   }
 
   getInputName(question) {
-    return `${this.options.name}[${question.value}]`;
+    return `${this.options.name}[${question.value}][${this.id}]`;
   }
 
   getValueAsString(value, options) {

--- a/test/renders/form-bootstrap-advanced.html
+++ b/test/renders/form-bootstrap-advanced.html
@@ -180,10 +180,10 @@
               A
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][a]" value="1" id="survey-a-1" ref="input">
+              <input type="radio" name="data[survey][a][survey]" value="1" id="survey-a-1" ref="input">
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][a]" value="2" id="survey-a-2" ref="input">
+              <input type="radio" name="data[survey][a][survey]" value="2" id="survey-a-2" ref="input">
             </td>
           </tr>
           <tr>
@@ -191,10 +191,10 @@
               B
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][b]" value="1" id="survey-b-1" ref="input">
+              <input type="radio" name="data[survey][b][survey]" value="1" id="survey-b-1" ref="input">
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][b]" value="2" id="survey-b-2" ref="input">
+              <input type="radio" name="data[survey][b][survey]" value="2" id="survey-b-2" ref="input">
             </td>
           </tr>
         </tbody>

--- a/test/renders/form-bootstrap-defaults.html
+++ b/test/renders/form-bootstrap-defaults.html
@@ -253,10 +253,10 @@
               One
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][one]" value="a" id="survey-one-a" ref="input">
+              <input type="radio" name="data[survey][one][survey]" value="a" id="survey-one-a" ref="input">
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][one]" value="b" id="survey-one-b" ref="input">
+              <input type="radio" name="data[survey][one][survey]" value="b" id="survey-one-b" ref="input">
             </td>
           </tr>
           <tr>
@@ -264,10 +264,10 @@
               Two
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][two]" value="a" id="survey-two-a" ref="input">
+              <input type="radio" name="data[survey][two][survey]" value="a" id="survey-two-a" ref="input">
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][two]" value="b" id="survey-two-b" ref="input">
+              <input type="radio" name="data[survey][two][survey]" value="b" id="survey-two-b" ref="input">
             </td>
           </tr>
         </tbody>

--- a/test/renders/form-bootstrap-readOnly-advanced.html
+++ b/test/renders/form-bootstrap-readOnly-advanced.html
@@ -180,10 +180,10 @@
               A
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][a]" value="1" id="survey-a-1" ref="input">
+              <input type="radio" name="data[survey][a][survey]" value="1" id="survey-a-1" ref="input">
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][a]" value="2" id="survey-a-2" ref="input">
+              <input type="radio" name="data[survey][a][survey]" value="2" id="survey-a-2" ref="input">
             </td>
           </tr>
           <tr>
@@ -191,10 +191,10 @@
               B
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][b]" value="1" id="survey-b-1" ref="input">
+              <input type="radio" name="data[survey][b][survey]" value="1" id="survey-b-1" ref="input">
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][b]" value="2" id="survey-b-2" ref="input">
+              <input type="radio" name="data[survey][b][survey]" value="2" id="survey-b-2" ref="input">
             </td>
           </tr>
         </tbody>

--- a/test/renders/form-bootstrap-readOnly-defaults.html
+++ b/test/renders/form-bootstrap-readOnly-defaults.html
@@ -257,10 +257,10 @@
               One
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][one]" value="a" id="survey-one-a" ref="input">
+              <input type="radio" name="data[survey][one][survey]" value="a" id="survey-one-a" ref="input">
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][one]" value="b" id="survey-one-b" ref="input">
+              <input type="radio" name="data[survey][one][survey]" value="b" id="survey-one-b" ref="input">
             </td>
           </tr>
           <tr>
@@ -268,10 +268,10 @@
               Two
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][two]" value="a" id="survey-two-a" ref="input">
+              <input type="radio" name="data[survey][two][survey]" value="a" id="survey-two-a" ref="input">
             </td>
             <td style="text-align: center;">
-              <input type="radio" name="data[survey][two]" value="b" id="survey-two-b" ref="input">
+              <input type="radio" name="data[survey][two][survey]" value="b" id="survey-two-b" ref="input">
             </td>
           </tr>
         </tbody>

--- a/test/unit/Survey.unit.js
+++ b/test/unit/Survey.unit.js
@@ -1,11 +1,14 @@
 import assert from 'power-assert';
+import _ from 'lodash';
 
 import Harness from '../harness';
 import SurveyComponent from '../../src/components/survey/Survey';
+import { Formio } from '../../src/Formio';
 
 import {
   comp1,
-  comp2
+  comp2,
+  comp3,
 } from './fixtures/survey';
 
 describe('Survey Component', () => {
@@ -15,12 +18,12 @@ describe('Survey Component', () => {
       inputs.forEach((input, index) => {
         if (index < 5) {
           // Service
-          assert.equal(input.name, 'data[surveyQuestions][service]');
+          assert.equal(input.name, `data[surveyQuestions][service][${component.id}]`);
           assert.equal(input.id, `${component.key}-service-${comp1.values[index].value}`);
         }
         else {
           // How do you like our service?
-          assert.equal(input.name, 'data[surveyQuestions][howWouldYouRateTheTechnology]');
+          assert.equal(input.name, `data[surveyQuestions][howWouldYouRateTheTechnology][${component.id}]`);
           assert.equal(input.id, `${component.key}-howWouldYouRateTheTechnology-${comp1.values[index - 5].value}`);
         }
       });
@@ -43,5 +46,23 @@ describe('Survey Component', () => {
         }
       }
     });
+  });
+
+  it('Should set the value for nested surveys.', async () => {
+    const element = document.createElement('div');
+    const form = await Formio.createForm(element, _.cloneDeep(comp3));
+    const survey = form.getComponent(['form', 'survey']);
+    const surveyInput = survey.refs.input[0];
+    surveyInput.checked = true;
+    surveyInput.dispatchEvent(new Event('change'));
+    assert.equal(surveyInput.checked, true);
+    const survey2 = form.getComponent(['form1', 'survey']);
+    const surveyInput2 = survey2.refs.input[0];
+    surveyInput2.checked = true;
+    surveyInput2.dispatchEvent(new Event('change'));
+    assert.equal(surveyInput.checked, true);
+    assert.equal(surveyInput2.checked, true);
+    assert.deepEqual(survey.dataValue, { question: 'yes' });
+    assert.deepEqual(survey2.dataValue, { question: 'yes' });
   });
 });

--- a/test/unit/fixtures/survey/comp3.js
+++ b/test/unit/fixtures/survey/comp3.js
@@ -1,0 +1,85 @@
+export default {
+  type: 'form',
+  components: [
+    {
+      label: 'Form',
+      tableView: true,
+      components: [
+        {
+          label: 'Survey',
+          tableView: false,
+          questions: [
+            {
+              label: 'Question',
+              value: 'question',
+              tooltip: ''
+            }
+          ],
+          values: [
+            {
+              label: 'Yes',
+              value: 'yes',
+              tooltip: ''
+            },
+            {
+              label: 'No',
+              value: 'no',
+              tooltip: ''
+            }
+          ],
+          validateWhenHidden: false,
+          key: 'survey',
+          type: 'survey',
+          input: true
+        }
+      ],
+      key: 'form',
+      type: 'form',
+      input: true
+    },
+    {
+      label: 'Form',
+      tableView: true,
+      components: [
+        {
+          label: 'Survey',
+          tableView: false,
+          questions: [
+            {
+              label: 'Question',
+              value: 'question',
+              tooltip: ''
+            }
+          ],
+          values: [
+            {
+              label: 'Yes',
+              value: 'yes',
+              tooltip: ''
+            },
+            {
+              label: 'No',
+              value: 'no',
+              tooltip: ''
+            }
+          ],
+          validateWhenHidden: false,
+          key: 'survey',
+          type: 'survey',
+          input: true
+        }
+      ],
+      key: 'form1',
+      type: 'form',
+      input: true
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false
+    }
+  ]
+}

--- a/test/unit/fixtures/survey/index.js
+++ b/test/unit/fixtures/survey/index.js
@@ -1,3 +1,4 @@
 import comp1 from './comp1';
 import comp2 from './comp2';
-export { comp1, comp2 };
+import comp3 from './comp3';
+export { comp1, comp2, comp3 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9510

## Description

**Issue**: When creating a wizard form and adding the same nested form with a survey component to every page, exporting the form to a PDF causes the wizard form to transform into a webform with panels instead of pages. As a result, all survey components are rendered in a single HTML structure.

The survey component internally uses a radio input, and the issue arises in the `getInputName` method of the survey component. This method generates the radio input name using the question value and option value. Consequently, all survey components from the nested form end up with the same input name. This causes a conflict where selecting a radio input in one survey component unchecks the radio input in another survey component.

**Solution**: To resolve this issue, we need to add a unique identifier to the input name. This ensures proper encapsulation for each survey component, preventing name collisions and ensuring that the components function independently without overlapping.

## How has this PR been tested?

Unit

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
