### PR TITLE
FIO-9884: Fixed file upload plugin for ckeditor

### DIFF
--- a/src/providers/storage/uploadAdapter.js
+++ b/src/providers/storage/uploadAdapter.js
@@ -55,9 +55,11 @@ class FormioUploadAdapter {
   }
 }
 
-const getFormioUploadAdapterPlugin = (fileService, component) => (editor) => {
-  editor.plugins.get('FileRepository').createUploadAdapter = (loader) => {
-    return new FormioUploadAdapter(loader, fileService, component);
+const getFormioUploadAdapterPlugin = (fileService, component) => {
+  return function (editor) {
+    editor.plugins.get('FileRepository').createUploadAdapter = (loader) => {
+      return new FormioUploadAdapter(loader, fileService, component);
+    };
   };
 };
 

--- a/test/unit/TextArea.unit.js
+++ b/test/unit/TextArea.unit.js
@@ -10,6 +10,7 @@ import { Formio } from '../../src/Formio';
 import { comp1, comp2, comp3, comp4 } from './fixtures/textarea';
 import TextAreaComponent from '../../src/components/textarea/TextArea';
 import { fastCloneDeep } from '@formio/core';
+import { getFormioUploadAdapterPlugin } from '../../src/providers/storage/uploadAdapter';
 window.ace = require('ace-builds');
 
 describe('TextArea Component', () => {
@@ -449,6 +450,23 @@ describe('TextArea Component', () => {
             done();
           }, 300);
         }).catch(done);
+      });
+
+      it('File upload plugin should be constructor', (done) => {
+        try {
+          const fileUploadPlugin = getFormioUploadAdapterPlugin();
+          const plugin = new fileUploadPlugin({
+            plugins: {
+              get: () => ({
+                createUploadAdapter: () => {}
+              }),
+            }
+          });
+          assert.deepEqual(plugin, {});
+          done();
+        } catch (error) {
+          done(error)
+        }
       });
     });
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9884

## Description

**Issue**: In CKEditor, any plugin should have a constructor. Currently, we have a `getFormioUploadAdapterPlugin` function that returns another function, which is intended to act as the plugin's constructor. However, this returned function is an arrow function, and arrow functions cannot be used as constructors.

Previously, when we used Babel as the transpiler, it converted arrow functions into function expressions, which worked as expected. However, since we switched to TypeScript for the build process, the arrow function remains unchanged, leading to issues with CKEditor.

**Solution**: Update the `getFormioUploadAdapterPlugin` function to return a function expression instead of an arrow function, ensuring compatibility with CKEditor.

## How has this PR been tested?

Unit testing

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
