### PR TITLE
Revert "Replace in utils fastCloneDeep func cloning with json.parse-stringiry to structuredClone api"

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1479,7 +1479,7 @@ export function sanitize(string, options) {
  * @returns {any} - The cloned object.
  */
 export function fastCloneDeep(obj) {
-  return obj ? structuredClone(obj) : obj;
+  return obj ? JSON.parse(JSON.stringify(obj)) : obj;
 }
 
 export { Evaluator, interpolate };


### PR DESCRIPTION
Reverts formio/formio.js#5942 because tests were failing 