### PR TITLE
FIO-10128: Fix styles when using the quick inline embed script

### DIFF
--- a/src/Embed.js
+++ b/src/Embed.js
@@ -296,7 +296,7 @@ export class Formio {
                     src: url("https://cdn.jsdelivr.net/npm/bootstrap-icons/font/fonts/bootstrap-icons.woff2?dd67030699838ea613ee6dbda90effa6") format("woff2"),
                          url("https://cdn.jsdelivr.net/npm/bootstrap-icons/font/fonts/bootstrap-icons.woff?dd67030699838ea613ee6dbda90effa6") format("woff");
                 }`
-            }
+            },
         };
         // Add all bootswatch templates.
         ['cerulean', 'cosmo', 'cyborg', 'darkly', 'flatly', 'journal', 'litera', 'lumen', 'lux', 'materia', 'minty', 'pulse', 'sandstone', 'simplex', 'sketchy', 'slate', 'solar', 'spacelab', 'superhero', 'united', 'yeti'].forEach((template) => {
@@ -362,8 +362,8 @@ export class Formio {
         // Add libraries if they wish to include the libs.
         if (Formio.config.template && Formio.config.includeLibs) {
             await Formio.addLibrary(
-                libWrapper, 
-                Formio.config.libs[Formio.config.template], 
+                libWrapper,
+                Formio.config.libs[Formio.config.template],
                 Formio.config.template
             );
         }
@@ -387,6 +387,15 @@ export class Formio {
         }
 
         await Formio.addStyles(libWrapper, Formio.formioScript(Formio.config.style || `${Formio.cdn.js}/${renderer}.css`, builder));
+
+        // In some cases (dropdown list of autocomplete or confirmation popup of skethpad) we render elements outside of shadow dom
+        // and as result we can't get access to this styles outside of shadow dom. Here i added needed styles to work it properly
+        if(useShadowDom) {
+            await Formio.addStyles(document.body, Formio.formioScript(Formio.config.style || `${Formio.cdn.js}/${renderer}.css`, builder));
+            const toGlobalStyleLibs = ["bootstrap", "bootstrap4", "bootstrap-icons"];
+            const libHrefs = toGlobalStyleLibs.map(key => Formio.config.libs[key]).filter(Boolean).map(href => href.css);
+            await Formio.addStyles(document.body, libHrefs, builder);
+        }
         if (Formio.config.before) {
             await Formio.config.before(Formio.FormioClass, element, Formio.config);
         }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10128

## Description

First of all everything for **quick inline embed script** renders inside of shadow dom. The problem appeared because in some cases (dropdown list of autocomplete or confirmation popup of sketchpad) we render elements (the dropdown list or confirmation popup) outside of shadow dom and as result we can't get access to this styles which accessible only inside of shadow dom. And a lot of styles related to this popup confirmation or autocomplete locate in formio.form.min.css. My solution allows to add this needed styles outside to make it work properly.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Manually

## Checklist:

- [X] I have completed the above PR template
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [X] New and existing unit/integration tests pass locally with my changes
- [X] Any dependent changes have corresponding PRs that are listed above
