### PR TITLE
FIO-10006: Radio values not displayed with render mode html

### DIFF
--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -179,6 +179,13 @@ export default class RadioComponent extends ListComponent {
     });
   }
 
+  mapThroughValues(values) {
+    if (this.options.renderMode === 'html' && this.type === 'radio') {
+      return values.map(x => ({ ...x, value: this.normalize(x.value) }))
+    }
+    return values
+  }
+
   render() {
     if (!this.optionsLoaded) {
       return super.render(this.renderTemplate('loader'));
@@ -186,7 +193,7 @@ export default class RadioComponent extends ListComponent {
     return super.render(this.renderTemplate('radio', {
       input: this.inputInfo,
       inline: this.component.inline,
-      values: this.component.dataSrc === 'values' ? this.component.values : this.loadedOptions,
+      values: this.component.dataSrc === 'values' ? this.mapThroughValues(this.component.values) : this.loadedOptions,
       value: this.dataValue,
       row: this.row,
     }));
@@ -472,7 +479,7 @@ export default class RadioComponent extends ListComponent {
    * @param {*} value - The value to normalize
    * @returns {*} - Returns the normalized value
    */
-  normalizeValue(value) {
+  normalize(value) {
     const dataType = this.component.dataType || 'auto';
     if (value === this.emptyValue) {
       return value;
@@ -480,7 +487,6 @@ export default class RadioComponent extends ListComponent {
 
     switch (dataType) {
       case 'auto':
-
         if (!isNaN(parseFloat(value)) && isFinite(value) && _.toString(value) === Number(value).toString()) {
           value = +value;
         }
@@ -507,15 +513,21 @@ export default class RadioComponent extends ListComponent {
         break;
       }
 
-    if (this.isSelectURL && this.templateData && this.templateData[value]) {
+      return value;
+  }
+
+  normalizeValue(value) {
+    const valueNormalized = this.normalize(value)
+
+    if (this.isSelectURL && this.templateData && this.templateData[valueNormalized]) {
       const submission = this.root.submission;
       if (!submission.metadata.selectData) {
         submission.metadata.selectData = {};
       }
 
-      _.set(submission.metadata.selectData, this.path, this.templateData[value]);
+      _.set(submission.metadata.selectData, this.path, this.templateData[valueNormalized]);
     }
 
-    return super.normalizeValue(value);
+    return super.normalizeValue(valueNormalized);
   }
 }

--- a/src/components/radio/Radio.js
+++ b/src/components/radio/Radio.js
@@ -179,9 +179,9 @@ export default class RadioComponent extends ListComponent {
     });
   }
 
-  mapThroughValues(values) {
+  convertValues(values) {
     if (this.options.renderMode === 'html' && this.type === 'radio') {
-      return values.map(x => ({ ...x, value: this.normalize(x.value) }))
+      return values.map(x => ({ ...x, value: this.convertByDataType(x.value) }))
     }
     return values
   }
@@ -193,7 +193,7 @@ export default class RadioComponent extends ListComponent {
     return super.render(this.renderTemplate('radio', {
       input: this.inputInfo,
       inline: this.component.inline,
-      values: this.component.dataSrc === 'values' ? this.mapThroughValues(this.component.values) : this.loadedOptions,
+      values: this.component.dataSrc === 'values' ? this.convertValues(this.component.values) : this.loadedOptions,
       value: this.dataValue,
       row: this.row,
     }));
@@ -479,7 +479,7 @@ export default class RadioComponent extends ListComponent {
    * @param {*} value - The value to normalize
    * @returns {*} - Returns the normalized value
    */
-  normalize(value) {
+  convertByDataType(value) {
     const dataType = this.component.dataType || 'auto';
     if (value === this.emptyValue) {
       return value;
@@ -517,17 +517,17 @@ export default class RadioComponent extends ListComponent {
   }
 
   normalizeValue(value) {
-    const valueNormalized = this.normalize(value)
+    const valueConverted = this.convertByDataType(value)
 
-    if (this.isSelectURL && this.templateData && this.templateData[valueNormalized]) {
+    if (this.isSelectURL && this.templateData && this.templateData[valueConverted]) {
       const submission = this.root.submission;
       if (!submission.metadata.selectData) {
         submission.metadata.selectData = {};
       }
 
-      _.set(submission.metadata.selectData, this.path, this.templateData[valueNormalized]);
+      _.set(submission.metadata.selectData, this.path, this.templateData[valueConverted]);
     }
 
-    return super.normalizeValue(valueNormalized);
+    return super.normalizeValue(valueConverted);
   }
 }

--- a/test/unit/Radio.unit.js
+++ b/test/unit/Radio.unit.js
@@ -16,9 +16,11 @@ import {
   comp9,
   comp10,
   comp11,
-  comp13
+  comp13,
+  comp14
 } from './fixtures/radio';
 import { fastCloneDeep } from '@formio/core';
+import { wait } from '../util';
 
 describe('Radio Component', () => {
   it('Should build a radio component', () => {
@@ -606,5 +608,23 @@ describe('Radio Component', () => {
         })
       })
       .catch(done);
+  });
+
+  it("Should display result for radio submission with form='html' and dataType='number'", async function () {
+    const element = document.createElement('div');
+    const form = await Formio.createForm(
+      element,
+      comp14,
+      {
+        readOnly: true,
+        renderMode: 'html'
+      }
+    );
+    const el = form.element.querySelector('[ref="value"]');
+    assert.equal(el.innerHTML.trim(), '');
+    await form.setSubmission({ data: { radio: 2, submit: true } });
+    await wait(200);
+    const elNext = form.element.querySelector('[ref="value"]');
+    assert.equal(elNext.innerHTML.trim(), 'B');
   });
 });

--- a/test/unit/fixtures/radio/comp14.js
+++ b/test/unit/fixtures/radio/comp14.js
@@ -1,0 +1,36 @@
+export default {
+  type: "form",
+  name: "selectr",
+  path: "selectr",
+  components: [
+    {
+      label: "Radio",
+      optionsLabelPosition: "right",
+      inline: false,
+      tableView: false,
+      defaultValue: true,
+      values: [
+        {
+          label: "A",
+          value: "1",
+          shortcut: ""
+        },
+        {
+          label: "B",
+          value: "2",
+          shortcut: ""
+        },
+        {
+          label: "C",
+          value: "3",
+          shortcut: ""
+        },
+      ],
+      dataType: "number",
+      validateWhenHidden: false,
+      key: "radio",
+      type: "radio",
+      input: true
+    },
+  ]
+}

--- a/test/unit/fixtures/radio/index.js
+++ b/test/unit/fixtures/radio/index.js
@@ -11,4 +11,5 @@ import comp10 from './comp10';
 import comp11 from './comp11';
 import comp12 from './comp12';
 import comp13 from './comp13';
-export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13 };
+import comp14 from './comp14';
+export { comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10006

## Description

Fix bug related to values of the radio component are not displayed when the renderMode: "HTML", dataType number/not chosen, and radio values are numbers. The problem is when we change the **dataType** to "number" for example, the value in the submit goes through the **normalizeValue** function, and the values ​​of this.component.dataSrc were strings, so in the html.ejs.js template we have a strict comparison of value, so the bug occurred. My solution involves normalizing all values ​​in this.component.dataSrc in accordance with the passed dataType.

**Why have you chosen this solution?**

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

I added unit test.

## Checklist:

- [X] I have completed the above PR template
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [X] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [X] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
