### PR TITLE
FIO-9985 fixed appearing extra option with an empty key

### DIFF
--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -176,6 +176,9 @@ export default class SelectBoxesComponent extends RadioComponent {
         }
       }
     }
+    else if (_.isEmpty(this.loadedOptions) && !checkedValues.length) {
+      value = {};
+    }
     return value;
   }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9985

## Description

*Previously, when submitting a persistent SelectBoxes component with the url dataSrc type, an option with an empty key and a false value could appear in the data. The reason for this behavior was that when adding a new SelectBoxes component with the Url dataSrc, an option with an empty key and a false value was added to the default value. This behavior was fixed and now only the corresponding loaded options are displayed in the list of options.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*all tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
