### PR TITLE
FIO-9847: time on textfield only changes when timezone included

### DIFF
--- a/src/components/textfield/TextField.js
+++ b/src/components/textfield/TextField.js
@@ -1,5 +1,6 @@
 import Input from '../_classes/input/Input';
 import { conformToMask } from '@formio/vanilla-text-mask';
+import {hasEncodedTimezone} from "../../utils/utils";
 import Inputmask from 'inputmask';
 import * as FormioUtils from '../../utils/utils';
 import _ from 'lodash';
@@ -99,8 +100,8 @@ export default class TextFieldComponent extends Input {
         locale: this.component.widget.locale || this.options.language,
         saveAs: 'text'
       };
-      // update originalComponent to include widget settings after component initialization 
-      // originalComponent is used to restore the component (and widget) after evaluating field logic 
+      // update originalComponent to include widget settings after component initialization
+      // originalComponent is used to restore the component (and widget) after evaluating field logic
       this.originalComponent = FormioUtils.fastCloneDeep(this.component);
     }
   }
@@ -345,6 +346,24 @@ export default class TextFieldComponent extends Input {
     if (value && this.component.inputFormat === 'plain' && /<[^<>]+>/g.test(value)) {
       value = value.replaceAll('<','&lt;').replaceAll('>', '&gt;');
     }
+    // If the textfield does not have an encoded timezone then return
+    if(!hasEncodedTimezone(value)){
+      if (!value) {
+        return '';
+      }
+      if (Array.isArray(value)) {
+        return value.join(', ');
+      }
+      if (_.isPlainObject(value)) {
+        return JSON.stringify(value);
+      }
+      if (value === null || value === undefined) {
+        return '';
+      }
+      const stringValue = value.toString();
+      return this.sanitize(stringValue);
+    }
+
     return super.getValueAsString(value, options);
   }
 }

--- a/src/components/textfield/TextField.js
+++ b/src/components/textfield/TextField.js
@@ -1,6 +1,5 @@
 import Input from '../_classes/input/Input';
 import { conformToMask } from '@formio/vanilla-text-mask';
-import {hasEncodedTimezone} from "../../utils/utils";
 import Inputmask from 'inputmask';
 import * as FormioUtils from '../../utils/utils';
 import _ from 'lodash';
@@ -346,24 +345,6 @@ export default class TextFieldComponent extends Input {
     if (value && this.component.inputFormat === 'plain' && /<[^<>]+>/g.test(value)) {
       value = value.replaceAll('<','&lt;').replaceAll('>', '&gt;');
     }
-    // If the textfield does not have an encoded timezone then return
-    if(!hasEncodedTimezone(value)){
-      if (!value) {
-        return '';
-      }
-      if (Array.isArray(value)) {
-        return value.join(', ');
-      }
-      if (_.isPlainObject(value)) {
-        return JSON.stringify(value);
-      }
-      if (value === null || value === undefined) {
-        return '';
-      }
-      const stringValue = value.toString();
-      return this.sanitize(stringValue);
-    }
-
     return super.getValueAsString(value, options);
   }
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1750,3 +1750,14 @@ export const interpolateErrors = (component, errors, interpolateFn) => {
     return { ...error, message: unescapeHTML(interpolateFn(toInterpolate, context)), context: { ...context } };
   });
 };
