### PR TITLE
FIO-9931: fixed an issue wehre min and max date settings are not saved in builder

### DIFF
--- a/src/components/datetime/editForm/DateTime.edit.validation.js
+++ b/src/components/datetime/editForm/DateTime.edit.validation.js
@@ -9,35 +9,48 @@ export default [
     tooltip: 'Enables to use input for moment functions instead of calendar.'
   },
   {
-    type: 'datetime',
-    input: true,
+    label: 'Minimum Date',
+    tooltip:
+      "The minimum date that can be picked. You can also use Moment.js functions. For example: moment().subtract(10, 'days')",
+    applyMaskOn: 'change',
     key: 'datePicker.minDate',
-    label: 'Use calendar to set minDate',
-    skipMerge: true,
-    weight: 10,
-    tooltip: 'Enables to use calendar to set date.',
-    customConditional({ data, component }) {
-      if (component.datePicker && component.datePicker.minDate && component.datePicker.minDate.indexOf('moment') !== -1) {
-        return false;
-      }
-      return !data.enableMinDateInput;
-    },
-  },
-  {
+    logic: [
+      {
+        name: 'check input mode',
+        trigger: {
+          type: 'javascript',
+          javascript:
+            "if (component.datePicker && component.datePicker.minDate && component.datePicker.minDate.indexOf('moment') !== -1) {\r\n  result = false;\r\n}\r\nelse {\r\n  result = !data.enableMinDateInput;\r\n}",
+        },
+        actions: [
+          {
+            name: 'change component',
+            type: 'mergeComponentSchema',
+            schemaDefinition:
+              "schema = {\n  type: 'datetime',\n  label: 'Use calendar to set minDate',\n  enableDate: true,\n  enableTime: true,\n  tooltip: 'Enables to use calendar to set date.',\n  widget: {\n    type: 'calendar',\n    displayInTimezone: 'viewer',\n    locale: 'en',\n    useLocaleSettings: false,\n    allowInput: true,\n    mode: 'single',\n    enableTime: true,\n    noCalendar: false,\n    format: 'yyyy-MM-dd hh:mm a',\n    hourIncrement: 1,\n    minuteIncrement: 1,\n    time_24hr: false,\n    disableWeekends: false,\n    disableWeekdays: false,\n    maxDate: null,\n  },\n};",
+          },
+        ],
+      },
+      {
+        name: 'clear value',
+        trigger: {
+          type: 'event',
+          event: 'componentChange',
+        },
+        actions: [
+          {
+            name: 'reset value',
+            type: 'customAction',
+            customAction:
+              "var isDateInput = instance.component?.type === 'datetime';\nvar enableInput = data.enableMinDateInput;\nvar allowReset = result[0].component && result[0].component.key === 'enableMinDateInput' && !result[0].flags?.fromSubmission;\nif(((enableInput && isDateInput) || (!enableInput && !isDateInput)) && allowReset) {\n  instance.resetValue()\n}\n",
+          },
+        ],
+      },
+    ],
     type: 'textfield',
     input: true,
-    enableTime: false,
-    key: 'datePicker.minDate',
     skipMerge: true,
-    label: 'Minimum Date',
     weight: 10,
-    tooltip: 'The minimum date that can be picked. You can also use Moment.js functions. For example: \n \n moment().subtract(10, \'days\')',
-    customConditional({ data, component }) {
-      if (component.datePicker && component.datePicker.minDate && component.datePicker.minDate.indexOf('moment') !== -1) {
-        return true;
-      }
-      return data.enableMinDateInput;
-    },
   },
   {
     type: 'checkbox',
@@ -49,34 +62,49 @@ export default [
     tooltip: 'Enables to use input for moment functions instead of calendar.'
   },
   {
-    type: 'datetime',
-    input: true,
+    label: 'Maximum Date',
+    tooltip: "The maximum date that can be picked. You can also use Moment.js functions. For example: moment().add(10, 'days')",
+    applyMaskOn: 'change',
+    tableView: true,
+    validateWhenHidden: false,
     key: 'datePicker.maxDate',
-    skipMerge: true,
-    label: 'Use calendar to set maxDate',
-    weight: 20,
-    tooltip: 'Enables to use calendar to set date.',
-    customConditional({ data, component }) {
-      if (component.datePicker && component.datePicker.maxDate && component.datePicker.maxDate.indexOf('moment') !== -1) {
-        return false;
-      }
-      return !data.enableMaxDateInput;
-    },
-  },
-  {
+    logic: [
+      {
+        name: 'check input mode',
+        trigger: {
+          type: 'javascript',
+          javascript:
+            "if (component.datePicker && component.datePicker.maxDate && component.datePicker.maxDate.indexOf('moment') !== -1) {\r\n  result = false;\r\n}\r\nelse {\r\n  result = !data.enableMaxDateInput;\r\n}",
+        },
+        actions: [
+          {
+            name: 'change component',
+            type: 'mergeComponentSchema',
+            schemaDefinition:
+              "schema = {\n  type: 'datetime',\n  label: 'Use calendar to set maxDate',\n  enableDate: true,\n  enableTime: true,\n  tooltip: 'Enables to use calendar to set date.',\n  widget: {\n    type: 'calendar',\n    displayInTimezone: 'viewer',\n    locale: 'en',\n    useLocaleSettings: false,\n    allowInput: true,\n    mode: 'single',\n    enableTime: true,\n    noCalendar: false,\n    format: 'yyyy-MM-dd hh:mm a',\n    hourIncrement: 1,\n    minuteIncrement: 1,\n    time_24hr: false,\n    disableWeekends: false,\n    disableWeekdays: false,\n    maxDate: null,\n  },\n};",
+          },
+        ],
+      },
+      {
+        name: 'clear value',
+        trigger: {
+          type: 'event',
+          event: 'componentChange',
+        },
+        actions: [
+          {
+            name: 'reset value',
+            type: 'customAction',
+            customAction:
+              "var isDateInput = instance.component?.type === 'datetime';\nvar enableInput = data.enableMaxDateInput;\nvar allowReset = result[0].component && result[0].component.key === 'enableMaxDateInput' && !result[0].flags?.fromSubmission;\nif(((enableInput && isDateInput) || (!enableInput && !isDateInput)) && allowReset) {\n  instance.resetValue()\n}\n",
+          },
+        ],
+      },
+    ],
     type: 'textfield',
     input: true,
     enableTime: false,
-    key: 'datePicker.maxDate',
     skipMerge: true,
-    label: 'Maximum Date',
-    tooltip: 'The maximum date that can be picked. You can also use Moment.js functions. For example: \n \n moment().add(10, \'days\')',
     weight: 20,
-    customConditional({ data, component }) {
-      if (component.datePicker && component.datePicker.maxDate && component.datePicker.maxDate.indexOf('moment') !== -1) {
-        return true;
-      }
-      return data.enableMaxDateInput;
-    },
   }
 ];

