### PR TITLE
FIO-10110: Fix the dropdown list of the Address Component when using …

### DIFF
--- a/src/Embed.js
+++ b/src/Embed.js
@@ -286,6 +286,26 @@ export class Formio {
                 dependencies: ['bootstrap-icons'],
                 css: `${Formio.cdn.bootstrap}/css/bootstrap.min.css`
             },
+            autocomplete: {
+                globalStyle: `
+                    .autocomplete {
+                        background: white;
+                        font: 14px/22px "-apple-system", BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+                        overflow: auto;
+                        box-sizing: border-box;
+                        border: 1px solid rgba(50, 50, 50, 0.6);
+                        z-index: 11000;
+                    }
+                    .autocomplete > div {
+                        cursor: pointer;
+                        padding: 6px 10px;
+                    }
+                    .autocomplete > div:hover:not(.group), .autocomplete > div.selected {
+                        background: #1e90ff;
+                        color: #ffffff;
+                    }
+                `
+            },
             'bootstrap-icons': {
                 // Due to an issue with font-face not loading in the shadowdom (https://issues.chromium.org/issues/41085401), we need
                 // to do 2 things. 1.) Load the fonts from the global cdn, and 2.) add the font-face to the global styles on the page.
@@ -306,7 +326,6 @@ export class Formio {
             };
         });
         const id = Formio.config.id || `formio-${Math.random().toString(36).substring(7)}`;
-
         // Create a new wrapper and add the element inside of a new wrapper.
         let wrapper = Formio.createElement('div', {
             'id': `${id}-wrapper`
@@ -362,10 +381,17 @@ export class Formio {
         // Add libraries if they wish to include the libs.
         if (Formio.config.template && Formio.config.includeLibs) {
             await Formio.addLibrary(
-                libWrapper, 
-                Formio.config.libs[Formio.config.template], 
+                libWrapper,
+                Formio.config.libs[Formio.config.template],
                 Formio.config.template
             );
+            if (useShadowDom) {
+                await Formio.addLibrary(
+                    libWrapper,
+                    Formio.config.libs['autocomplete'],
+                    'autocomplete'
+                );
+            }
         }
 
         if (!Formio.config.libraries) {


### PR DESCRIPTION
…the Quick Inline Embed script

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10110

## Description
The problem appeared because the dropdown list for the address component is rendered outside **the shadow dom**, and there are no styles for displaying this dropdown. All styles for dropdown list exist in formio.form.min.css file connected by script inside of  **the shadow dom** , but they are not available for nodes outside **the shadow dom**. My solution allows to add a script with styles outside  the **shadow dom**, so the dropdown list finds the necessary styles and everything is displayed correctly.

To run and test it is necessary to rebuild the **offline** lib with fix and rebuild **formmanager** with updated **offline** in it  and add it to **formio-app**. Then build **formio-app** and run it.

## Dependencies

offline

## How has this PR been tested?

Manually

## Checklist:

- [X] I have completed the above PR template
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [X] New and existing unit/integration tests pass locally with my changes
- [X] Any dependent changes have corresponding PRs that are listed above
