### PR TITLE
FIO-9780 Fixed inability to save component settings if nested compone…

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1229,6 +1229,15 @@ export default class WebformBuilder extends Component {
           'fields.month.required',
           'fields.year.required',
         ]));
+        if (defaultValueComponent.component.components) {
+          if (!this.originalDefaultValue) {
+            this.originalDefaultValue = fastCloneDeep(defaultValueComponent.component);
+          }
+
+          eachComponent(defaultValueComponent.component.components, (comp => {
+            comp.validate.required = false;
+          }));
+        }
         const parentComponent = defaultValueComponent.parent;
         let tabIndex = -1;
         let index = -1;
@@ -1330,6 +1339,9 @@ export default class WebformBuilder extends Component {
     if (index !== -1) {
       let submissionData = this.editForm.submission.data;
       submissionData = submissionData.componentJson || submissionData;
+      if (submissionData.components && this.originalDefaultValue) {
+        submissionData.components = this.originalDefaultValue.components;
+      }
       const fieldsToRemoveDoubleQuotes = ['label', 'tooltip'];
 
       this.replaceDoubleQuotes(submissionData, fieldsToRemoveDoubleQuotes);

--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1235,7 +1235,9 @@ export default class WebformBuilder extends Component {
           }
 
           eachComponent(defaultValueComponent.component.components, (comp => {
-            comp.validate.required = false;
+            if (comp.validate?.required) {
+              comp.validate.required = false;
+            }
           }));
         }
         const parentComponent = defaultValueComponent.parent;


### PR DESCRIPTION
…nts are required

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9780

## Description

After moving to core validation, there was an issue when saving component settings, because the validation would trigger which led to inability to save a component, if it had nested components that are required. This PR makes a change to bypass this behavior by removing 'required' from the nested components in 'Default Value' component, and then restoring original component settings after the component is saved.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

Tested locally

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
