### PR TITLE
FIO-9848 Fixed readonly textarea for screen readers

### DIFF
--- a/src/components/textarea/TextArea.js
+++ b/src/components/textarea/TextArea.js
@@ -65,7 +65,15 @@ export default class TextAreaComponent extends TextFieldComponent {
     info.content = value;
     if ((this.options.readOnly || this.disabled) && !this.isHtmlRenderMode()) {
       const elementStyle = this.info.attr.style || '';
-      const children = `<div ${this._referenceAttributeName}="input" class="formio-editor-read-only-content" ${elementStyle ? `style='${elementStyle}'` : ''}></div>`;
+      const children = `
+        <div ${this._referenceAttributeName}="input" 
+          class="formio-editor-read-only-content" 
+          ${elementStyle ? `style='${elementStyle}'` : ''}
+          role="textbox"
+          aria-multiline="true"
+          aria-readonly="true"
+        >
+        </div>`;
 
       return this.renderTemplate('well', {
         children,


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9848

## Description

Previously, Well component was rendered instead of TextArea when the component was disabled/readonly, which did not take the semantics into account and it led to screenreaders to misread the component. I've tried multiple approaches, and adding aria tags that mimic a textarea component is the best solution in my opinion, other than reverting to display native textarea component, which will cause some issues displaying data. There was also a consideration for making the component focusable, but for now I think it is not necessary, because the content of the component is announced correctly when the page is first loaded by a screenreader.

## Breaking Changes / Backwards Compatibility

-

## Dependencies

-

## How has this PR been tested?

Tested locally

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
