### PR TITLE
FIO-9941 fixed errors list translations

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1325,11 +1325,8 @@ export default class Webform extends NestedDataComponent {
             errors.forEach(({ message, context, fromServer, component }, index) => {
                 const text =
                     !component?.label || context?.hasLabel || fromServer
-                        ? this.t('alertMessage', { message: this.t(message) })
-                        : this.t('alertMessageWithLabel', {
-                              label: this.t(component?.label),
-                              message: this.t(message),
-                          });
+                        ? this.t(message)
+                        : `${this.t(component?.label)}: ${this.t(message)}`;
                 displayedErrors.push(createListItem(text, index));
             });
         }

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -8,8 +8,6 @@ export default {
   invalidRowError: 'Invalid row. Please correct it or delete.',
   invalidOption: '{{field}} is an invalid value.',
   invalidDay: '{{field}} is not a valid day.',
-  alertMessageWithLabel: '{{label}}: {{message}}',
-  alertMessage: '{{message}}',
   complete: 'Submission Complete',
   error: 'Please fix the following errors before submitting.',
   errorListHotkey: 'Press Ctrl + Alt + X to go back to the error list.',

--- a/test/unit/Webform.unit.js
+++ b/test/unit/Webform.unit.js
@@ -2101,13 +2101,12 @@ describe('Webform tests', function() {
     assert.equal(form.language, 'es');
   });
 
-  it('Should translate form errors in alerts', () => {
+  it('Should translate form errors in alerts without allertMessage', () => {
     const formElement = document.createElement('div');
     const form = new Webform(formElement, {
       language: 'es',
       i18n: {
         es: {
-          alertMessage: '{{message}}',
           required: '{{field}} es obligatorio'
         }
       }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9941

## Description

*The translation of the Error List was fixed. Previously, in order to correctly translate the error list, it was necessary to add `{ alertMessageWithLabel: '{{label}}: {{message}}', alertMessage: '{{message}}'`} properties to the options, which in fact were not include translation.*
 
## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated test was updated. All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
