### PR TITLE
FIO-10245: Fixed issues with getComponent function on DataGrid to always return a component instance and not an array.

### DIFF
--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -774,7 +774,7 @@ export default class DataGridComponent extends NestedArrayComponent {
       }
     });
 
-    return result.length > 0 ? result : null;
+    return result.length > 0 ? result[result.length - 1] : null;
   }
 
   toggleGroup(element, index) {

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -774,7 +774,7 @@ export default class DataGridComponent extends NestedArrayComponent {
       }
     });
 
-    return result.length > 0 ? result[result.length - 1] : null;
+    return result.length > 0 ? result : null;
   }
 
   toggleGroup(element, index) {

--- a/src/utils/conditionOperators/DateGreaterThan.js
+++ b/src/utils/conditionOperators/DateGreaterThan.js
@@ -24,12 +24,14 @@ export default class DateGeaterThan extends ConditionOperator {
             return false;
         }
 
-        let conditionTriggerComponent = null;
+        let conditionTriggerComponent = options.conditionTriggerComponent || null;
 
         if (instance && instance.root) {
             conditionTriggerComponent = instance.root.getComponent(conditionComponentPath);
         }
-
+        if (Array.isArray(conditionTriggerComponent)) {
+            return conditionTriggerComponent.some(component => this.execute({ ...options, conditionTriggerComponent: component }, functionName));
+        }
         if ( conditionTriggerComponent && conditionTriggerComponent.isPartialDay && conditionTriggerComponent.isPartialDay(value)) {
             return false;
         }

--- a/src/utils/conditionOperators/IsEmptyValue.js
+++ b/src/utils/conditionOperators/IsEmptyValue.js
@@ -19,6 +19,9 @@ export default class IsEmptyValue extends ConditionOperator {
 
         if (instance && instance.root) {
             const conditionTriggerComponent = instance.root.getComponent(conditionComponentPath);
+            if (Array.isArray(conditionTriggerComponent)) {
+                return conditionTriggerComponent.some(component => component ? component.isEmpty() : isEmptyValue);
+            }
             return conditionTriggerComponent ? conditionTriggerComponent.isEmpty() : isEmptyValue;
         }
 

--- a/src/utils/conditionOperators/IsEqualTo.js
+++ b/src/utils/conditionOperators/IsEqualTo.js
@@ -11,7 +11,7 @@ export default class IsEqualTo extends ConditionOperator {
         return 'Is Equal To';
     }
 
-    execute({ value, comparedValue, instance, conditionComponentPath }) {
+    execute({ value, comparedValue, instance, conditionComponentPath, conditionTriggerComponent }) {
         if ((value || value === false) && comparedValue && typeof value !== typeof comparedValue && _.isString(comparedValue)) {
             try {
                 comparedValue = JSON.parse(comparedValue);
@@ -21,8 +21,10 @@ export default class IsEqualTo extends ConditionOperator {
         }
 
         if (instance && instance.root) {
-            const conditionTriggerComponent = instance.root.getComponent(conditionComponentPath);
-
+            conditionTriggerComponent = conditionTriggerComponent || instance.root.getComponent(conditionComponentPath);
+            if (Array.isArray(conditionTriggerComponent)) {
+                return conditionTriggerComponent.some(component => this.execute({ value, comparedValue, instance, conditionTriggerComponent: component }));
+            }
             if (
                 conditionTriggerComponent
                 && isSelectResourceWithObjectValue(conditionTriggerComponent.component)


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10245

## Description

The method "getComponent" is supposed to return an instance of a component. There was a bug with the DataGrid version of the getComponent method where it would return an array of components instead of the actual components. The array contains all of the components in the path tree, so the component that should be returned is the last component in the array.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Manual testing

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
