### PR TITLE
Update aws-cli to accommodate ubuntu-latest upgrade to 24.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         run: gem install jekyll
 
       - name: Restore node modules from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
@@ -41,8 +41,8 @@ jobs:
 
       - name: Install awscli
         run: |
-          sudo apt-get update
-          sudo apt install -y awscli
+          sudo snap install aws-cli --classic
+          aws --version
 
       - name: Release
         uses: borales/actions-yarn@v4


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-XXXX

## Description

**What changed?**

ubuntu-latest updated to 24.x and so the action runner can no longer find awscli, this updates it to install aws-cli

<img width="604" height="196" alt="image" src="https://github.com/user-attachments/assets/72c362e7-aa5d-40ac-b410-b62c215e5cf9" />


## How has this PR been tested?

Pushed a dev tag and you can see that "Release / deploy to test" ran successfully

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
