### PR TITLE
FIO-9614/Daty.js - fixed max and min date change on save

### DIFF
--- a/src/components/day/Day.js
+++ b/src/components/day/Day.js
@@ -52,13 +52,13 @@ export default class DayComponent extends Field {
     schema = schema || {};
     return getComponentSavedTypes(schema) || [componentValueTypes.string];
   }
-
+  
   constructor(component, options, data) {
-    if (component.maxDate && component.maxDate.indexOf('moment(') === -1) {
-      component.maxDate = moment(component.maxDate, 'YYYY-MM-DD').toISOString();
+    if (component.maxDate && component.maxDate.indexOf('moment(') === -1) { 
+      component.maxDate = moment(component.maxDate).toISOString();
     }
     if (component.minDate && component.minDate.indexOf('moment(') === -1) {
-      component.minDate = moment(component.minDate, 'YYYY-MM-DD').toISOString();
+      component.minDate = moment(component.minDate).toISOString();
     }
     super(component, options, data);
   }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9614

This also fix this issue: https://github.com/formio/formio.js/issues/5963#issuecomment-2779214649

## Description

Fixed Day.js component maxDate and minDate moment assign
Made to avoid changing of time every save

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
