### PR TITLE
FIO-9942 update default evaluator

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,6 @@
 import * as utils from './utils';
 import * as formUtils from './formUtils';
-import { Evaluator, registerEvaluator, interpolate } from './Evaluator';
+import { Evaluator, registerEvaluator, interpolate, DefaultEvaluator } from './Evaluator';
 import ConditionOperators from './conditionOperators';
 import _ from 'lodash';
 import moment from 'moment';
@@ -8,6 +8,7 @@ import moment from 'moment';
 const FormioUtils = {
   ...utils,
   ...formUtils,
+  DefaultEvaluator,
   Evaluator,
   interpolate,
   ConditionOperators,


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9942

## Description

Was provided access to DefaultEvaluator class via FormioUtils to allow of inheritance  for Protected Evaluator.

To Evaluator was added  evaluator object that forwards calls to current evaluator to provide access to actual Evaluator instance in a case of register ProtectedEvaluator. This change is due to the fact that in the previous case FormioUtils always contain Default Evaluator instance. It’s is related to JS  module behavior (when you import { Evaluator } from another module, you're importing the value of Evaluator at the time of import, not a live reference to the variable itself.)

## Breaking Changes / Backwards Compatibility


## Dependencies

## How has this PR been tested?
manually
autotests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
