### PR TITLE
FIO-9992: check for server when triggering the captcha

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -743,7 +743,9 @@ export default class Webform extends NestedDataComponent {
         const rebuild = this.rebuild() || Promise.resolve();
         return rebuild.then(() => {
             this.emit('formLoad', form);
-            this.triggerCaptcha();
+            if (!this.options.server) {
+              this.triggerCaptcha();
+            }
             // Make sure to trigger onChange after a render event occurs to speed up form rendering.
             setTimeout(() => {
                 this.onChange(flags);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9992

## Description

We're still using @formio/js for email rendering on the server ([soon to change!](https://github.com/formio/vm/pull/57)) and it appears that the captcha trigger is causing problems, namely because the Captcha component appears to the server as a Hidden component. I'm not sure if this is because the vm library is not properly loading premium components or what, but because this is a blocker right before release and because presumably you shouldn't need to trigger the captcha component just to render an email, I've gone ahead and gated the captcha trigger to client-side stuff only.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
