### PR TITLE
FIO-10359 failing tests fixes

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import { Formio } from '../../Formio';
 import ListComponent from '../_classes/list/ListComponent';
-import Input from '../_classes/input/Input';
 import Form from '../../Form';
 import {
   getRandomComponentId,
@@ -1049,7 +1048,7 @@ export default class SelectComponent extends ListComponent {
         this.addEventListener(this.choices.containerOuter.element, 'focus', () => this.focusableElement.focus());
       }
 
-      Input.prototype.addFocusBlurEvents.call(this, this.focusableElement);
+      this.addFocusBlurEvents(this.choices.input.element);
 
       if (this.itemsFromUrl && !this.component.noRefreshOnScroll) {
         this.scrollList = this.choices.choiceList.element;

--- a/test/unit/Select.unit.js
+++ b/test/unit/Select.unit.js
@@ -352,8 +352,8 @@ describe('Select Component', () => {
     const value = 'b';
     select.setValue(value);
 
-    // timeout(0) need to complete triggerChange
-    await Promise.all([select.itemsLoaded, timeout(0)]);
+    // timeout(50) need to complete triggerChange
+    await Promise.all([select.itemsLoaded, timeout(50)]);
     assert.equal(select.dataValue, value);
     assert.equal(select.getValue(), value);
 

--- a/test/unit/Webform.unit.js
+++ b/test/unit/Webform.unit.js
@@ -802,10 +802,10 @@ describe('Webform tests', function() {
       const blurEvent = new Event('blur');
 
       const selectChoices = form.getComponent('selectChoices');
-      selectChoices.focusableElement.dispatchEvent(focusEvent);
+      selectChoices.choices.input.element.dispatchEvent(focusEvent);
 
       setTimeout(() => {
-        selectChoices.focusableElement.dispatchEvent(blurEvent);
+        selectChoices.choices.input.element.dispatchEvent(blurEvent);
 
         const selectHtml = form.getComponent('selectHtml');
         selectHtml.refs.selectContainer.dispatchEvent(focusEvent);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10359

## Description

*Fixed tests:*

- *Select component, `Should clear select value when "clear value on refresh options" and "refresh options on" is enable and number component is changed`.The  test was failed because [this line](https://github.com/formio/formio.js/pull/6048/files#diff-205bfa6e42b811dc081395dddb4786be231c2cf6fa56d01a316ec8e222566a0dR356) was missed.*
- *Select component, `OnBlur validation Should work properly with Select component`. The test was failed because [this PR](https://github.com/formio/formio.js/pull/5668) was merged, but was not included into the build*
- *WebformBuilder, `Should not show unique API error when components with same keys are inside and outside of the Data component`. The test is currently failing because [this PR](https://github.com/formio/formio.js/pull/6125) was merged into the 5.2.x branch of formio.js, but the corresponding [dependency PR](https://github.com/formio/core/pull/255) was not included in the version of @formio/core. The  test will be fixed as soon as a new version of @formio/core includes [this PR](https://github.com/formio/core/pull/255)*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*https://github.com/formio/core/pull/255*

## How has this PR been tested?

*Tests was fixed, but require new build for @formio/core*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
