### PR TITLE
FIO-10425: Fixed issues where fields with errors in nested forms with in wizards are not properly highlighting when you click the error link.

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -687,7 +687,7 @@ export default class Wizard extends Webform {
       if (!this._seenPages.includes(parentNum)) {
         this._seenPages = this._seenPages.concat(parentNum);
       }
-      this.redraw().then(() => {
+      return this.redraw().then(() => {
         this.checkData(this.submission.data);
         this.triggerCaptcha(this.currentPage.components);
         const errors = this.submitted ? this.validate(this.localData, { dirty: true }) : this.validateCurrentPage();
@@ -695,7 +695,6 @@ export default class Wizard extends Webform {
           this.showErrors(errors, true, true);
         }
       });
-      return Promise.resolve();
     }
     else if (!this.pages.length) {
       this.redraw();
@@ -1078,10 +1077,7 @@ export default class Wizard extends Webform {
       if (pageIndex >= 0) {
         const page = this.pages[pageIndex];
         if (page && page !== this.currentPage) {
-          return this.setPage(pageIndex).then(() => {
-            this.showErrors(this.validate(this.localData, { dirty: true }));
-            super.focusOnComponent(key);
-          });
+          return this.setPage(pageIndex).then(() => super.focusOnComponent(key));
         }
       }
     }

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -329,16 +329,17 @@ export default class FormComponent extends Component {
             if (this.isNestedWizard) {
               element = this.root.element;
             }
-            this.subForm.attach(element);
-            this.valueChanged = this.hasSetValue;
-            if (!this.shouldConditionallyClear()) {
-              if (!this.valueChanged && this.dataValue.state !== 'submitted') {
-                this.setDefaultValue();
+            return this.subForm.attach(element).then(() => {
+              this.valueChanged = this.hasSetValue;
+              if (!this.shouldConditionallyClear()) {
+                if (!this.valueChanged && this.dataValue.state !== 'submitted') {
+                  this.setDefaultValue();
+                }
+                else {
+                  this.restoreValue();
+                }
               }
-              else {
-                this.restoreValue();
-              }
-            }
+            });
           }
           if (!this.builderMode && this.component.modalEdit) {
             const modalShouldBeOpened = this.componentModal ? this.componentModal.isOpened : false;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10425

## Description

The nested form component was not properly passing along the promises so that when the "showErrors" method was getting called after the page was changed, the component had not yet attached so the errors would not show up on that page. This resolves that problem by ensuring all the promises are properly passed along.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Manual testing

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
