### PR TITLE
FIO-10157: update error data processing

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1372,17 +1372,18 @@ export default class Webform extends NestedDataComponent {
     }
 
     normalizeError(error) {
-        if (error) {
-            if (typeof error === 'object' && 'details' in error) {
-                error = error.details;
-            }
+        if (error?.error) {
+          let errorData = error.error;
+          if (typeof errorData === 'object' && 'details' in errorData) {
+              error = errorData.details;
+          }
 
-            if (typeof error === 'string') {
-                error = { message: error };
-            }
+          if (typeof errorData === 'string') {
+              error = { message: errorData };
+          }
         }
 
-        return error;
+      return error;
     }
 
     /**
@@ -1659,15 +1660,16 @@ export default class Webform extends NestedDataComponent {
     }
 
     setServerErrors(error) {
-        if (error.details) {
-            this.serverErrors = error.details
+        const errorData = error.error;
+        if (errorData.details) {
+            this.serverErrors = errorData.details
                 .filter((err) => (err.level ? err.level === 'error' : err))
                 .map((err) => {
                     err.fromServer = true;
                     return err;
                 });
-        } else if (typeof error === 'string') {
-            this.serverErrors = [{ fromServer: true, level: 'error', message: error }];
+        } else if (typeof errorData === 'string') {
+            this.serverErrors = [{ fromServer: true, level: 'error', message: errorData }];
         }
     }
 

--- a/test/forms/formWithUniqueValidation.js
+++ b/test/forms/formWithUniqueValidation.js
@@ -45,22 +45,27 @@ export default {
     data: { textField: 'test', textFieldUnique: 'notUnique', submit: false },
   },
   serverErrors: {
-    name: 'ValidationError',
-    details: [
-      {
-        message: 'Text Field unique must be unique',
-        level: 'error',
-        path: ['textFieldUnique'],
-        context: {
-          validator: 'unique',
-          hasLabel: true,
-          key: 'textFieldUnique',
-          label: 'Text Field unique',
-          path: 'textFieldUnique',
-          value: 'notUnique',
-          index: 0,
+    ok: false,
+    status: 400,
+    statusText: "Bad Request",
+    error: {
+      name: 'ValidationError',
+      details: [
+        {
+          message: 'Text Field unique must be unique',
+          level: 'error',
+          path: ['textFieldUnique'],
+          context: {
+            validator: 'unique',
+            hasLabel: true,
+            key: 'textFieldUnique',
+            label: 'Text Field unique',
+            path: 'textFieldUnique',
+            value: 'notUnique',
+            index: 0,
+          },
         },
-      },
-    ],
+      ],
+    }
   },
 };

--- a/test/unit/Webform.unit.js
+++ b/test/unit/Webform.unit.js
@@ -657,7 +657,12 @@ describe('Webform tests', function() {
     Formio.makeRequest = function() {
       return new Promise((res, rej) => {
         setTimeout(() => {
-          rej(errorText);
+          rej({
+            ok: false,
+            status: 400,
+            statusText: "Bad Request",
+            error: errorText
+           });
         }, 50);
       });
     };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10157

## Description
The problem was caused by the extension of returned error data in by Formio class request method (@formio/core). (This updates were made to improve logging. PR: https://github.com/formio/core/pull/224/files#diff-d40e1a9b1dec9513b7f2d5be60d053c84b7dc33fe66a440dc37d03c8540e57daR1621) To fix the issue, the methods handling error data were updated. The mocked data for tests was also updated.

## Dependencies
Should be used with @formio/core version contains changes from PR:
https://github.com/formio/core/pull/224
(currently v2.6.0-rc.2  v2.6.0-rc.1 v2.5.0-rc.2 v2.5.0-rc.1)

## How has this PR been tested?
manually
autotests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
