### PR TITLE
FIO-10425: Fixed issues where fields with errors in nested forms with in wizards are not properly highlighting when you click the error link.

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -688,14 +688,13 @@ export default class Wizard extends Webform {
       if (!this._seenPages.includes(parentNum)) {
         this._seenPages = this._seenPages.concat(parentNum);
       }
-      this.redraw().then(() => {
+      return this.redraw().then(() => {
         this.checkData(this.submission.data);
         const errors = this.submitted ? this.validate(this.localData, { dirty: true }) : this.validateCurrentPage();
         if (this.alert) {
           this.showErrors(errors, true, true);
         }
       });
-      return Promise.resolve();
     }
     else if (!this.pages.length) {
       this.redraw();
@@ -1087,10 +1086,7 @@ export default class Wizard extends Webform {
       if (pageIndex >= 0) {
         const page = this.pages[pageIndex];
         if (page && page !== this.currentPage) {
-          return this.setPage(pageIndex).then(() => {
-            this.showErrors(this.validate(this.localData, { dirty: true }));
-            super.focusOnComponent(key);
-          });
+          return this.setPage(pageIndex).then(() => super.focusOnComponent(key));
         }
       }
     }

--- a/src/components/_classes/nested/NestedComponent.js
+++ b/src/components/_classes/nested/NestedComponent.js
@@ -599,8 +599,7 @@ export default class NestedComponent extends Field {
 
     element = this.hook('attachComponents', element, components, container, this);
     if (!element) {
-      // Return a non-resolving promise.
-      return (new Promise(() => {}));
+      return Promise.resolve();
     }
 
     let index = 0;

--- a/src/components/_classes/nested/NestedComponent.unit.js
+++ b/src/components/_classes/nested/NestedComponent.unit.js
@@ -4,7 +4,7 @@ import Harness from '../../../../test/harness';
 import assert from 'power-assert';
 import each from 'lodash/each';
 import { expect } from 'chai';
-import { comp1, comp2, comp3, comp4 } from './fixtures';
+import { comp1, comp2, comp3 } from './fixtures';
 import { nestedForm } from '../../../../test/fixtures';
 import _map from 'lodash/map';
 import Webform from '../../../Webform';
@@ -253,18 +253,6 @@ describe('NestedComponent class', () => {
           assert(dataGrid.components[0].path === 'dataGrid[0].textField');
           assert(tabs.path === 'tabs');
           assert(tabs.tabs[0][0].path === 'tabsTextfield');
-          done();
-        })
-        .catch(done);
-    });
-    // see these functions in core to see how component path is derived for checkbox components of inputType radio
-    // - https://github.com/formio/core/blob/master/src/utils/formUtil.ts#L228-L240
-    // - https://github.com/formio/core/blob/master/src/utils/formUtil.ts#L418-L427
-    it('returns the right path (i.e. name) for checkbox components with an inputType of radio', (done) => {
-      Harness.testCreate(NestedComponent, comp4)
-        .then((nested) => {
-          assert(nested.components[0].path === 'radio');
-          assert(nested.components[1].path === 'radio');
           done();
         })
         .catch(done);

--- a/src/components/_classes/nested/fixtures/comp4.js
+++ b/src/components/_classes/nested/fixtures/comp4.js
@@ -1,8 +1,0 @@
-import comp from '../checkbox/comp2';
-
-export default {
-    components: [
-        { ...comp },
-        { ...comp, value: 'false' }
-    ]
-};

--- a/src/components/_classes/nested/fixtures/index.js
+++ b/src/components/_classes/nested/fixtures/index.js
@@ -1,4 +1,3 @@
 export { default as comp1 } from './comp1';
 export { default as comp2 } from './comp2';
 export { default as comp3 } from './comp3';
-export { default as comp4 } from './comp4';

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -322,6 +322,16 @@ export default class FormComponent extends Component {
           }
 
           this.setContent(element, this.render());
+          const postAttach = () => {
+            if (!this.builderMode && this.component.modalEdit) {
+              const modalShouldBeOpened = this.componentModal ? this.componentModal.isOpened : false;
+              const currentValue = modalShouldBeOpened ? this.componentModal.currentValue : this.dataValue;
+              this.componentModal = new ComponentModal(this, element, modalShouldBeOpened, currentValue, this._referenceAttributeName);
+              this.setOpenModalElement();
+            }
+
+            this.calculateValue();
+          };
           if (this.subForm) {
             if (this.isNestedWizard) {
               element = this.root.element;
@@ -334,16 +344,10 @@ export default class FormComponent extends Component {
               else {
                 this.restoreValue();
               }
+              postAttach();
             });
           }
-          if (!this.builderMode && this.component.modalEdit) {
-            const modalShouldBeOpened = this.componentModal ? this.componentModal.isOpened : false;
-            const currentValue = modalShouldBeOpened ? this.componentModal.currentValue : this.dataValue;
-            this.componentModal = new ComponentModal(this, element, modalShouldBeOpened, currentValue, this._referenceAttributeName);
-            this.setOpenModalElement();
-          }
-
-          this.calculateValue();
+          postAttach();
         });
       });
   }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10425

## Description

This solves the wizard error navigation links by ensuring that all the promise resolutions occur after the attachment of the components within the nested form.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Manual

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
