### PR TITLE
FIO-10109 fixed TextArea Styling for Quick Inline Embed

### DIFF
--- a/src/Embed.js
+++ b/src/Embed.js
@@ -320,6 +320,12 @@ export class Formio {
                 mode: 'open'
             });
             options.shadowRoot = wrapper;
+            // Due to an issue with quill not loading styles in the shadowdom, we need to add quill styles and js to the shadowdom
+            const quill = {
+                js: `${Formio.cdn.quill}/quill.min.js`,
+                css: `${Formio.cdn.quill}/quill.snow.css`
+            }
+            await Formio.addLibrary(wrapper, quill, 'quill');
         }
 
         element.parentNode.removeChild(element);

--- a/src/components/_classes/component/Component.js
+++ b/src/components/_classes/component/Component.js
@@ -2788,6 +2788,19 @@ export default class Component extends Element {
           return Promise.resolve(editor);
         }
         else {
+          // Due to an issue with ckeditor not loading styles in the shadowdom (https://github.com/ckeditor/ckeditor5/issues/15824), we need to copy cke-styles to the shadowdom
+          let current = element;
+          while (current) {
+            if (current instanceof ShadowRoot) {
+              const ckeStyles = document.querySelector('style[data-cke="true"]');
+              const clone = document.createElement('style');
+              clone.setAttribute('data-cke', 'true');
+              clone.textContent = ckeStyles.textContent;
+              current.prepend(clone);
+              break;
+            };
+            current = current.parentNode || current.host;
+          }
           return ClassicEditor.create(element, settings).then(editor => {
             editor.model.document.on('change', () => onChange(editor.data.get()));
             return editor;
@@ -2876,6 +2889,7 @@ export default class Component extends Element {
         editor.setOptions(settings);
         editor.getSession().setMode(settings.mode);
         editor.on('change', () => onChange(editor.getValue()));
+        editor.renderer.attachToShadowRoot();
         if (settings.isUseWorkerDisabled) {
           editor.session.setUseWorker(false);
         }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10109

## Description

*The reason for the issue of broken styles for the TextArea component with editors applied when using a  Quick Inline Embed link is that if the Quick Inline Embed link includes `libs=true` property, then a shadowRoot is created to display the form.
At the same time ShadowRoot does not apply external styles. This issue has been fixed for the `ace` library using the built-in method. However, since the CKeditor and Quill libraries do not support  using in ShadowRoot, the appropriate styles were loaded inside shadowRoot to display the TextArea component correctly.

If the Quick Inline Embed link does not include libs=true , then the entire form is displayed as expected.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*locally using Quick Inline Embed link. All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
