### PR TITLE
fix 'this' coming back as undefined when using standalone interpolate

### DIFF
--- a/src/utils/Evaluator.js
+++ b/src/utils/Evaluator.js
@@ -58,7 +58,7 @@ export class DefaultEvaluator extends CoreEvaluator {
 export let Evaluator = new DefaultEvaluator();
 
 // preserve the standalone interpolate function for backwards compatibility
-export const interpolate = Evaluator.interpolate;
+export const interpolate = Evaluator.interpolate.bind(Evaluator);
 
 /**
  * Set the evaluator to use for evaluating expressions.

--- a/test/unit/utils.unit.js
+++ b/test/unit/utils.unit.js
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { expect, assert } from 'chai';
 import _ from 'lodash';
 import utils from '../../src/utils';
+const {interpolate} = utils;
 const submission1 = JSON.parse(fs.readFileSync('test/unit/fixtures/utils/submission1.json'));
 
 describe('Util Tests', () => {
@@ -631,5 +632,11 @@ describe('Util Tests', () => {
       }
     });
 */
+  });
+
+  describe('interpolate', () => {
+      it('should allow you to use the standalone interpolate function', () => {
+        interpolate('() => {}', {}, {})
+      });
   });
 });


### PR DESCRIPTION
## Description

**What changed?**

added a Evaluator bind to Evaluator.interpolate

**Why have you chosen this solution?**

When using interpolate standalone the 'this' is undefined.

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

Automated test added

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
