### PR TITLE
FIO-10122: Fix dropdown arrow displaying for the select with HTML5 Wi…

### DIFF
--- a/src/sass/formio.embed.scss
+++ b/src/sass/formio.embed.scss
@@ -2,7 +2,7 @@
     position: relative;
     min-height: 100px;
 }
-  
+
 .loader-wrapper {
     z-index: 1000;
     position:absolute;
@@ -42,4 +42,10 @@
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
+}
+
+select.form-control {
+    -webkit-appearance: auto;
+    -moz-appearance: auto;
+    appearance: auto;
 }


### PR DESCRIPTION
…dget for the Quick Inline Embed script

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10122

## Description

**What changed?**

The problem is that the embed script uses the **appearance:none** style from **bootstrap**, which removes the dropdown arrow. My solution is rewrite appearance:none with appearance:auto into formio.embed.css.

**Important. How to add this fix.**
You need to connect this fix with pro.formview.io and built it. Then rebuild formmanager with updated pro.formview.io. And finally you need to update formio-app with formmanager.

## Dependencies

formmanager, pro.formview.io

## How has this PR been tested?

Manually

## Checklist:

- [X] I have completed the above PR template
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [X] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [X] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
