### PR TITLE
FIO-9854 fixed appearance of the custom component edit fields

### DIFF
--- a/src/components/unknown/Unknown.form.js
+++ b/src/components/unknown/Unknown.form.js
@@ -1,23 +1,28 @@
+import { unionWith } from 'lodash';
 import UnknownEditDisplay from './editForm/Unknown.edit.display';
+import EditFormUtils from '../../components/_classes/component/editForm/utils';
 
 /**
  * Unknown Component schema.
  * @returns {object} - The Unknown Component edit form.
  */
-export default function() {
+export default function(...extend) {
+  const components = [
+    {
+      label: 'Custom',
+      key: 'display',
+      weight: 0,
+      components: UnknownEditDisplay
+    }
+   
+  ].concat(...extend);
+
   return {
     components: [
       {
         type: 'tabs',
         key: 'tabs',
-        components: [
-          {
-            label: 'Custom',
-            key: 'display',
-            weight: 0,
-            components: UnknownEditDisplay
-          }
-        ]
+        components: unionWith(components, EditFormUtils.unifyComponents)
       }
     ]
   };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9854

## Description

*Previously, the fields of the edit modal window for Custom Component settings were displayed even when the Form Builder options were set to ignore = true. This was fixed by adding extend argument to the EditForm Custom Component.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*https://github.com/formio/enterprise-builder-core/pull/13*
*https://github.com/formio/premium/pull/387*

## How has this PR been tested?

*locally using EFB and demo app*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
