### PR TITLE
FIO-9942: apply evaluator override properties to fix interpolation is…

### DIFF
--- a/src/utils/Evaluator.js
+++ b/src/utils/Evaluator.js
@@ -74,5 +74,8 @@ export function interpolate(...args) {
  * @returns {void}
  */
 export function registerEvaluator(override) {
+    if(override.noeval){
+      Evaluator.noeval = override.noeval
+    }
     Evaluator = override;
 }


### PR DESCRIPTION
…sues

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9942

## Description
Copy override evaluator noeval properte to DefaultEvaluator instance to prevent CSP errors from lodash template function during interpolation. Restores formiojs 4.x behavior.

## Breaking Changes / Backwards Compatibility
-

## Dependencies
-

## How has this PR been tested?
manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
