### PR TITLE
FIO-10525 fixed issue with duplicated nested components for new data components

### DIFF
--- a/src/WebformBuilder.js
+++ b/src/WebformBuilder.js
@@ -1383,6 +1383,7 @@ export default class WebformBuilder extends Component {
       submissionData = submissionData.componentJson || submissionData;
       if (submissionData.components && this.originalDefaultValue) {
         submissionData.components = this.originalDefaultValue.components;
+        this.originalDefaultValue = null;
       }
       const fieldsToRemoveDoubleQuotes = ['label', 'tooltip'];
 

--- a/test/unit/WebformBuilder.unit.js
+++ b/test/unit/WebformBuilder.unit.js
@@ -453,6 +453,36 @@ describe('WebformBuilder tests', function() {
     const webformBuilder = new WebformBuilder({});
     assert.equal(webformBuilder.hasEditTabs('abc123'), false);
   });
+
+  it('Should not duplicate nested components of the DataGrid for new Data components', (done) => {
+    const builder = Harness.getBuilder();
+    builder.setForm({}).then(() => {
+      Harness.buildComponent('datagrid');
+      setTimeout(() => {
+        Harness.saveComponent();
+        setTimeout(() => {
+          const dataGrid = builder.webform.element.querySelector('[ref="dataGrid-container"]');
+          Harness.buildComponent('textfield', dataGrid);
+          setTimeout(() => {
+            Harness.saveComponent();
+            setTimeout(() => {
+              Harness.buildComponent('datagrid');
+              setTimeout(()=> {
+                Harness.saveComponent();
+                setTimeout(()=> {
+                  const dataGridWithNestedComp = builder.webform.getComponent('dataGrid');
+                  assert.equal(dataGridWithNestedComp.components.length, 1);
+                  const dataGridEmpty = builder.webform.getComponent('dataGrid1');
+                  assert.equal(dataGridEmpty.components.length, 0);
+                  done();
+                }, 150);
+              }, 150);
+            }, 150);
+          }, 150);
+        }, 150);
+      }, 150);
+    })
+  })
 });
 
 describe('Select Component selectData property', () => {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10525

## Description

*Previously, after adding the first Data Grid component, all nested components from the original Data Grid component were duplicated for all new added Data components. It was happened because when adding a new component, the `this.originalDefaultValue` property was overwritten only if the value was falsy, but it was not emptied after saving the component.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated test was added. All tests pass locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
