### PR TITLE
FIO-9974 fixed Clear on Hide for layout components

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -823,7 +823,7 @@ export default class Component extends Element {
       this._conditionallyClear = true;
       return this._conditionallyClear;
     }
-    this._conditionallyClear = this.hasSetValue ? false : this.parentShouldConditionallyClear();
+    this._conditionallyClear = this.parentShouldConditionallyClear();
     return this._conditionallyClear;
   }
 

--- a/test/formtest/clearOnHideInsideLayoutComponent.json
+++ b/test/formtest/clearOnHideInsideLayoutComponent.json
@@ -1,0 +1,85 @@
+{
+  "type": "form",
+  "components": [
+    {
+      "label": "Checkbox",
+      "tableView": false,
+      "defaultValue": true,
+      "validateWhenHidden": false,
+      "key": "checkbox",
+      "type": "checkbox",
+      "input": true
+    },
+    {
+      "label": "Panel",
+      "collapsible": false,
+      "key": "panel",
+      "conditional": {
+        "show": true,
+        "conjunction": "all",
+        "conditions": [
+          {
+            "component": "checkbox",
+            "operator": "isEqual",
+            "value": true
+          }
+        ]
+      },
+      "type": "panel",
+      "input": false,
+      "tableView": false,
+      "components": [
+        {
+          "label": "Text Field",
+          "applyMaskOn": "change",
+          "tableView": true,
+          "validateWhenHidden": false,
+          "key": "textFieldInPanel",
+          "type": "textfield",
+          "input": true
+        }
+      ]
+    },
+    {
+      "label": "",
+      "key": "fieldset",
+      "conditional": {
+        "show": true,
+        "conjunction": "all",
+        "conditions": [
+          {
+            "component": "checkbox",
+            "operator": "isEqual",
+            "value": true
+          }
+        ]
+      },
+      "type": "fieldset",
+      "input": false,
+      "tableView": false,
+      "components": [
+        {
+          "label": "Text Field",
+          "applyMaskOn": "change",
+          "tableView": true,
+          "validateWhenHidden": false,
+          "key": "textFieldInFieldset",
+          "type": "textfield",
+          "input": true
+        }
+      ]
+    },
+    {
+      "type": "button",
+      "label": "Submit",
+      "key": "submit",
+      "disableOnInvalid": true,
+      "input": true,
+      "tableView": false
+    }
+  ],
+  "title": "clearOnHide",
+  "display": "form",
+  "name": "clearOnHide",
+  "path": "clearonhide"
+}

--- a/test/formtest/index.js
+++ b/test/formtest/index.js
@@ -6,6 +6,7 @@ const layout = require('./layout.json');
 const premium = require('./premium.json');
 const settingErrors = require('./settingErrors.json');
 const clearOnHide = require('./clearOnHide.json');
+const clearOnHideInsideLayoutComponent = require('./clearOnHideInsideLayoutComponent.json');
 const manualOverride = require('./manualOverride.json');
 const uniqueApiKeys = require('./uniqueApiKeys.json');
 const uniqueApiKeysLayout = require('./uniqueApiKeysLayout.json');
@@ -53,6 +54,7 @@ module.exports = {
   premium,
   settingErrors,
   clearOnHide,
+  clearOnHideInsideLayoutComponent,
   manualOverride,
   uniqueApiKeys,
   uniqueApiKeysLayout,

--- a/test/unit/Webform.unit.js
+++ b/test/unit/Webform.unit.js
@@ -11,6 +11,7 @@ import { Formio } from '../../src/formio.form.js';
 import {
   settingErrors,
   clearOnHide,
+  clearOnHideInsideLayoutComponent,
   manualOverride,
   validationOnBlur,
   calculateValueWithManualOverride,
@@ -2390,6 +2391,41 @@ describe('Webform tests', function() {
         assert.deepEqual(form.data, visibleData.data);
         Harness.setInputValue(form, 'data[visible]', 'no');
 
+        setTimeout(() => {
+          assert.deepEqual(form.data, hiddenData.data);
+          done();
+        }, 250);
+      }, 250);
+    });
+  });
+
+  it('Should delete value of component inside parent conditionally hidden component if clearOnHide is turned on', function(done) {
+    const formElement = document.createElement('div');
+    const form = new Webform(formElement);
+    form.setForm(clearOnHideInsideLayoutComponent).then(() => {
+      const visibleData = {
+        data: {
+          checkbox: true,
+          textFieldInPanel: 'some text in panel',
+          textFieldInFieldset: 'some text in fieldset',
+          submit: false
+        }
+      };
+
+      const hiddenData = {
+        data: {
+          checkbox: false,
+          submit: false
+        }
+      };
+      const textFieldInPanel = form.getComponent('textFieldInPanel');
+      textFieldInPanel.setValue('some text in panel');
+      const textFieldInFieldset = form.getComponent('textFieldInFieldset');
+      textFieldInFieldset.setValue('some text in fieldset');
+      setTimeout(() => {
+        assert.deepEqual(form.data, visibleData.data);
+        const checkbox = form.getComponent('checkbox');
+        checkbox.setValue(false);
         setTimeout(() => {
           assert.deepEqual(form.data, hiddenData.data);
           done();


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9974

## Description

*The reason for the issue of not being able to uncheck the Default Group in the Builder Configurator form is a regression (components inside the Layout Component do not clear values when the ClearOnHide property is set to true). That is, if there is a Layout component (for example, a Panel that can be conditionally hidden) and a nested component in it (for example, a TextField with the ClearOnHide property set to true), then when filling in the value of the nested component and then hiding the parent layout component , the data of the child component is not cleared. The reason for this is that in the `shouldConditionallyClear` method, provided that `this.hasSetValue == true`,  `this._conditionallyClear` property is always [set to `false`](https://github.com/formio/formio.js/blob/master/src/components/_classes/component/Component.js#L826), although `this.parentShouldConditionallyClear()` [should be checked](https://github.com/formio/formio.js/blob/5.1.x/src/components/_classes/component/Component.js#L784).*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated test was added/ All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
