### PR TITLE
FIO-9933: Fixed the default value for the Lazy Load option for Select dropdowns.

### DIFF
--- a/src/components/select/editForm/Select.edit.data.js
+++ b/src/components/select/editForm/Select.edit.data.js
@@ -81,6 +81,7 @@ export default [
     key: 'lazyLoad',
     tooltip: 'When set, this will not fire off the request to the URL until this control is within focus. This can improve performance if you have many Select dropdowns on your form where the API\'s will only fire when the control is activated.',
     weight: 11,
+    defaultValue: true,
     conditional: {
       json: {
         and: [


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9933

## Description

Now that the default value and clearOnHide work as expected, the default value of the Lazy Load option is clearing (as it should) when it is defaulted. The solution is to set the default value of the Lazy Load option to "true".

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Manual

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
