### PR TITLE
Fix textarea's rows attr not taking effect

### DIFF
--- a/src/sass/formio.form.scss
+++ b/src/sass/formio.form.scss
@@ -47,7 +47,7 @@ $autocomplete-in-dialog-z-index: $dialog-z-index + 1000;
 }
 
 .form-control {
-  height: calc(1.4em + 0.75rem + 2px);
+  min-height: calc(1.4em + 0.75rem + 2px);
 }
 
 .formio-disabled-input .form-control.flatpickr-input {


### PR DESCRIPTION

## Description

**What changed?**

Changed the **height** css rule for **.form-control** to **min-height** instead as bootstrap sets, Cuz the previous rule prevents textarea's rows attribute from taking effect and expanding.

**Why have you chosen this solution?**

It's the way bootstrap sets it.


## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
