### PR TITLE
Fix: remove uuid dependency by using native crypto.randomUUID (CVE-2026-41907)

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "signature_pad": "^4.2.0",
     "string-hash": "^1.1.3",
     "tippy.js": "^6.3.7",
-    "uuid": "^9.0.0",
     "vanilla-picker": "^2.12.3"
   },
   "devDependencies": {

--- a/src/providers/storage/indexeddb.js
+++ b/src/providers/storage/indexeddb.js
@@ -1,4 +1,27 @@
-import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Generates an RFC 4122 version 4 UUID.
+ *
+ * Uses the native `crypto.randomUUID()` when available. That API is only exposed
+ * in secure contexts (HTTPS or localhost), whereas IndexedDB also works over plain
+ * HTTP, so a `crypto.getRandomValues()` based fallback preserves the previous
+ * behaviour in those environments.
+ * @returns {string} A randomly generated v4 UUID.
+ */
+function generateId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant RFC 4122
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 /**
  * indexedDb provider for file storage.
  * @returns {import('./typedefs').FileProvider} The FileProvider interface defined in index.js.
@@ -30,7 +53,7 @@ function indexeddb() {
           reader.onload = () => {
             const blobObject = new Blob([file], { type: file.type });
 
-            const id = uuidv4(blobObject);
+            const id = generateId();
 
             const data = {
               id,


### PR DESCRIPTION
## Link to Jira Ticket

N/A — external community contribution, no FIO ticket available.
Happy to link one if a maintainer creates it.

Related: closes the gap left by #6306 (Snyk bump, closed unmerged).
<!-- Si tu as ouvert une issue, ajoute ici : Fixes #<numéro> -->

## Description

**What changed?**

- Removed the `uuid` dependency from `package.json`.
- `src/providers/storage/indexeddb.js` no longer imports `uuid`; the single v4
  identifier it needs is now produced by a local `generateId()` helper built on
  the native Web Crypto API.

This is the only usage of `uuid` in the package:

```
$ grep -rn "from 'uuid'\|require('uuid')" src/
src/providers/storage/indexeddb.js:1
```

**Why have you chosen this solution?**

`uuid@9.0.1` is flagged by **CVE-2026-41907** (out-of-bounds write, CVSS 3.1 **7.5 High**).
The advisory covers **all versions < 14.0.0**, and the fix landed **only in 14.0.0**.

A straight version bump is not viable: `uuid@14.0.0` is **ESM-only** — its `package.json`
declares `"type": "module"` and its `exports` map has no `require` condition, so it cannot be
`require()`'d from the CommonJS build in `lib/cjs/`. That is the underlying reason the Snyk
PR #6306 could not be merged, leaving the dependency stuck on a flagged version.

Since `uuid` is used exactly once, and only to generate a v4 identifier, dropping the
dependency altogether resolves the situation at the source rather than deferring it:

- removes this class of advisory permanently, for every consumer of `@formio/js`;
- no ESM/CJS interop problem to work around;
- no bundle-size cost (one fewer transitive dependency).

The generated value remains a fully RFC 4122-compliant v4 UUID (same version and variant
bits), so stored records and their keys are unchanged in shape.

## Breaking Changes / Backwards Compatibility

**None.**

- The generated identifier keeps the exact same format (RFC 4122 v4 string), so existing
  IndexedDB records and lookups by `id` are unaffected.
- `crypto.randomUUID()` is only exposed in **secure contexts** (HTTPS / `localhost`), whereas
  IndexedDB also works over plain HTTP. To avoid regressing those deployments, the helper
  falls back to `crypto.getRandomValues()` (available since IE11, no secure-context
  requirement) and formats the bytes manually:

```js
function generateId() {
  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
    return crypto.randomUUID();
  }

  const bytes = new Uint8Array(16);
  crypto.getRandomValues(bytes);
  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant RFC 4122

  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
}
```

- `generateId()` is only reached inside `uploadFile()`, after the existing
  `if (!('indexedDB' in window))` guard, so it never runs outside a browser context.

Side note: the previous call passed a `Blob` as uuid's `options` argument
(`uuidv4(blobObject)`). A `Blob` provides neither `random` nor `rng`, so it was silently
ignored and the call behaved as `uuidv4()`. Behaviour is therefore unchanged.

## Dependencies

None. This PR only *removes* a dependency (`uuid`) and adds no new one.

## How has this PR been tested?

<!-- À COMPLÉTER selon ce que tu as réellement fait — n'affirme rien que tu n'as pas vérifié -->

- Verified `uuid` no longer appears anywhere in the source: `grep -rn "uuid" src/` returns nothing.
- Verified the generated identifiers are valid RFC 4122 v4 UUIDs (character 15 is `4`,
  character 20 is one of `8`, `9`, `a`, `b`), in both branches of `generateId()`
  (with and without `crypto.randomUUID` available).
- Exercised the IndexedDB storage provider end to end (upload → download → delete) to confirm
  records are stored and retrieved by the generated `id`.

No automated test was added: the IndexedDB provider has no existing unit-test coverage, and
testing it meaningfully requires a browser environment (IndexedDB + Web Crypto) rather than
the current JSDOM-based unit suite. Happy to add one if you can point me at the preferred
approach.

<!-- Si `npm test` échoue chez toi sur `matchMedia is not defined`, vérifie d'abord avec
     `git stash` que l'échec existe déjà sur `main` sans ta modif. Si c'est le cas, ajoute :
"Note: `npm test` currently fails on `main` in a clean checkout with
`ReferenceError: matchMedia is not defined` (raised by `inputmask` via JSDOM, unrelated to
this change)." -->

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