--- a/test/forms/formWithMergeComponentSchemaAndCustomLogic.js
+++ b/test/forms/formWithMergeComponentSchemaAndCustomLogic.js
@@ -1,0 +1,141 @@
+export default {
+  _id: '67ea94c6848c242d23244618',
+  title: 'kkk',
+  name: 'kkk',
+  path: 'kkk',
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      label: 'Use Input to add moment.js for minDate',
+      tableView: false,
+      defaultValue: false,
+      validateWhenHidden: false,
+      key: 'enableMinDateInput',
+      type: 'checkbox',
+      input: true,
+    },
+    {
+      label: 'Use Input to add moment.js for maxDate',
+      tableView: false,
+      validateWhenHidden: false,
+      key: 'enableMaxDateInput',
+      type: 'checkbox',
+      input: true,
+    },
+    {
+      label: 'Minimum Date',
+      tooltip:
+        "The minimum date that can be picked. You can also use Moment.js functions. For example: \\n \\n moment().subtract(10, 'days')",
+      applyMaskOn: 'change',
+      tableView: true,
+      validateWhenHidden: false,
+      key: 'datePicker.minDate',
+      logic: [
+        {
+          name: 'check input mode',
+          trigger: {
+            type: 'javascript',
+            javascript:
+              "if (component.datePicker && component.datePicker.minDate && component.datePicker.minDate.indexOf('moment') !== -1) {\r\n  result = false;\r\n}\r\nelse {\r\n  result = !data.enableMinDateInput;\r\n}",
+          },
+          actions: [
+            {
+              name: 'change component',
+              type: 'mergeComponentSchema',
+              schemaDefinition:
+                "schema = {\n  type: 'datetime',\n  label: 'Use calendar to set minDate',\n  enableDate: true,\n  enableTime: true,\n  tooltip: 'Enables to use calendar to set date.',\n  widget: {\n    type: 'calendar',\n    displayInTimezone: 'viewer',\n    locale: 'en',\n    useLocaleSettings: false,\n    allowInput: true,\n    mode: 'single',\n    enableTime: true,\n    noCalendar: false,\n    format: 'yyyy-MM-dd hh:mm a',\n    hourIncrement: 1,\n    minuteIncrement: 1,\n    time_24hr: false,\n    disableWeekends: false,\n    disableWeekdays: false,\n    maxDate: null,\n  },\n};",
+            },
+          ],
+        },
+        {
+          name: 'clear value',
+          trigger: {
+            type: 'event',
+            event: 'componentChange',
+          },
+          actions: [
+            {
+              name: 'reset value',
+              type: 'customAction',
+              customAction:
+                "var isDateInput = instance.component.type === 'datetime';\nvar enableInput = data.enableMinDateInput;\nvar allowReset = result[0].component && result[0].component.key === 'enableMinDateInput' && !result[0].flags?.fromSubmission;\nif(((enableInput && isDateInput) || (!enableInput && !isDateInput)) && allowReset) {\n  instance.resetValue()\n}\n",
+            },
+          ],
+        },
+      ],
+      type: 'textfield',
+      input: true,
+      skipMerge: true,
+      weight: 10,
+    },
+    {
+      label: 'Maximum Date',
+      tooltip:
+        "The maximum date that can be picked. You can also use Moment.js functions. For example: \\n \\n moment().add(10, 'days')",
+      applyMaskOn: 'change',
+      tableView: true,
+      validateWhenHidden: false,
+      key: 'datePicker.maxDate',
+      logic: [
+        {
+          name: 'check input mode',
+          trigger: {
+            type: 'javascript',
+            javascript:
+              "  if (component.datePicker && component.datePicker.maxDate && component.datePicker.maxDate.indexOf('moment') !== -1) {\r\n  result = false;\r\n}\r\nelse {\r\n  result = !data.enableMaxDateInput;\r\n}",
+          },
+          actions: [
+            {
+              name: 'change component',
+              type: 'mergeComponentSchema',
+              schemaDefinition:
+                "schema = {\n  type: 'datetime',\n  label: 'Use calendar to set maxDate',\n  enableDate: true,\n  enableTime: true,\n  tooltip: 'Enables to use calendar to set date.',\n  widget: {\n    type: 'calendar',\n    displayInTimezone: 'viewer',\n    locale: 'en',\n    useLocaleSettings: false,\n    allowInput: true,\n    mode: 'single',\n    enableTime: true,\n    noCalendar: false,\n    format: 'yyyy-MM-dd hh:mm a',\n    hourIncrement: 1,\n    minuteIncrement: 1,\n    time_24hr: false,\n    disableWeekends: false,\n    disableWeekdays: false,\n    maxDate: null,\n  },\n};",
+            },
+          ],
+        },
+        {
+          name: 'clear value',
+          trigger: {
+            type: 'event',
+            event: 'componentChange',
+          },
+          actions: [
+            {
+              name: 'resetV value',
+              type: 'customAction',
+              customAction:
+                "var isDateInput = instance.component.type === 'datetime';\nvar enableInput = data.enableMaxDateInput;\nvar allowReset = result[0].component && result[0].component.key === 'enableMaxDateInput' && !result[0].flags?.fromSubmission;\nif(((enableInput && isDateInput) || (!enableInput && !isDateInput)) && allowReset) {\n  instance.resetValue()\n}\n",
+            },
+          ],
+        },
+      ],
+      type: 'textfield',
+      input: true,
+      enableTime: false,
+      skipMerge: true,
+      weight: 20,
+    },
+    {
+      label: 'Text Field',
+      applyMaskOn: 'change',
+      tableView: true,
+      validateWhenHidden: false,
+      key: 'textField',
+      type: 'textfield',
+      input: true,
+    },
+    {
+      type: 'button',
+      label: 'Submit',
+      key: 'submit',
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  project: '67caad5b0416ffb92916c9ad',
+  created: '2025-03-31T13:12:38.477Z',
+  modified: '2025-04-01T10:19:44.322Z',
+  machineName: 'bcmuuifnsbrkvdx:kkk',
+};