+
+/**
+ * Checks if a string has timezone information encoded in it
+ * Example: 2024-01-01T00:00:00Z -> true
+ * Example: 2011-05-03T00:00:00 -> false
+ * @param {string} value the string value to check
+ * @returns {boolean} if value has encoded timezone
+ */
+export function hasEncodedTimezone(value){
+  return (value.substring(value.length - 1) === 'z' || value.substring(value.length - 1) === 'Z' || value.match(/[+|-][0-9]+:[0-9]+/));
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1763,5 +1763,5 @@ export function hasEncodedTimezone(value){
   if (typeof value !== 'string'){
     return false;
   }
-  return (value.substring(value.length - 1) === 'z' || value.substring(value.length - 1) === 'Z' || value.match(/[+|-][0-9]+:[0-9]+/));
+  return (value.substring(value.length - 1) === 'z' || value.substring(value.length - 1) === 'Z' || value.match(/[+|-][0-9]{2}:[0-9]{2}$/));
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1754,10 +1754,14 @@ export const interpolateErrors = (component, errors, interpolateFn) => {
 /**
  * Checks if a string has timezone information encoded in it
  * Example: 2024-01-01T00:00:00Z -> true
+ * Example: 2024-01-01T00:00:00+03:00 -> true
  * Example: 2011-05-03T00:00:00 -> false
  * @param {string} value the string value to check
  * @returns {boolean} if value has encoded timezone
  */
 export function hasEncodedTimezone(value){
+  if (typeof value !== 'string'){
+    return false;
+  }
   return (value.substring(value.length - 1) === 'z' || value.substring(value.length - 1) === 'Z' || value.match(/[+|-][0-9]+:[0-9]+/));
 }

--- a/src/widgets/CalendarWidget.js
+++ b/src/widgets/CalendarWidget.js
@@ -346,7 +346,7 @@ export default class CalendarWidget extends InputWidget {
 
     // If the component is a textfield that does not have timezone information included in the string value then skip
     // the timezone offset
-    if(this.component.type === 'textfield' && !(hasEncodedTimezone)(value)){
+    if(this.component.type === 'textfield' && !hasEncodedTimezone(value)){
       this.settings.skipOffset = true;
     }
 

--- a/src/widgets/CalendarWidget.js
+++ b/src/widgets/CalendarWidget.js
@@ -12,7 +12,7 @@ import {
   momentDate,
   zonesLoaded,
   shouldLoadZones,
-  loadZones,
+  loadZones, hasEncodedTimezone,
 } from '../utils/utils';
 import moment from 'moment';
 import _ from 'lodash';
@@ -164,7 +164,7 @@ export default class CalendarWidget extends InputWidget {
         }
       })
       .then((ShortcutButtonsPlugin) => {
-        return Formio.requireLibrary('flatpickr', 'flatpickr', `${Formio.cdn['flatpickr']}/flatpickr.min.js`, true)
+        return Formio.requireLibrary('flatpickr', 'flatpickr', `${Formio.cdn['flatpickr']}/flatpickr.js`, true)
           .then((Flatpickr) => {
             if (this.component.shortcutButtons?.length && ShortcutButtonsPlugin) {
               this.initShortcutButtonsPlugin(ShortcutButtonsPlugin);
@@ -342,6 +342,12 @@ export default class CalendarWidget extends InputWidget {
     if (!this.calendar) {
       value = value ? formatDate(this.timezonesUrl, value, convertFormatToMoment(this.settings.format), this.timezone, convertFormatToMoment(this.valueMomentFormat)) : value;
       return super.setValue(value);
+    }
+
+    if(this.component.type === 'textfield' && !(hasEncodedTimezone)(value)){
+      this.calendar._input.value = value;
+      this.calendar.altInput.value = value;
+      return;
     }
 
     const zonesLoading = this.loadZones();

--- a/src/widgets/CalendarWidget.js
+++ b/src/widgets/CalendarWidget.js
@@ -164,7 +164,7 @@ export default class CalendarWidget extends InputWidget {
         }
       })
       .then((ShortcutButtonsPlugin) => {
-        return Formio.requireLibrary('flatpickr', 'flatpickr', `${Formio.cdn['flatpickr']}/flatpickr.js`, true)
+        return Formio.requireLibrary('flatpickr', 'flatpickr', `${Formio.cdn['flatpickr']}/flatpickr.min.js`, true)
           .then((Flatpickr) => {
             if (this.component.shortcutButtons?.length && ShortcutButtonsPlugin) {
               this.initShortcutButtonsPlugin(ShortcutButtonsPlugin);
@@ -344,10 +344,10 @@ export default class CalendarWidget extends InputWidget {
       return super.setValue(value);
     }
 
+    // If the component is a textfield that does not have timezone information included in the string value then skip
+    // the timezone offset
     if(this.component.type === 'textfield' && !(hasEncodedTimezone)(value)){
-      this.calendar._input.value = value;
-      this.calendar.altInput.value = value;
-      return;
+      this.settings.skipOffset = true;
     }
 
     const zonesLoading = this.loadZones();
@@ -538,7 +538,7 @@ export default class CalendarWidget extends InputWidget {
     return (date, format) => {
       // Only format this if this is the altFormat and the form is readOnly.
       if (this.settings.readOnly && (format === this.settings.altFormat)) {
-        if (!this.settings.enableTime || this.loadZones()) {
+        if (!this.settings.enableTime || this.loadZones() || this.settings.skipOffset) {
           return Flatpickr.formatDate(date, format);
         }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9847

## Description

**What changed?**

Added encoded timezone checks to determine if setting a timezone value should use the plain text timezone

**Why have you chosen this solution?**

Trying to make changes without breaking anything

## Breaking Changes / Backwards Compatibility

If a time does not have timezone information attached to it then it will be treated as plain text for textfields

## Dependencies

N/A

## How has this PR been tested?

manually tested

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
