### PR TITLE
FIO-8853: remove legacy jquery version check

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,4 +1,3 @@
-/* global jQuery */
 import _ from 'lodash';
 import moment from 'moment-timezone/moment-timezone';
 import jtz from 'jstimezonedetect';
@@ -1126,9 +1125,7 @@ export function bootstrapVersion(options) {
   if (options.bootstrap) {
     return options.bootstrap;
   }
-  if ((typeof jQuery === 'function') && (typeof jQuery().collapse === 'function')) {
-    return parseInt(jQuery.fn.collapse.Constructor.VERSION.split('.')[0], 10);
-  }
+
   if (window.bootstrap && window.bootstrap.Collapse) {
     return parseInt(window.bootstrap.Collapse.VERSION.split('.')[0], 10);
   }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8853

## Description

Resolves #5735 

Previous versions of bootstrap require jquery as a peer dependency, so we had some legacy code that parses the current jquery version. This is no longer necessary with bootstrap 5, and was polluting the global environments of customers trying to use jquery. 

## Breaking Changes / Backwards Compatibility

I don't think there will be any breaking changes here, other than the fact that the `bootstrapVersion` function will no longer return the current version of jquery.

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
