### PR TITLE
FIO-9921: fix issue with local paths not being propogated to edit grid

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -3434,9 +3434,11 @@ export default class Component extends Element {
    * @param {boolean} dirty - If the component is dirty.
    * @param {boolean} ignoreCondition - If conditions for the component should be ignored when checking validity.
    * @param {*} row - Contextual row data for this component.
+   * @param {*} options - Additional options for validation.
    * @returns {string} - The message to show when the component is invalid.
    */
-  invalidMessage(data, dirty, ignoreCondition, row) {
+  invalidMessage(data, dirty, ignoreCondition, row, options = {}) {
+    const { local } = options;
     if (!row) {
       row = getContextualRowData(this.component, data, this.paths);
     }
@@ -3459,6 +3461,7 @@ export default class Component extends Element {
       component: this.component,
       data,
       row,
+      local,
       path: this.path || this.component.key,
       parent: this.parent?.component,
       paths: this.paths,
@@ -3647,7 +3650,7 @@ export default class Component extends Element {
 
     // Some components (for legacy reasons) have calls to "checkData" in inappropriate places such
     // as setValue. Historically, this was bypassed by a series of cached states around the data model
-    // which caused its own problems. We need to ensure that premium and custom components do not fall into 
+    // which caused its own problems. We need to ensure that premium and custom components do not fall into
     // an infinite loop by only checking this component once.
     if (this.checkingData) {
       return;

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -1302,6 +1302,8 @@ export default class EditGridComponent extends NestedArrayComponent {
       return false;
     }
 
+    // TODO: this is the only place invalidMessage gets called, and it's not clear why it's needed - we already validate the editGrid
+    // component above with super.checkComponentValidity
     const message = this.invalid || this.invalidMessage(data, dirty, false, row, options);
     if (allRowErrors.length && this.root?.submitted && !message) {
       this._errors = this.setCustomValidity(message, dirty);

--- a/src/components/editgrid/EditGrid.js
+++ b/src/components/editgrid/EditGrid.js
@@ -1302,7 +1302,7 @@ export default class EditGridComponent extends NestedArrayComponent {
       return false;
     }
 
-    const message = this.invalid || this.invalidMessage(data, dirty, false, row);
+    const message = this.invalid || this.invalidMessage(data, dirty, false, row, options);
     if (allRowErrors.length && this.root?.submitted && !message) {
       this._errors = this.setCustomValidity(message, dirty);
       errors.push(...this._errors);

--- a/src/components/unknown/Unknown.form.js
+++ b/src/components/unknown/Unknown.form.js
@@ -4,6 +4,7 @@ import EditFormUtils from '../../components/_classes/component/editForm/utils';
 
 /**
  * Unknown Component schema.
+ * @param {...any} extend
  * @returns {object} - The Unknown Component edit form.
  */
 export default function(...extend) {

--- a/test/unit/Tags.unit.js
+++ b/test/unit/Tags.unit.js
@@ -155,8 +155,8 @@ describe('Tags Component', function() {
         setTimeout(() => {
           assert.equal(tags.errors.length, 1, 'Should set error after Tags component was blurred');
           done();
-        }, 250);
-      }, 250);
+        }, 350);
+      }, 350);
     }).catch(done);
   });
 });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9921

## Description

Since we made changes to the way components' paths are stored and constructed, one crucial element of a correct path is the "local" flag, which determines whether or not a component should be pathed as "local" (i.e. to the current form context) or not (i.e. when it is participating in the process as a nested form). 

This PR fixes an issue in EditGrid in which the local option was not being passed to a specific validation step. What's odd is that EditGrid appears to be the _only_ component that calls the `invalidMessage` function and that validation step appears to be redundant, but for the sake of risk factor and incrementalism I've decided to just pass the option rather than taking the drastic step of removing the function call entirely.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

I couldn't figure out a way to reliably reproduce this issue in our automated testing because the only indication that something is wrong is a visual error (the form will successfully submit regardless of the validation problem). I'm going to investigate THAT issue (the fact that an invalid child form's parent will still successfully submit) and return to this to write tests.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
