### PR TITLE
FIO-9813: Make validateWhenHidden to sepend on the parent component validateWhenHidden property

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -358,6 +358,13 @@ export default class Webform extends NestedDataComponent {
         return this._data;
     }
 
+    get validateWhenHidden() {
+        if (this.parent?.component?.type === 'form' && this.parent.component.validateWhenHidden) {
+            return this.parent.validateWhenHidden;
+        }
+        return false;
+    }
+
     /**
      * Sets the language for this form.
      * @param {string} lang - The language to use (e.g. 'en', 'sp', etc.)

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2536,6 +2536,17 @@ export default class Component extends Element {
     element.setAttribute('aria-invalid', invalid ? 'true' : 'false');
   }
 
+  get validateWhenHidden() {
+    if (this.component.validateWhenHidden) {
+      if (this.parent && (this.parent !== this.parent.root)) {
+        return this.parent.validateWhenHidden;
+      } else {
+        return this.component.validateWhenHidden;
+      }
+    }
+    return false;
+  }
+
   /**
    * Clears the components data if it is conditionally hidden AND clearOnHide is set to true for this component.
    */
@@ -3778,7 +3789,7 @@ export default class Component extends Element {
       () => this.isValueHidden(),
       // Force valid if component is hidden.
       () => {
-        if (!this.component.validateWhenHidden && (!this.visible || !this.checkCondition(row, data))) {
+        if (!this.validateWhenHidden && (!this.visible || !this.checkCondition(row, data))) {
           // If this component is forced valid when it is hidden, then we also need to reset the errors for this component.
           this._errors = [];
           return true;

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -18,6 +18,7 @@ export default class FormComponent extends Component {
       form: '',
       path: '',
       tableView: true,
+      validateWhenHidden: false,
     }, ...extend);
   }
 
@@ -437,12 +438,6 @@ export default class FormComponent extends Component {
       // Iterate through every component and hide the submit button.
       eachComponent(form.components, (component) => {
         this.hideSubmitButton(component);
-        if (component.validateWhenHidden) {
-          this.component.validateWhenHidden = true;
-          // Change original component as well, so it won't cause any custom logic to be continuously triggered
-          // because the original component does not have this property
-          this.originalComponent.validateWhenHidden = true;
-        }
       });
 
       // If the subform is already created then destroy the old one.
@@ -529,6 +524,9 @@ export default class FormComponent extends Component {
           this.formObj = formObj;
           if (this.options.pdf && this.component.useOriginalRevision) {
             this.formObj.display = 'form';
+          }
+          if (this.component.validateWhenHidden) {
+            this.formObj.validateWhenHidden = true;
           }
           this.subFormLoading = false;
           return formObj;

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -437,6 +437,12 @@ export default class FormComponent extends Component {
       // Iterate through every component and hide the submit button.
       eachComponent(form.components, (component) => {
         this.hideSubmitButton(component);
+        if (component.validateWhenHidden) {
+          this.component.validateWhenHidden = true;
+          // Change original component as well, so it won't cause any custom logic to be continuously triggered
+          // because the original component does not have this property
+          this.originalComponent.validateWhenHidden = true;
+        }
       });
 
       // If the subform is already created then destroy the old one.

--- a/src/components/form/editForm/Form.edit.data.js
+++ b/src/components/form/editForm/Form.edit.data.js
@@ -18,5 +18,13 @@ export default [
     tooltip: 'When a field is hidden, clear the value.',
     input: true
   },
+  {
+    weight: 100,
+    type: 'checkbox',
+    label: 'Validate When Hidden',
+    tooltip: 'Validates the component when it is hidden/conditionally hidden. Vaildation errors are displayed in the error alert on the form submission. Use caution when enabling this setting, as it can cause a hidden component to be invalid with no way for the form user to correct it.',
+    key: 'validateWhenHidden',
+    input: true
+  },
 ];
 /* eslint-enable max-len */


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9813

## Description

Previously, validateWhenHidden was completely independent for every component and Nested Form did not have that property at all producing some unexpected results. Now any nested component will be validated being hidden only if 1. It has validateWhenHidden set to true & 2. If it's parent data component has validateWhenHidden set to true (if it is inside a parent data component) 
Notice that the Nested Forms submitted as reference will still trigger the validation error for validateWhenhidden component even if the Nested Form component does not have validateWhenHidden property set. This is because server creates a separate submission for the nested form and validate it outside of the parent form context and such submission must be valid outside the parent's context, so this is a completely expected behaviour. 
## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

[*Use this section to list any dependent changes/PRs in other Form.io modules*](https://github.com/formio/core/pull/229)

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
