### PR TITLE
Fixing issue with getComponent returning an array for DataGrid.

### DIFF
--- a/src/utils/conditionOperators/DateGreaterThan.js
+++ b/src/utils/conditionOperators/DateGreaterThan.js
@@ -28,6 +28,7 @@ export default class DateGeaterThan extends ConditionOperator {
 
         if (instance && instance.root) {
             conditionTriggerComponent = instance.root.getComponent(conditionComponentPath);
+            conditionTriggerComponent = Array.isArray(conditionTriggerComponent) ? conditionTriggerComponent[0] : conditionTriggerComponent;
         }
 
         if ( conditionTriggerComponent && conditionTriggerComponent.isPartialDay && conditionTriggerComponent.isPartialDay(value)) {

--- a/src/utils/conditionOperators/IsEmptyValue.js
+++ b/src/utils/conditionOperators/IsEmptyValue.js
@@ -18,7 +18,8 @@ export default class IsEmptyValue extends ConditionOperator {
         const isEmptyValue = _.isEmpty(value);
 
         if (instance && instance.root) {
-            const conditionTriggerComponent = instance.root.getComponent(conditionComponentPath);
+            let conditionTriggerComponent = instance.root.getComponent(conditionComponentPath);
+            conditionTriggerComponent = Array.isArray(conditionTriggerComponent) ? conditionTriggerComponent[0] : conditionTriggerComponent;
             return conditionTriggerComponent ? conditionTriggerComponent.isEmpty() : isEmptyValue;
         }
 

--- a/src/utils/conditionOperators/IsEqualTo.js
+++ b/src/utils/conditionOperators/IsEqualTo.js
@@ -21,7 +21,8 @@ export default class IsEqualTo extends ConditionOperator {
         }
 
         if (instance && instance.root) {
-            const conditionTriggerComponent = instance.root.getComponent(conditionComponentPath);
+            let conditionTriggerComponent = instance.root.getComponent(conditionComponentPath);
+            conditionTriggerComponent = Array.isArray(conditionTriggerComponent) ? conditionTriggerComponent[0] : conditionTriggerComponent;
 
             if (
                 conditionTriggerComponent


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10245

## Description

The getComponent method for components within a DataGrid can return an array. It throws an error in the conditionals. 

## Breaking Changes / Backwards Compatibility

None

## How has this PR been tested?

Manual

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
