### PR TITLE
FIO-10096: Text Area causes infinite loop in html render mode

### DIFF
--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -495,7 +495,6 @@ export default class Component extends Element {
 
   /**
    * Returns if the parent should conditionally clear.
-   * 
    * @returns {boolean} - If the parent should conditionally clear.
    */
   parentShouldConditionallyClear() {
@@ -816,8 +815,8 @@ export default class Component extends Element {
 
     // If we have a condition and it is not conditionally visible, the it should conditionally clear.
     if (
-      this.hasCondition() && 
-      !this.conditionallyVisible() && 
+      this.hasCondition() &&
+      !this.conditionallyVisible() &&
       (!this.rootPristine || this.shouldConditionallyClearOnPristine())
     ) {
       this._conditionallyClear = true;
@@ -3106,6 +3105,7 @@ export default class Component extends Element {
     }
     const isArray = Array.isArray(value);
     const valueInput = this.refs.fileLink || this.refs.input;
+    const isFilelink = !!this.refs.fileLink
     if (
       isArray &&
       Array.isArray(this.defaultValue) &&
@@ -3114,7 +3114,9 @@ export default class Component extends Element {
       (valueInput.length !== value.length) &&
       this.visible
     ) {
-      this.redraw();
+      if (isFilelink || valueInput.length) {
+        this.redraw();
+      }
     }
     if (this.isHtmlRenderMode() && flags && flags.fromSubmission && changed) {
       this.redraw();

--- a/test/unit/TextArea.unit.js
+++ b/test/unit/TextArea.unit.js
@@ -7,7 +7,7 @@ import formWithRichTextAreas from '../forms/formWithRichTextAreas';
 import textAreaJsonType from '../forms/textAreaJsonType';
 import Harness from '../harness';
 import { Formio } from '../../src/Formio';
-import { comp1, comp2, comp3, comp4 } from './fixtures/textarea';
+import { comp1, comp2, comp3, comp4, comp5 } from './fixtures/textarea';
 import TextAreaComponent from '../../src/components/textarea/TextArea';
 import { fastCloneDeep } from '@formio/core';
 import { getFormioUploadAdapterPlugin } from '../../src/providers/storage/uploadAdapter';
@@ -18,6 +18,18 @@ describe('TextArea Component', () => {
     return Harness.testCreate(TextAreaComponent, comp1).then((component) => {
       Harness.testElements(component, 'textarea', 1);
     });
+  });
+
+  it("Redraw in setValue should not be called if a component with multiple flag = true and renderMode = html", async function () {
+    const element = document.createElement("div");
+    const form = await Formio.createForm(element, comp5, {
+      readOnly: true,
+      renderMode: "html",
+    });
+    const component = form.getComponent("textArea");
+    const emit = sinon.spy(component, "redraw");
+    component.setValue(["Hello"]);
+    assert.equal(emit.callCount, 0);
   });
 
   it('setValue should be called only once', () => {
@@ -570,7 +582,7 @@ describe('TextArea Component', () => {
 
     it('Should set array as value for textarea with ace editor with json data type', (done) => {
       const element = document.createElement('div');
-     
+
       Formio.createForm(element, textAreaJsonType).then(form => {
           const textArea = form.getComponent('textArea');
           textArea.setValue([1,2,3]);

--- a/test/unit/fixtures/textarea/comp5.js
+++ b/test/unit/fixtures/textarea/comp5.js
@@ -1,0 +1,15 @@
+export default {
+  type: 'form',
+  display: 'form',
+  components: [
+    {
+      label: "Text Area",
+      autoExpand: false,
+      multiple: true,
+      key: "textArea",
+      type: "textarea",
+      input: true,
+
+    },
+  ],
+};

--- a/test/unit/fixtures/textarea/index.js
+++ b/test/unit/fixtures/textarea/index.js
@@ -2,4 +2,5 @@ import comp1 from './comp1';
 import comp2 from './comp2';
 import comp3 from './comp3';
 import comp4 from './comp4';
-export { comp1, comp2, comp3, comp4 };
+import comp5 from './comp5';
+export { comp1, comp2, comp3, comp4, comp5};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10096

## Description

**What changed?**

The infinite loop happened because for the html mode **this.refs.input** does not contain elements ref = "input" in template and as a result the redraw method began to be called an infinite number of times. I added a check to get out of this loop

## Breaking Changes / Backwards Compatibility

n/a

## How has this PR been tested?

I added unit test

## Checklist:

- [X] I have completed the above PR template
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [X] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [X] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
