### PR TITLE
FIO-9902-9878: fixed an issue where PDF is not loaded for the form with hidden/conditionally hidden select

### DIFF
--- a/src/components/_classes/list/ListComponent.js
+++ b/src/components/_classes/list/ListComponent.js
@@ -29,9 +29,9 @@ export default class ListComponent extends Field {
     // If the root submission has been set, and we are still not attached, then assume
     // that our data is ready.
     if (
-      this.root &&
+      (this.root &&
       this.root.submissionSet &&
-      !this.attached
+      !this.attached) || !this.visible
     ) {
       return Promise.resolve();
     }

--- a/test/forms/formWithHiddenComponents.js
+++ b/test/forms/formWithHiddenComponents.js
@@ -1,0 +1,146 @@
+export default {
+  _id: '67e673ce068b3eb1202de1f3',
+  title: 'data ready test',
+  name: 'dataReadyTest',
+  path: 'datareadytest',
+  type: 'form',
+  display: 'form',
+  owner: '637b2e6b48c1227e60b1f910',
+  components: [
+    {
+      label: 'Checkbox',
+      tableView: false,
+      validateWhenHidden: false,
+      key: 'checkbox',
+      type: 'checkbox',
+      input: true,
+    },
+    {
+      label: 'Select',
+      widget: 'choicesjs',
+      hidden: true,
+      tableView: true,
+      data: {
+        values: [
+          {
+            label: 'a',
+            value: 'a',
+          },
+          {
+            label: 'b',
+            value: 'b',
+          },
+        ],
+      },
+      validateWhenHidden: false,
+      key: 'select',
+      type: 'select',
+      input: true,
+    },
+    {
+      label: 'Select',
+      widget: 'choicesjs',
+      tableView: true,
+      data: {
+        values: [
+          {
+            label: 'a',
+            value: 'a',
+          },
+          {
+            label: 'b',
+            value: 'b',
+          },
+        ],
+      },
+      validateWhenHidden: false,
+      key: 'select1',
+      conditional: {
+        show: true,
+        conjunction: 'all',
+        conditions: [
+          {
+            component: 'checkbox',
+            operator: 'isEqual',
+            value: true,
+          },
+        ],
+      },
+      type: 'select',
+      input: true,
+    },
+    {
+      label: 'Select Boxes',
+      optionsLabelPosition: 'right',
+      hidden: true,
+      tableView: false,
+      defaultValue: {
+        a: false,
+        b: false,
+        c: false,
+      },
+      values: [
+        {
+          label: 'a',
+          value: 'a',
+          shortcut: '',
+        },
+        {
+          label: 'b',
+          value: 'b',
+          shortcut: '',
+        },
+        {
+          label: 'c',
+          value: 'c',
+          shortcut: '',
+        },
+      ],
+      validateWhenHidden: false,
+      key: 'selectBoxes',
+      type: 'selectboxes',
+      input: true,
+      inputType: 'checkbox',
+    },
+    {
+      label: 'Radio',
+      optionsLabelPosition: 'right',
+      inline: false,
+      hidden: true,
+      tableView: false,
+      values: [
+        {
+          label: 'a',
+          value: 'a',
+          shortcut: '',
+        },
+        {
+          label: 'b',
+          value: 'b',
+          shortcut: '',
+        },
+        {
+          label: 'c',
+          value: 'c',
+          shortcut: '',
+        },
+      ],
+      validateWhenHidden: false,
+      key: 'radio',
+      type: 'radio',
+      input: true,
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  project: '67caad5b0416ffb92916c9ad',
+  created: '2025-03-28T10:02:54.960Z',
+  modified: '2025-03-28T10:10:00.430Z',
+  machineName: 'bcmuuifnsbrkvdx:dataReadyTest',
+};

--- a/test/unit/Webform.unit.js
+++ b/test/unit/Webform.unit.js
@@ -89,6 +89,7 @@ import formWithConditionalEmail from '../forms/formWithConditionalEmail.js';
 import formsWithSimpleConditionals from '../forms/formsWithSimpleConditionals.js';
 import translationErrorMessages from '../forms/translationErrorMessages.js';
 import simpleController from '../forms/formWithSimpleController.js';
+import formWithHiddenComponents from '../forms/formWithHiddenComponents.js';
 const SpySanitize = sinon.spy(FormioUtils, 'sanitize');
 
 if (_.has(Formio, 'Components.setComponents')) {
@@ -98,6 +99,20 @@ if (_.has(Formio, 'Components.setComponents')) {
 /* eslint-disable max-statements  */
 describe('Webform tests', function() {
   this.retries(3);
+  it('Should resolve dataReady promise when a form includes hidden/conditionally hidden components', function(done) {
+    const formElement = document.createElement('div');
+    const form = new Webform(formElement);
+
+    form.setForm(formWithHiddenComponents).then(() => {
+      let dataReadyResolved = false
+      form.dataReady.then(() => { dataReadyResolved = true; })
+      setTimeout(() => {
+        assert.equal(dataReadyResolved, true);
+        done();
+      }, 300);
+    }).catch((err) => done(err));
+  });
+
   it('Should show fields correctly if there are 2 components with the same key in the form', function(done) {
     const formElement = document.createElement('div');
     const form = new Webform(formElement);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9902
https://formio.atlassian.net/browse/FIO-9878

## Description

**What changed?**

When the formio-viewer renders submission on the pdf-server, it waits until dataReady is resolved. But the dataReady is not resolved for list components when they are hidden that courses the PDF not to be generated. This PR fixes it.

**Why have you chosen this solution?**

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

https://github.com/formio/premium/pull/389

## How has this PR been tested?

manually + tests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