--- a/test/unit/Webform.unit.js
+++ b/test/unit/Webform.unit.js
@@ -90,6 +90,7 @@ import formsWithSimpleConditionals from '../forms/formsWithSimpleConditionals.js
 import translationErrorMessages from '../forms/translationErrorMessages.js';
 import simpleController from '../forms/formWithSimpleController.js';
 import formWithShowAsString from '../forms/formWithShowAsString.js';
+import formWithMergeComponentSchemaAndCustomLogic from '../forms/formWithMergeComponentSchemaAndCustomLogic.js';
 const SpySanitize = sinon.spy(FormioUtils, 'sanitize');
 
 if (_.has(Formio, 'Components.setComponents')) {
@@ -99,6 +100,102 @@ if (_.has(Formio, 'Components.setComponents')) {
 /* eslint-disable max-statements  */
 describe('Webform tests', function() {
   this.retries(3);
+  it('Should merge component schema when condition is executed and set/keep values ', function(done) {
+    const formElement = document.createElement('div');
+    const form = new Webform(formElement);
+
+    form.setForm(formWithMergeComponentSchemaAndCustomLogic).then(() => {
+      const maxDateCheckbox = form.getComponent('enableMaxDateInput');
+      const minDateCheckbox = form.getComponent('enableMinDateInput');
+      const minDateInput = form.getComponent('datePicker.minDate');
+      const maxDateInput = form.getComponent('datePicker.maxDate');
+      assert.equal(maxDateCheckbox.dataValue, false);
+      assert.equal(minDateCheckbox.dataValue, false);
+      assert.equal(minDateInput.component.type, 'datetime');
+      assert.equal(maxDateInput.component.type, 'datetime');
+      assert.equal(!!minDateInput.refs.suffix.length, true);
+      assert.equal(!!maxDateInput.refs.suffix.length, true);
+      minDateInput.setValue('2025-03-03T12:00:00+03:00');
+      maxDateInput.setValue('2025-03-03T12:00:00+03:00');
+
+      setTimeout(() => {
+        assert.equal(maxDateCheckbox.dataValue, false);
+        assert.equal(minDateCheckbox.dataValue, false);
+        assert.equal(minDateInput.component.type, 'datetime');
+        assert.equal(maxDateInput.component.type, 'datetime');
+        assert.equal(!!minDateInput.refs.suffix.length, true);
+        assert.equal(!!maxDateInput.refs.suffix.length, true);
+        assert.equal(!!minDateInput.dataValue, true);
+        assert.equal(!!maxDateInput.dataValue, true);
+
+        maxDateCheckbox.setValue(true);
+        minDateCheckbox.setValue(true);
+        
+
+        setTimeout(() => {
+          assert.equal(maxDateCheckbox.dataValue, true);
+          assert.equal(minDateCheckbox.dataValue, true);
+          assert.equal(minDateInput.component.type, 'textfield');
+          assert.equal(maxDateInput.component.type, 'textfield');
+          assert.equal(!!minDateInput.refs.suffix.length, false);
+          assert.equal(!!maxDateInput.refs.suffix.length, false);
+          assert.equal(!!minDateInput.dataValue, false, 'Value should be cleared');
+          assert.equal(!!maxDateInput.dataValue, false, 'Value should be cleared');
+
+          minDateInput.setValue('moment().subtract(10, "days")');
+          maxDateInput.setValue('moment().add(10, "days")');
+
+          setTimeout(() => {
+            assert.equal(maxDateCheckbox.dataValue, true);
+            assert.equal(minDateCheckbox.dataValue, true);
+            assert.equal(minDateInput.component.type, 'textfield');
+            assert.equal(maxDateInput.component.type, 'textfield');
+            assert.equal(!!minDateInput.refs.suffix.length, false);
+            assert.equal(!!maxDateInput.refs.suffix.length, false);
+            assert.equal(!!minDateInput.dataValue, true);
+            assert.equal(!!maxDateInput.dataValue, true);
+
+            maxDateCheckbox.setValue(false);
+            minDateCheckbox.setValue(false);
+
+            setTimeout(() => {
+              assert.equal(maxDateCheckbox.dataValue, false);
+              assert.equal(minDateCheckbox.dataValue, false);
+              assert.equal(minDateInput.component.type, 'datetime');
+              assert.equal(maxDateInput.component.type, 'datetime');
+              assert.equal(!!minDateInput.refs.suffix.length, true);
+              assert.equal(!!maxDateInput.refs.suffix.length, true);
+              assert.equal(!!minDateInput.dataValue, false, 'Value should be cleared 2');
+              assert.equal(!!maxDateInput.dataValue, false, 'Value should be cleared 2');
+
+              form.setSubmission({
+                data: {
+                  datePicker: {
+                    minDate: "moment().subtract(10, 'days')",
+                    maxDate: '2025-03-03T12:00:00+03:00',
+                  },
+                  enableMinDateInput: true,
+                  enableMaxDateInput: false,
+                },
+              }).then(() => {
+                setTimeout(() => {
+                  assert.equal(maxDateCheckbox.dataValue, false);
+                  assert.equal(minDateCheckbox.dataValue, true);
+                  assert.equal(minDateInput.component.type, 'textfield');
+                  assert.equal(maxDateInput.component.type, 'datetime');
+                  assert.equal(!!minDateInput.refs.suffix.length, false);
+                  assert.equal(!!maxDateInput.refs.suffix.length, true);
+                  assert.equal(!!minDateInput.dataValue, true);
+                  assert.equal(!!maxDateInput.dataValue, true);
+                  done();
+                }, 300)
+              }).catch(done);
+            }, 300);
+          }, 300);
+        }, 300);
+      }, 300);
+    }).catch((err) => done(err));
+  });
   it('Should show fields correctly if there are 2 components with the same key in the form', function(done) {
     const formElement = document.createElement('div');
     const form = new Webform(formElement);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9931

## Description

**What changed?**

When the min/max date is configured in datetime component settings in builder, the user can choose the mode for the value: calendar picker or just textfield where the user can use moment() function. Before we used two conditional components with the same key that become visible based on the mode. It worked more or less good until the clearOnHide and conditional checks in general were refactored (commits https://github.com/formio/formio.js/commit/d70fdbaf1306974d82600ba9ece25ab4379b21ce#diff-8795d5891ca105e3583ef74383eb1929aeec1fa888d641a0d7be8a91a0abd5f4 and https://github.com/formio/formio.js/pull/6048/files#diff-05d41a5d854049f92f62772ee82f295d614534d5f4f0717b3ec30c69dfc3a7f5). So, when the one component is hidden, it is value is unset, but we have the component with the same key that is visible and it refers to the same value in data object that was unset. So, this is the reason why the value for visible component is lost. 
In general, our renderer is not supposed the form to have components with the same key. And the fact, that they worked, is more like an accident. So, this PR changes the min and max date components to use еру merge сomponent schema to change its input type.

## How has this PR been tested?

Manually + autotests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
