### PR TITLE
FIO-10040: fixed an issue where lazyload option on form setting shows checked although it has the false value

### DIFF
--- a/src/components/form/editForm/Form.edit.form.js
+++ b/src/components/form/editForm/Form.edit.form.js
@@ -30,10 +30,11 @@ export default [
     tooltip: 'if it is checked, the subform is loaded after navigation to the page with this component within the wizard.',
     input: true,
     customConditional( { instance, data }) {
-      const formInfo = instance.root?.getComponent('form')?.defaultDownloadedResources.find(res => res._id === data.form);
+      const formComp = instance.root?.getComponent('form');
+      const formInfo = formComp?.defaultDownloadedResources.find(res => res._id === data.form);
       const displayMode = 'wizard';
 
-      return instance.options?.editForm?.display === displayMode && formInfo && formInfo.display !== displayMode;
+      return  instance.options?.editForm?.display === displayMode && ((data.form && !formInfo) || (formInfo && formInfo.display !== displayMode));
     },
   },
   {

--- a/src/components/form/editForm/Form.edit.form.js
+++ b/src/components/form/editForm/Form.edit.form.js
@@ -34,7 +34,7 @@ export default [
       const formInfo = formComp?.defaultDownloadedResources.find(res => res._id === data.form);
       const displayMode = 'wizard';
 
-      return  instance.options?.editForm?.display === displayMode && ((data.form && !formInfo) || (formInfo && formInfo.display !== displayMode));
+      return instance.options?.editForm?.display === displayMode && ((data.form && !formInfo) || (formInfo && formInfo.display !== displayMode));
     },
   },
   {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10040

## Description

**What changed?**

Improved the condition for lazyLoad option in the nested form component settings so that it does not show falsy checked value. 

## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
