### PR TITLE
FIO-10631: Emails would not send when survey component is required.

### DIFF
--- a/src/components/survey/Survey.js
+++ b/src/components/survey/Survey.js
@@ -137,6 +137,9 @@ export default class SurveyComponent extends Field {
     if (!boolValue(setting)) {
       return true;
     }
+    if (!value) {
+      return false;
+    }
     return this.component.questions.reduce((result, question) =>
       result && Boolean(value[question.value]), true);
   }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10631

## Description

When a form is rendered for email, it first calls "setForm" which passes an empty object for the data object. The Required validator will then get the value of the survey component, which is 'undefined', which would then crash when passed to the validateRequired method.

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Manual

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
