### PR TITLE
FIO-10159: fixed an issue where value of the Custom component is not saved

### DIFF
--- a/src/components/Components.js
+++ b/src/components/Components.js
@@ -65,7 +65,7 @@ export default class Components {
       // eslint-disable-next-line new-cap
       comp = new Components.components['datagrid'](component, options, data);
     }
-    else if (component.tree) {
+    else if (component.tree || (component.input && Array.isArray(component.components))) {
       // eslint-disable-next-line new-cap
       comp = new Components.components['nesteddata'](component, options, data);
     }

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -907,7 +907,7 @@ export default class NestedComponent extends Field {
       return false;
     }
     if (component.type === 'components') {
-      if (component.tree && component.hasValue(value)) {
+      if ((component.tree || component.hasInput) && component.hasValue(value)) {
         return component.setValue(_.get(value, component.key), flags);
       }
       return component.setValue(value, flags);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10159

## Description

After new path changes core consider custom component as layout if it has nested components and no input. Made these changes to match expected data structure for custom component with `input = true`, since previously formio.js considered it as layout. 

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

tested manually, all existing tests pass

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
