### PR TITLE
Patch: include DefaultEvaluator in the Formio object

### DIFF
--- a/src/formio.form.js
+++ b/src/formio.form.js
@@ -32,6 +32,7 @@ Formio.Widgets = Widgets;
 Formio.Evaluator = Evaluator;
 Formio.AllComponents = AllComponents;
 Formio.Licenses = Licenses;
+Formio.DefaultEvaluator = DefaultEvaluator;
 
 // This is strange, but is needed for "premium" components to import correctly.
 Formio.Formio = Formio;


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

DefaultEvaluator is not included in the global Formio object, which the Developer Portal application (for whatever reason) uses instead of regular modules. This is a hotfix for that issue.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

manually

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
