### PR TITLE
FIO-10183: Value for select is not cleared on refresh options

### DIFF
--- a/src/components/datamap/DataMap.js
+++ b/src/components/datamap/DataMap.js
@@ -258,6 +258,9 @@ export default class DataMapComponent extends DataGridComponent {
     options.name += `[${rowIndex}]`;
     options.row = `${rowIndex}`;
     options.rowIndex = rowIndex;
+        options.onChange = (flags, changed, modified) => {
+        this.triggerChange({ modified });
+    }
 
     const components = {};
     components['__key'] = this.createComponent(this.keySchema, options, { __key: this.builderMode ? this.defaultRowKey : key });
@@ -276,7 +279,9 @@ export default class DataMapComponent extends DataGridComponent {
 
     const componentOptions = this.options;
     componentOptions.row = options.row;
-    components[this.valueKey] = this.createComponent(valueComponent, componentOptions, this.dataValue);
+    const componentOptionsCloned = _.clone(componentOptions);
+    componentOptionsCloned.onChange = options.onChange;
+    components[this.valueKey] = this.createComponent(valueComponent, componentOptionsCloned, this.dataValue);
     return components;
   }
 
@@ -304,7 +309,7 @@ export default class DataMapComponent extends DataGridComponent {
     const index = this.rows.length;
     this.rows[index] = this.createRowComponents(this.dataValue, index);
     this.redraw();
-    this.triggerChange();
+    this.triggerChange({modified:true});
   }
 
   removeRow(index) {

--- a/test/unit/DataMap.unit.js
+++ b/test/unit/DataMap.unit.js
@@ -1,8 +1,9 @@
 import { Formio } from '../../src/Formio';
 import Harness from '../harness';
 import DataMapComponent from '../../src/components/datamap/DataMap';
-import { comp1, formWithConditionalPanel } from './fixtures/datamap';
+import { comp1, formWithConditionalPanel, selectClearOnRefreshForDataMap } from './fixtures/datamap';
 import assert from 'power-assert';
+import { wait } from '../util';
 
 describe('DataMap Component', () => {
   it('Should build a data map component', () => {
@@ -18,6 +19,38 @@ describe('DataMap Component', () => {
       });
     });
   });
+
+  it('Select with refreshOn=Data Map should be cleared when the Data Map fields change (clearOnRefresh should be enabled) ', async () => {
+    const dispatchNewValue = (dataMap, key) => {
+      const textFieldInput = dataMap.getComponent([key]).refs.input[0];
+      textFieldInput.value = "new value";
+      const inputEvent = new Event('input');
+      textFieldInput.dispatchEvent(inputEvent);
+    }
+    const form = await Formio.createForm(document.createElement('div'), selectClearOnRefreshForDataMap, { readOnly: true })
+    const dataMap = form.getComponent(['dataMap']);
+    const select = form.getComponent(['selectDataMap']);
+    select.setValue('a');
+    assert.equal(form.data.selectDataMap, "a");
+    dataMap.addRow();
+    await wait(500);
+    assert.equal(form.data.selectDataMap, "");
+    select.setValue('a');
+    assert.equal(form.data.selectDataMap, "a");
+    dispatchNewValue(dataMap, "__key")
+    await wait(500);
+    assert.equal(form.data.selectDataMap, "");
+    select.setValue('b');
+    assert.equal(form.data.selectDataMap, "b");
+    dispatchNewValue(dataMap, "key")
+    await wait(500);
+    assert.equal(form.data.selectDataMap, "");
+    select.setValue('c');
+    assert.equal(form.data.selectDataMap, "c");
+    dataMap.removeRow();
+    await wait(500);
+    assert.equal(form.data.selectDataMap, "");
+  })
 
   it(
     'Should render data from submission properly when the Data Map is inside conditionally shown layout component',

--- a/test/unit/fixtures/datamap/index.js
+++ b/test/unit/fixtures/datamap/index.js
@@ -1,3 +1,4 @@
 import comp1 from './comp1';
 import formWithConditionalPanel from './formWithConditionalPanel';
-export { comp1, formWithConditionalPanel };
+import selectClearOnRefreshForDataMap from './selectClearOnRefreshForDataMap';
+export { comp1, formWithConditionalPanel, selectClearOnRefreshForDataMap };

--- a/test/unit/fixtures/datamap/selectClearOnRefreshForDataMap.js
+++ b/test/unit/fixtures/datamap/selectClearOnRefreshForDataMap.js
@@ -1,0 +1,55 @@
+export default {
+  title: "8724 Data",
+  name: "8724Data",
+  path: "8724data",
+  owner: "6846c4df008f6ee0d1991f65",
+  components: [
+    {
+      label: "Select data map",
+      widget: "choicesjs",
+      tableView: true,
+      data: {
+        values: [
+          { label: "a", value: "a" },
+          { label: "b", value: "b" },
+          { label: "c", value: "c" }
+        ]
+      },
+      refreshOn: "dataMap",
+      clearOnRefresh: true,
+      validateWhenHidden: false,
+      key: "selectDataMap",
+      type: "select",
+      input: true
+    },
+    {
+      label: "Data Map",
+      tableView: false,
+      calculateServer: true,
+      validateWhenHidden: false,
+      key: "dataMap",
+      type: "datamap",
+      input: true,
+      valueComponent: {
+        label: "Text Field datamap",
+        applyMaskOn: "change",
+        hideLabel: true,
+        tableView: true,
+        validateWhenHidden: false,
+        key: "textField",
+        type: "textfield",
+        input: true
+      }
+    },
+    {
+      type: "button",
+      label: "Submit",
+      key: "submit",
+      disableOnInvalid: true,
+      input: true,
+      tableView: false
+    }
+  ],
+  created: "2025-06-09T11:25:15.417Z",
+  modified: "2025-06-10T08:16:12.620Z"
+}


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10183

## Description

I did the same as Datagrid.
This solution allows us to clear "Select" when refreshOn = "Data Map" and clearOnRefresh = true. The problem is that when changing the Data map fields, the changed component itself (textField) is placed in the **changed** object, but in the form we specify refreshOn = dataMap and as a result different paths (dataMap and dataMap.textfield) do not allow us to clear the select value. In addition, in **Component.js** there is an **inContext** method that will not allow refresh to be executed if the contexts are different. And a  context for Select and dataMap.textfield will be different.

**Why have you chosen this solution?**
The Datagrid works on the same principle

## Breaking Changes / Backwards Compatibility
n/a

## Dependencies

n/a

## How has this PR been tested?

I added test

## Checklist:

- [X] I have completed the above PR template
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [X] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [X] New and existing unit/integration tests pass locally with my changes
- [X] Any dependent changes have corresponding PRs that are listed above
